### PR TITLE
v0.4.1 Update order of Conditional Order Types, Validation logic update

### DIFF
--- a/abacus.podspec
+++ b/abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'abacus'
-    spec.version                  = '0.4.0'
+    spec.version                  = '0.4.1'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 group = "exchange.dydx.abacus"
-version = "0.4.0"
+version = "0.4.1"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
@@ -73,28 +73,28 @@ data class TradeInputOptions(
             iListOf(
                 SelectionOption(OrderType.limit.rawValue, "APP.TRADE.LIMIT_ORDER_SHORT", null),
                 SelectionOption(OrderType.market.rawValue, "APP.TRADE.MARKET_ORDER_SHORT", null),
+                SelectionOption(OrderType.stopLimit.rawValue, "APP.TRADE.STOP_LIMIT", null),
                 SelectionOption(OrderType.stopMarket.rawValue, "APP.TRADE.STOP_MARKET", null),
+                SelectionOption(OrderType.trailingStop.rawValue, "APP.TRADE.TRAILING_STOP", null),
+                SelectionOption(OrderType.takeProfitLimit.rawValue, "APP.TRADE.TAKE_PROFIT", null),
                 SelectionOption(
                     OrderType.takeProfitMarket.rawValue,
                     "APP.TRADE.TAKE_PROFIT_MARKET",
                     null
                 ),
-                SelectionOption(OrderType.stopLimit.rawValue, "APP.TRADE.STOP_LIMIT", null),
-                SelectionOption(OrderType.takeProfitLimit.rawValue, "APP.TRADE.TAKE_PROFIT", null),
-                SelectionOption(OrderType.trailingStop.rawValue, "APP.TRADE.TRAILING_STOP", null),
             )
         private val typeOptionsV4Array =
             iListOf(
                 SelectionOption(OrderType.limit.rawValue, "APP.TRADE.LIMIT_ORDER_SHORT", null),
                 SelectionOption(OrderType.market.rawValue, "APP.TRADE.MARKET_ORDER_SHORT", null),
+                SelectionOption(OrderType.stopLimit.rawValue, "APP.TRADE.STOP_LIMIT", null),
                 SelectionOption(OrderType.stopMarket.rawValue, "APP.TRADE.STOP_MARKET", null),
+                SelectionOption(OrderType.takeProfitLimit.rawValue, "APP.TRADE.TAKE_PROFIT", null),
                 SelectionOption(
                     OrderType.takeProfitMarket.rawValue,
                     "APP.TRADE.TAKE_PROFIT_MARKET",
                     null
                 ),
-                SelectionOption(OrderType.stopLimit.rawValue, "APP.TRADE.STOP_LIMIT", null),
-                SelectionOption(OrderType.takeProfitLimit.rawValue, "APP.TRADE.TAKE_PROFIT", null),
             )
 
         private val sideOptionsArray =

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeInputDataValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeInputDataValidator.kt
@@ -174,7 +174,9 @@ internal class TradeInputDataValidator(
                     val timeInForce = parser.asString(order["timeInForce"])
                     if (orderType != null && timeInForce != null) {
                         val isCurrentOrderStateful = isStatefulOrder(orderType, timeInForce)
-                        if ((status == "OPEN" || status == "PENDING" || status == "UNTRIGGERED") && (isCurrentOrderStateful == shouldCountStatefulOrders)) {
+                        // Short term with IOC or FOK should not be counted
+                        val isShortTermAndRequiresImmediateExecution = !isCurrentOrderStateful && (timeInForce == "IOC" || timeInForce == "FOK")
+                        if (!isShortTermAndRequiresImmediateExecution && (status == "OPEN" || status == "PENDING" || status == "UNTRIGGERED") && (isCurrentOrderStateful == shouldCountStatefulOrders)) {
                             count += 1
                         }
                     }


### PR DESCRIPTION
Change order of Conditional Order Types
- Limit
- Market
- Stop Limit
- Stop Market
- Trailing Stop (not ready yet)
- Take Profit Limit
- Take Profit Market

Update `orderCount` logic to not include short term orders with immediate execution