### PR TITLE
TRCL-2662 baseAsset is no longer in the payload

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 group = "exchange.dydx.abacus"
-version = "0.4.28"
+version = "0.4.29"
 
 repositories {
     google()

--- a/integration/iOS/Pods/Pods.xcodeproj/project.pbxproj
+++ b/integration/iOS/Pods/Pods.xcodeproj/project.pbxproj
@@ -183,11 +183,11 @@
 		15A46B32EBC892483620A52F24AFC350 /* ECB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ECB.swift; path = Sources/CryptoSwift/BlockMode/ECB.swift; sourceTree = "<group>"; };
 		161A656240E3B4B64ECE6858B65DC977 /* Pods-abacus.ios-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-abacus.ios-dummy.m"; sourceTree = "<group>"; };
 		186DE576AF9B0EC2149708CD77D2BC1F /* Shifts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Shifts.swift; path = Sources/CryptoSwift/CS_BigInt/Shifts.swift; sourceTree = "<group>"; };
+		18AD58FF9452C719E07E75C68F463197 /* abacus.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = abacus.debug.xcconfig; sourceTree = "<group>"; };
 		1B6D2B0A7ACC4ACD9BC9FA5D52199C08 /* Cipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cipher.swift; path = Sources/CryptoSwift/Cipher.swift; sourceTree = "<group>"; };
 		1C5732A96CD4AA2A534F0887522F1C39 /* CryptoSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.debug.xcconfig; sourceTree = "<group>"; };
 		1CF2318F38D1207A2F8BF92B7B8A294E /* Array+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extension.swift"; path = "Sources/CryptoSwift/Array+Extension.swift"; sourceTree = "<group>"; };
 		1DE302C0F83772A905581CC7090CA123 /* Collection+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Collection+Extension.swift"; path = "Sources/CryptoSwift/Collection+Extension.swift"; sourceTree = "<group>"; };
-		1E1F36967D766BC17B1215E06682912E /* abacus.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = abacus.release.xcconfig; sourceTree = "<group>"; };
 		1E34A6EC8D702D85DFC8AB0BCA04D225 /* Pods-abacus.iosTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-abacus.iosTests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		233CC871C3B5E5D1C643AA3F5362558A /* DigestType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DigestType.swift; path = Sources/CryptoSwift/DigestType.swift; sourceTree = "<group>"; };
 		236DF73D92D4D71C82089CF882764244 /* NoPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoPadding.swift; path = Sources/CryptoSwift/NoPadding.swift; sourceTree = "<group>"; };
@@ -217,10 +217,10 @@
 		5825EF8E1C9D92AFC155A41AB00E7CDE /* CryptoSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-umbrella.h"; sourceTree = "<group>"; };
 		58D9EEC98E8673B039471D0E403B05CD /* PCBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PCBC.swift; path = Sources/CryptoSwift/BlockMode/PCBC.swift; sourceTree = "<group>"; };
 		5B30BDDC9AD9C2380BF6791299AE1FBE /* Subtraction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Subtraction.swift; path = Sources/CryptoSwift/CS_BigInt/Subtraction.swift; sourceTree = "<group>"; };
-		5B4434D04B297F5AA300030644FC6AED /* abacus.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = abacus.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		5E828917FF2AA3CC6B23ECF8A598B684 /* CryptoSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.release.xcconfig; sourceTree = "<group>"; };
 		61300E9B71B8A176D5EAA3B605958848 /* AES.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.swift; path = Sources/CryptoSwift/AES.swift; sourceTree = "<group>"; };
 		64F91D24D56FF58C2F34255BCC0CA8D2 /* Strideable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strideable.swift; path = Sources/CryptoSwift/CS_BigInt/Strideable.swift; sourceTree = "<group>"; };
+		676E1890C9700A3A84C72C7B944DF207 /* abacus.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = abacus.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		6793D5A483FC322067B570388A6B3706 /* ISO78164Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ISO78164Padding.swift; path = Sources/CryptoSwift/ISO78164Padding.swift; sourceTree = "<group>"; };
 		6904BFCC87FB786B28D1207D0AB43B33 /* Scrypt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Scrypt.swift; path = Sources/CryptoSwift/Scrypt.swift; sourceTree = "<group>"; };
 		6A3143416A23313EEA6BA63B1040BDE9 /* ASN1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ASN1.swift; path = Sources/CryptoSwift/ASN1/ASN1.swift; sourceTree = "<group>"; };
@@ -229,8 +229,6 @@
 		70AEA7453A63A13648C04F8DBDA947E8 /* Pods-abacus.iosTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-abacus.iosTests-dummy.m"; sourceTree = "<group>"; };
 		72ED5A3746B04AD8516BAA07DEB0AFFB /* Rabbit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Rabbit.swift; path = Sources/CryptoSwift/Rabbit.swift; sourceTree = "<group>"; };
 		73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		7387438C7495F77B43770D7B6FC19DEA /* abacus.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = abacus.debug.xcconfig; sourceTree = "<group>"; };
-		741487B600AA498D6CA5F665C3E8FB41 /* Abacus.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Abacus.framework; path = build/cocoapods/framework/Abacus.framework; sourceTree = "<group>"; };
 		75EBB1F2A3091B11F34E2303C5FF61FF /* Integer Conversion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Integer Conversion.swift"; path = "Sources/CryptoSwift/CS_BigInt/Integer Conversion.swift"; sourceTree = "<group>"; };
 		770402A5FA60DB3BB6604065DEAF7112 /* Updatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Updatable.swift; path = Sources/CryptoSwift/Updatable.swift; sourceTree = "<group>"; };
 		77C0EE24E7443418813C133F648727B2 /* BigInt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BigInt.swift; path = Sources/CryptoSwift/CS_BigInt/BigInt.swift; sourceTree = "<group>"; };
@@ -241,6 +239,7 @@
 		82E21560551522E26DA29FC2711C8B79 /* UInt64+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt64+Extension.swift"; path = "Sources/CryptoSwift/UInt64+Extension.swift"; sourceTree = "<group>"; };
 		8401ED14FF39BBF39217A88493885CA8 /* BlockDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockDecryptor.swift; path = Sources/CryptoSwift/BlockDecryptor.swift; sourceTree = "<group>"; };
 		8829F5E52FB40D40BE9F6752C2C053EE /* Pods-abacus.ios-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-abacus.ios-umbrella.h"; sourceTree = "<group>"; };
+		89410D0A4EEF5C7783289BFFA8C65132 /* abacus.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = abacus.release.xcconfig; sourceTree = "<group>"; };
 		8A57B68075D5163750469D071E976128 /* BlockCipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockCipher.swift; path = Sources/CryptoSwift/BlockCipher.swift; sourceTree = "<group>"; };
 		8D06FF8AD7D871B54C7ACCBAC7006F7A /* Pods-abacus.iosTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-abacus.iosTests-umbrella.h"; sourceTree = "<group>"; };
 		8D306C05CD4B555FB15107F16BC703AB /* Codable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Codable.swift; path = Sources/CryptoSwift/CS_BigInt/Codable.swift; sourceTree = "<group>"; };
@@ -296,6 +295,7 @@
 		E595AD44CC42D6071C4AE6FF94574E3E /* Bitwise Ops.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bitwise Ops.swift"; path = "Sources/CryptoSwift/CS_BigInt/Bitwise Ops.swift"; sourceTree = "<group>"; };
 		E64FF95343A43E9FD11A590F1CCB375E /* CryptoSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-prefix.pch"; sourceTree = "<group>"; };
 		E7D1F2F85B2B5D9DBCE3CD1629F37B12 /* Authenticator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authenticator.swift; path = Sources/CryptoSwift/Authenticator.swift; sourceTree = "<group>"; };
+		E84ED7F0DA01628D38C57BFA8C0A2885 /* Abacus.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Abacus.framework; path = build/cocoapods/framework/Abacus.framework; sourceTree = "<group>"; };
 		E86F49595E9BDFBFA2F248DF23D6940E /* Pods-abacus.ios.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-abacus.ios.modulemap"; sourceTree = "<group>"; };
 		E8C491607FDEEACF4F90CE02524CDBF3 /* Prime Test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Prime Test.swift"; path = "Sources/CryptoSwift/CS_BigInt/Prime Test.swift"; sourceTree = "<group>"; };
 		EBE2877F7E8A200D74C4E18847B81123 /* CompactMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompactMap.swift; path = Sources/CryptoSwift/CompactMap.swift; sourceTree = "<group>"; };
@@ -339,25 +339,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		11D79B65BBCD0960017163F4C9B7E49A /* abacus */ = {
-			isa = PBXGroup;
-			children = (
-				FED2887D0E5091C4759D8D8ADFF59C66 /* Frameworks */,
-				8C61F33543ADD6CAD21A0CF0AA823AAF /* Pod */,
-				6B380C499C1E361C8E35461210459B6B /* Support Files */,
-			);
-			name = abacus;
-			path = "/Users/zhenqianhe/v4-abacus";
-			sourceTree = "<absolute>";
-		};
-		28A0B44B5E70F779B3A567F1AE82D8B7 /* Development Pods */ = {
-			isa = PBXGroup;
-			children = (
-				11D79B65BBCD0960017163F4C9B7E49A /* abacus */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
 		578452D2E740E91742655AC8F1636D1F /* iOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -366,14 +347,20 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		6B380C499C1E361C8E35461210459B6B /* Support Files */ = {
+		5ABB1F8B85A50B132154AD0F354134DA /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				7387438C7495F77B43770D7B6FC19DEA /* abacus.debug.xcconfig */,
-				1E1F36967D766BC17B1215E06682912E /* abacus.release.xcconfig */,
+				BB0D37B984AC21D51D35F563098A09F4 /* abacus */,
 			);
-			name = "Support Files";
-			path = "integration/iOS/Pods/Target Support Files/abacus";
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		76A3B71FC16F03C932D838CB3EBF74A1 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				676E1890C9700A3A84C72C7B944DF207 /* abacus.podspec */,
+			);
+			name = Pod;
 			sourceTree = "<group>";
 		};
 		77BFA6027665EBACC42B94A7C2372871 /* Pods-abacus.iosTests */ = {
@@ -400,14 +387,6 @@
 				E216D81D3656F56D4335CA097BDACFA9 /* Pods-abacus.iosTests */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		8C61F33543ADD6CAD21A0CF0AA823AAF /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				5B4434D04B297F5AA300030644FC6AED /* abacus.podspec */,
-			);
-			name = Pod;
 			sourceTree = "<group>";
 		};
 		915C28C583640C124E56AE6BB9F0DAB2 /* CryptoSwift */ = {
@@ -555,11 +534,22 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
+		BB0D37B984AC21D51D35F563098A09F4 /* abacus */ = {
+			isa = PBXGroup;
+			children = (
+				F223BCFEB610D86D0439F551571306C9 /* Frameworks */,
+				76A3B71FC16F03C932D838CB3EBF74A1 /* Pod */,
+				F5ABF3A663095C6FAD156352681853E7 /* Support Files */,
+			);
+			name = abacus;
+			path = "/Users/johnhuang/v4-abacus";
+			sourceTree = "<absolute>";
+		};
 		CF1408CF629C7361332E53B88F7BD30C = {
 			isa = PBXGroup;
 			children = (
 				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
-				28A0B44B5E70F779B3A567F1AE82D8B7 /* Development Pods */,
+				5ABB1F8B85A50B132154AD0F354134DA /* Development Pods */,
 				D210D550F4EA176C3123ED886F8F87F5 /* Frameworks */,
 				DA389CCA0C382AECE0DD24ED555B7245 /* Pods */,
 				7D94CDF401128D689D2B11EDCC7ECD3A /* Products */,
@@ -598,12 +588,22 @@
 			path = "../Target Support Files/CryptoSwift";
 			sourceTree = "<group>";
 		};
-		FED2887D0E5091C4759D8D8ADFF59C66 /* Frameworks */ = {
+		F223BCFEB610D86D0439F551571306C9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				741487B600AA498D6CA5F665C3E8FB41 /* Abacus.framework */,
+				E84ED7F0DA01628D38C57BFA8C0A2885 /* Abacus.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F5ABF3A663095C6FAD156352681853E7 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				18AD58FF9452C719E07E75C68F463197 /* abacus.debug.xcconfig */,
+				89410D0A4EEF5C7783289BFFA8C65132 /* abacus.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "integration/iOS/Pods/Target Support Files/abacus";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -958,7 +958,7 @@
 		};
 		22B0388248EDA44270493DDECC58CF78 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1E1F36967D766BC17B1215E06682912E /* abacus.release.xcconfig */;
+			baseConfigurationReference = 89410D0A4EEF5C7783289BFFA8C65132 /* abacus.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1048,7 +1048,7 @@
 		};
 		5B331F72A7F4402311EBC4A06282E60D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7387438C7495F77B43770D7B6FC19DEA /* abacus.debug.xcconfig */;
+			baseConfigurationReference = 18AD58FF9452C719E07E75C68F463197 /* abacus.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Market.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Market.kt
@@ -804,13 +804,14 @@ data class PerpetualMarket(
 //                data["orderbook"] as? IMap<String, Any>
 //            )
 
-            if (id == null) {
+            if (id == null || assetId == null) {
                 /*
                 If the market is in the config, but not from v3_markets socket, let's skip
                  */
                 return null
             }
-            if (assetId == null || assets?.get(assetId) == null) {
+            val asset = parser.asMap(assets?.get(assetId)) ?: return null
+            if (asset["name"] == null) {
                 return null
             }
             val significantChange = existing?.id != id ||

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Market.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Market.kt
@@ -763,6 +763,7 @@ data class PerpetualMarket(
             existing: PerpetualMarket?,
             parser: ParserProtocol,
             data: IMap<String, Any>,
+            assets: IMap<String, Any>?,
             resetOrderbook: Boolean,
             resetTrades: Boolean,
         ): PerpetualMarket? {
@@ -803,10 +804,13 @@ data class PerpetualMarket(
 //                data["orderbook"] as? IMap<String, Any>
 //            )
 
-            if (id == null || assetId == null) {
+            if (id == null) {
                 /*
                 If the market is in the config, but not from v3_markets socket, let's skip
                  */
+                return null
+            }
+            if (assetId == null || assets?.get(assetId) == null) {
                 return null
             }
             val significantChange = existing?.id != id ||
@@ -875,6 +879,7 @@ data class PerpetualMarketSummary(
             existing: PerpetualMarketSummary?,
             parser: ParserProtocol,
             data: IMap<String, Any>,
+            assets: IMap<String, Any>?
         ): PerpetualMarketSummary? {
             DebugLogger.log("creating Perpetual Market Summary\n")
 
@@ -888,6 +893,7 @@ data class PerpetualMarketSummary(
                     existing?.markets?.get(key),
                     parser,
                     marketData,
+                    assets,
                     false,
                     false
                 )
@@ -903,6 +909,7 @@ data class PerpetualMarketSummary(
             existing: PerpetualMarketSummary?,
             parser: ParserProtocol,
             data: IMap<String, Any>,
+            assets: IMap<String, Any>?,
             changes: StateChanges,
         ): PerpetualMarketSummary? {
             val marketsData = parser.asMap(data["markets"]) ?: return null
@@ -918,6 +925,7 @@ data class PerpetualMarketSummary(
                     existingMarket,
                     parser,
                     marketData,
+                    assets,
                     changes.changes.contains(Changes.orderbook),
                     changes.changes.contains(Changes.trades)
                 )

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/assets/AssetProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/assets/AssetProcessor.kt
@@ -4,6 +4,7 @@ import exchange.dydx.abacus.processor.base.BaseProcessor
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.utils.IMap
 import exchange.dydx.abacus.utils.iMapOf
+import exchange.dydx.abacus.utils.safeSet
 
 @Suppress("UNCHECKED_CAST")
 internal class AssetProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
@@ -45,6 +46,11 @@ internal class AssetProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
         val symbol = received["symbol"]
         if (symbol != null) {
             received["id"] = symbol
+        } else {
+            received.safeSet(
+                "id",
+                parser.asString(payload["ticker"] ?: payload["market"])?.split("-")?.firstOrNull()
+            )
         }
         return received
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/assets/AssetsProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/assets/AssetsProcessor.kt
@@ -33,8 +33,8 @@ internal class AssetsProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
         val assets = existing?.mutable() ?: iMutableMapOf<String, Any>()
         for ((_, data) in payload) {
             val marketPayload = parser.asMap(data)
-            val assetId = parser.asString(marketPayload?.get("baseAsset"))
-            if (marketPayload != null && assetId != null) {
+            val assetId = assetIdFromMarket(marketPayload)
+            if (marketPayload != null && assetId != null && assetId != "") {
                 assetProcessor.received(
                     parser.asMap(existing?.get(assetId)),
                     marketPayload
@@ -44,6 +44,11 @@ internal class AssetsProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
             }
         }
         return assets
+    }
+
+    private fun assetIdFromMarket(payload: IMap<String, Any>?): String? {
+        return parser.asString(payload?.get("baseAsset")) ?:
+            parser.asString(payload?.get("ticker") ?: payload?.get("market"))?.split("-")?.firstOrNull()
     }
 
     internal fun receivedConfigurations(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/modal/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/modal/TradingStateMachine.kt
@@ -792,7 +792,7 @@ open class TradingStateMachine(
 
         if (changes.changes.contains(Changes.markets)) {
             parser.asMap(data?.get("markets"))?.let {
-                marketsSummary = PerpetualMarketSummary.apply(marketsSummary, parser, it, changes)
+                marketsSummary = PerpetualMarketSummary.apply(marketsSummary, parser, it, this.assets, changes)
             } ?: run {
                 marketsSummary = null
             }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/V3AppStateTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/V3AppStateTests.kt
@@ -68,6 +68,10 @@ class V3AppStateTests {
         }
         assertEquals(socketRequestsCount, requests.socketRequests!!.size)
 
+        appStateMachine.processHttpResponse(
+            AbUrl.fromString("https://dydx-v4-shared-resources.vercel.app/v4/markets.json"),
+            mock.marketsConfigurations.configurations
+        )
         /* Markets Connected */
         state = appStateMachine.processSocketResponse(
             AbUrl.fromString("wss://api.stage.dydx.exchange/v3/ws"),

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/V4AppStateMachineForegroundCycleTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/V4AppStateMachineForegroundCycleTests.kt
@@ -52,6 +52,10 @@ class V4AppStateMachineForegroundCycleTests {
     private fun setStateMachineConnectedWithMarkets(): AppStateResponse {
         appStateMachine.setChainId("dydxprotocol-testnet")
         appStateMachine.setReadyToConnect(true)
+        appStateMachine.processHttpResponse(
+            AbUrl.fromString("https://dydx-v4-shared-resources.vercel.app/v4/markets.json"),
+            mock.marketsConfigurations.configurations
+        )
         appStateMachine.processSocketResponse(
             testWsUrl, mock.connectionMock.connectedMessage
         )
@@ -153,6 +157,10 @@ class V4AppStateMachineForegroundCycleTests {
     fun whenMarketsSocketIsSubscribedSummaryShouldBeValid() {
         setStateMachineReadyToConnect()
 
+        appStateMachine.processHttpResponse(
+            AbUrl.fromString("https://dydx-v4-shared-resources.vercel.app/v4/markets.json"),
+            mock.marketsConfigurations.configurations
+        )
         /* Markets Connected */
         val state = appStateMachine.processSocketResponse(
             testWsUrl, mock.marketsChannel.v4_subscribed_r1

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/BaseTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/BaseTests.kt
@@ -1212,11 +1212,12 @@ open class BaseTests(private val maxSubaccountNumber: Int) {
         trace: String
     ) {
         val assetId = parser.asString(data?.get("assetId"))
-        val asset = if (assetId != null) assets?.get(assetId) else null
+        val asset = if (assetId != null) parser.asMap(assets?.get(assetId)) else null
+        val name = asset?.get("name")
         if (data != null &&
             data["id"] != null &&
             parser.asBool(parser.value(data, "status.canTrade")) == true &&
-            asset != null
+            asset != null && name != null
         ) {
             assertNotNull(obj)
             assertEquals(parser.asString(data["id"]), obj.id, "$trace.id")

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/BaseTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/BaseTests.kt
@@ -209,7 +209,12 @@ open class BaseTests(private val maxSubaccountNumber: Int) {
             "historicalPnl"
         )
         verifyAssetsState(perp.assets, state?.assets, "assets")
-        verifyMarketsState(perp.marketsSummary, state?.marketsSummary, "markets")
+        verifyMarketsState(
+            perp.marketsSummary,
+            perp.assets,
+            state?.marketsSummary,
+            "markets"
+        )
         verifyMarketsHistoricalFundingsState(
             parser.asMap(perp.marketsSummary?.get("markets")),
             state?.historicalFundings,
@@ -1162,6 +1167,7 @@ open class BaseTests(private val maxSubaccountNumber: Int) {
 
     private fun verifyMarketsState(
         data: IMap<String, Any>?,
+        assets: IMap<String, Any>?,
         obj: PerpetualMarketSummary?,
         trace: String,
     ) {
@@ -1176,30 +1182,41 @@ open class BaseTests(private val maxSubaccountNumber: Int) {
             obj?.openInterestUSDC,
             "$trace.openInterestUSDC"
         )
-        verifyMarkets(parser.asMap(data?.get("markets")), obj?.markets, "$trace.markets")
+        verifyMarkets(
+            parser.asMap(data?.get("markets")),
+            assets,
+            obj?.markets,
+            "$trace.markets"
+        )
     }
 
     private fun verifyMarkets(
         data: IMap<String, Any>?,
+        assets: IMap<String, Any>?,
         obj: IMap<String, PerpetualMarket>?,
         trace: String,
     ) {
         if (data != null) {
             for ((key, marketData) in data) {
-                verifyMarket(parser.asMap(marketData), obj?.get(key), "$trace.$key")
+                verifyMarket(parser.asMap(marketData), assets, obj?.get(key), "$trace.$key")
             }
         } else {
             assertNull(obj)
         }
     }
 
-    private fun verifyMarket(data: IMap<String, Any>?, obj: PerpetualMarket?, trace: String) {
-        if (data != null && data["id"] != null && parser.asBool(
-                parser.value(
-                    data,
-                    "status.canTrade"
-                )
-            ) == true
+    private fun verifyMarket(
+        data: IMap<String, Any>?,
+        assets: IMap<String, Any>?,
+        obj: PerpetualMarket?,
+        trace: String
+    ) {
+        val assetId = parser.asString(data?.get("assetId"))
+        val asset = if (assetId != null) assets?.get(assetId) else null
+        if (data != null &&
+            data["id"] != null &&
+            parser.asBool(parser.value(data, "status.canTrade")) == true &&
+            asset != null
         ) {
             assertNotNull(obj)
             assertEquals(parser.asString(data["id"]), obj.id, "$trace.id")

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/MarketsChannelMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/MarketsChannelMock.kt
@@ -12,8 +12,6 @@ internal class MarketsChannelMock {
               "BTC-USD": {
                 "market": "BTC-USD",
                 "status": "ONLINE",
-                "baseAsset": "BTC",
-                "quoteAsset": "USD",
                 "stepSize": "0.0001",
                 "tickSize": "1",
                 "indexPrice": "24062.7350",
@@ -38,8 +36,6 @@ internal class MarketsChannelMock {
               "AVAX-USD": {
                 "market": "AVAX-USD",
                 "status": "ONLINE",
-                "baseAsset": "AVAX",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.01",
                 "indexPrice": "25.0212",
@@ -64,8 +60,6 @@ internal class MarketsChannelMock {
               "SUSHI-USD": {
                 "market": "SUSHI-USD",
                 "status": "ONLINE",
-                "baseAsset": "SUSHI",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.001",
                 "indexPrice": "1.5289",
@@ -90,8 +84,6 @@ internal class MarketsChannelMock {
               "XTZ-USD": {
                 "market": "XTZ-USD",
                 "status": "ONLINE",
-                "baseAsset": "XTZ",
-                "quoteAsset": "USD",
                 "stepSize": "1",
                 "tickSize": "0.001",
                 "indexPrice": "1.7506",
@@ -116,8 +108,6 @@ internal class MarketsChannelMock {
               "ICP-USD": {
                 "market": "ICP-USD",
                 "status": "ONLINE",
-                "baseAsset": "ICP",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.01",
                 "indexPrice": "7.5207",
@@ -142,8 +132,6 @@ internal class MarketsChannelMock {
               "NEAR-USD": {
                 "market": "NEAR-USD",
                 "status": "ONLINE",
-                "baseAsset": "NEAR",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.01",
                 "indexPrice": "4.4813",
@@ -168,8 +156,6 @@ internal class MarketsChannelMock {
               "1INCH-USD": {
                 "market": "1INCH-USD",
                 "status": "ONLINE",
-                "baseAsset": "1INCH",
-                "quoteAsset": "USD",
                 "stepSize": "1",
                 "tickSize": "0.001",
                 "indexPrice": "0.7766",
@@ -194,8 +180,6 @@ internal class MarketsChannelMock {
               "ETH-USD": {
                 "market": "ETH-USD",
                 "status": "ONLINE",
-                "baseAsset": "ETH",
-                "quoteAsset": "USD",
                 "stepSize": "0.001",
                 "tickSize": "0.1",
                 "indexPrice": "1754.0223",
@@ -220,8 +204,6 @@ internal class MarketsChannelMock {
               "COMP-USD": {
                 "market": "COMP-USD",
                 "status": "ONLINE",
-                "baseAsset": "COMP",
-                "quoteAsset": "USD",
                 "stepSize": "0.01",
                 "tickSize": "0.1",
                 "indexPrice": "58.5982",
@@ -246,8 +228,6 @@ internal class MarketsChannelMock {
               "CRV-USD": {
                 "market": "CRV-USD",
                 "status": "ONLINE",
-                "baseAsset": "CRV",
-                "quoteAsset": "USD",
                 "stepSize": "1",
                 "tickSize": "0.001",
                 "indexPrice": "1.4585",
@@ -272,8 +252,6 @@ internal class MarketsChannelMock {
               "MKR-USD": {
                 "market": "MKR-USD",
                 "status": "ONLINE",
-                "baseAsset": "MKR",
-                "quoteAsset": "USD",
                 "stepSize": "0.001",
                 "tickSize": "1",
                 "indexPrice": "1169.0000",
@@ -298,8 +276,6 @@ internal class MarketsChannelMock {
               "ETC-USD": {
                 "market": "ETC-USD",
                 "status": "ONLINE",
-                "baseAsset": "ETC",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.01",
                 "indexPrice": "42.2465",
@@ -324,8 +300,6 @@ internal class MarketsChannelMock {
               "LTC-USD": {
                 "market": "LTC-USD",
                 "status": "ONLINE",
-                "baseAsset": "LTC",
-                "quoteAsset": "USD",
                 "stepSize": "0.01",
                 "tickSize": "0.1",
                 "indexPrice": "62.0689",
@@ -350,8 +324,6 @@ internal class MarketsChannelMock {
               "ATOM-USD": {
                 "market": "ATOM-USD",
                 "status": "ONLINE",
-                "baseAsset": "ATOM",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.01",
                 "indexPrice": "11.3807",
@@ -376,8 +348,6 @@ internal class MarketsChannelMock {
               "RUNE-USD": {
                 "market": "RUNE-USD",
                 "status": "ONLINE",
-                "baseAsset": "RUNE",
-                "quoteAsset": "USD",
                 "stepSize": "1",
                 "tickSize": "0.001",
                 "indexPrice": "2.7440",
@@ -402,8 +372,6 @@ internal class MarketsChannelMock {
               "UMA-USD": {
                 "market": "UMA-USD",
                 "status": "ONLINE",
-                "baseAsset": "UMA",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.01",
                 "indexPrice": "3.0002",
@@ -428,8 +396,6 @@ internal class MarketsChannelMock {
               "AAVE-USD": {
                 "market": "AAVE-USD",
                 "status": "ONLINE",
-                "baseAsset": "AAVE",
-                "quoteAsset": "USD",
                 "stepSize": "0.01",
                 "tickSize": "0.01",
                 "indexPrice": "98.1505",
@@ -454,8 +420,6 @@ internal class MarketsChannelMock {
               "SNX-USD": {
                 "market": "SNX-USD",
                 "status": "ONLINE",
-                "baseAsset": "SNX",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.01",
                 "indexPrice": "4.0715",
@@ -480,8 +444,6 @@ internal class MarketsChannelMock {
               "LINK-USD": {
                 "market": "LINK-USD",
                 "status": "ONLINE",
-                "baseAsset": "LINK",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.001",
                 "indexPrice": "8.0990",
@@ -506,8 +468,6 @@ internal class MarketsChannelMock {
               "XMR-USD": {
                 "market": "XMR-USD",
                 "status": "ONLINE",
-                "baseAsset": "XMR",
-                "quoteAsset": "USD",
                 "stepSize": "0.01",
                 "tickSize": "0.1",
                 "indexPrice": "162.5353",
@@ -532,8 +492,6 @@ internal class MarketsChannelMock {
               "ALGO-USD": {
                 "market": "ALGO-USD",
                 "status": "ONLINE",
-                "baseAsset": "ALGO",
-                "quoteAsset": "USD",
                 "stepSize": "1",
                 "tickSize": "0.001",
                 "indexPrice": "0.3412",
@@ -558,8 +516,6 @@ internal class MarketsChannelMock {
               "BCH-USD": {
                 "market": "BCH-USD",
                 "status": "ONLINE",
-                "baseAsset": "BCH",
-                "quoteAsset": "USD",
                 "stepSize": "0.01",
                 "tickSize": "0.1",
                 "indexPrice": "155.7338",
@@ -584,8 +540,6 @@ internal class MarketsChannelMock {
               "UNI-USD": {
                 "market": "UNI-USD",
                 "status": "ONLINE",
-                "baseAsset": "UNI",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.001",
                 "indexPrice": "9.1360",
@@ -610,8 +564,6 @@ internal class MarketsChannelMock {
               "DOGE-USD": {
                 "market": "DOGE-USD",
                 "status": "ONLINE",
-                "baseAsset": "DOGE",
-                "quoteAsset": "USD",
                 "stepSize": "10",
                 "tickSize": "0.0001",
                 "indexPrice": "0.0703",
@@ -636,8 +588,6 @@ internal class MarketsChannelMock {
               "EOS-USD": {
                 "market": "EOS-USD",
                 "status": "ONLINE",
-                "baseAsset": "EOS",
-                "quoteAsset": "USD",
                 "stepSize": "1",
                 "tickSize": "0.001",
                 "indexPrice": "1.3238",
@@ -662,8 +612,6 @@ internal class MarketsChannelMock {
               "SOL-USD": {
                 "market": "SOL-USD",
                 "status": "ONLINE",
-                "baseAsset": "SOL",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.001",
                 "indexPrice": "42.9874",
@@ -688,8 +636,6 @@ internal class MarketsChannelMock {
               "ZRX-USD": {
                 "market": "ZRX-USD",
                 "status": "ONLINE",
-                "baseAsset": "ZRX",
-                "quoteAsset": "USD",
                 "stepSize": "1",
                 "tickSize": "0.001",
                 "indexPrice": "0.3379",
@@ -714,8 +660,6 @@ internal class MarketsChannelMock {
               "ADA-USD": {
                 "market": "ADA-USD",
                 "status": "ONLINE",
-                "baseAsset": "ADA",
-                "quoteAsset": "USD",
                 "stepSize": "1",
                 "tickSize": "0.001",
                 "indexPrice": "0.5317",
@@ -740,8 +684,6 @@ internal class MarketsChannelMock {
               "CELO-USD": {
                 "market": "CELO-USD",
                 "status": "ONLINE",
-                "baseAsset": "CELO",
-                "quoteAsset": "USD",
                 "stepSize": "1",
                 "tickSize": "0.001",
                 "indexPrice": "1.0062",
@@ -766,8 +708,6 @@ internal class MarketsChannelMock {
               "TRX-USD": {
                 "market": "TRX-USD",
                 "status": "ONLINE",
-                "baseAsset": "TRX",
-                "quoteAsset": "USD",
                 "stepSize": "10",
                 "tickSize": "0.0001",
                 "indexPrice": "0.0698",
@@ -792,8 +732,6 @@ internal class MarketsChannelMock {
               "FIL-USD": {
                 "market": "FIL-USD",
                 "status": "ONLINE",
-                "baseAsset": "FIL",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.01",
                 "indexPrice": "6.0336",
@@ -818,8 +756,6 @@ internal class MarketsChannelMock {
               "LUNA-USD": {
                 "market": "LUNA-USD",
                 "status": "CLOSE_ONLY",
-                "baseAsset": "LUNA",
-                "quoteAsset": "USD",
                 "stepSize": "0.01",
                 "tickSize": "0.0001",
                 "indexPrice": "0.0001",
@@ -844,8 +780,6 @@ internal class MarketsChannelMock {
               "YFI-USD": {
                 "market": "YFI-USD",
                 "status": "ONLINE",
-                "baseAsset": "YFI",
-                "quoteAsset": "USD",
                 "stepSize": "0.0001",
                 "tickSize": "1",
                 "indexPrice": "11435.2138",
@@ -870,8 +804,6 @@ internal class MarketsChannelMock {
               "ZEC-USD": {
                 "market": "ZEC-USD",
                 "status": "ONLINE",
-                "baseAsset": "ZEC",
-                "quoteAsset": "USD",
                 "stepSize": "0.01",
                 "tickSize": "0.1",
                 "indexPrice": "65.0100",
@@ -896,8 +828,6 @@ internal class MarketsChannelMock {
               "DOT-USD": {
                 "market": "DOT-USD",
                 "status": "ONLINE",
-                "baseAsset": "DOT",
-                "quoteAsset": "USD",
                 "stepSize": "0.1",
                 "tickSize": "0.01",
                 "indexPrice": "8.4068",
@@ -922,8 +852,6 @@ internal class MarketsChannelMock {
               "XLM-USD": {
                 "market": "XLM-USD",
                 "status": "ONLINE",
-                "baseAsset": "XLM",
-                "quoteAsset": "USD",
                 "stepSize": "10",
                 "tickSize": "0.0001",
                 "indexPrice": "0.1193",
@@ -948,8 +876,6 @@ internal class MarketsChannelMock {
               "MATIC-USD": {
                 "market": "MATIC-USD",
                 "status": "ONLINE",
-                "baseAsset": "MATIC",
-                "quoteAsset": "USD",
                 "stepSize": "1",
                 "tickSize": "0.001",
                 "indexPrice": "0.9573",
@@ -974,8 +900,6 @@ internal class MarketsChannelMock {
               "ENJ-USD": {
                 "market": "ENJ-USD",
                 "status": "ONLINE",
-                "baseAsset": "ENJ",
-                "quoteAsset": "USD",
                 "stepSize": "1",
                 "tickSize": "0.001",
                 "indexPrice": "0.6171",
@@ -1053,8 +977,6 @@ internal class MarketsChannelMock {
                     "clobPairId":"0",
                     "ticker":"BTC-USD",
                     "status":"ACTIVE",
-                    "baseAsset":"",
-                    "quoteAsset":"",
                     "lastPrice":"0",
                     "oraclePrice":"0",
                     "priceChange24H":"0",
@@ -1076,8 +998,6 @@ internal class MarketsChannelMock {
                     "clobPairId":"1",
                     "ticker":"ETH-USD",
                     "status":"ACTIVE",
-                    "baseAsset":"",
-                    "quoteAsset":"",
                     "lastPrice":"0",
                     "oraclePrice":"0",
                     "priceChange24H":"0",
@@ -1094,6 +1014,27 @@ internal class MarketsChannelMock {
                     "stepBaseQuantums":1000000,
                     "subticksPerTick":10000,
                     "openInterest":"46115.049878"
+                 },
+                 "TEST-USD":{
+                    "clobPairId":"33",
+                    "ticker":"TEST-USD",
+                    "status":"ACTIVE",
+                    "lastPrice":"0",
+                    "oraclePrice":"57.80445",
+                    "priceChange24H":"0",
+                    "volume24H":"0",
+                    "trades24H":0,
+                    "nextFundingRate":"0",
+                    "initialMarginFraction":"0.05",
+                    "maintenanceMarginFraction":"0.03",
+                    "basePositionNotional":"1000000",
+                    "openInterest":"0",
+                    "atomicResolution":-10,
+                    "quantumConversionExponent":-8,
+                    "tickSize":"100000",
+                    "stepSize":"0.0001",
+                    "stepBaseQuantums":1000000,
+                    "subticksPerTick":1000000000
                  }
               }
            }
@@ -1180,8 +1121,6 @@ internal class MarketsChannelMock {
                     "clobPairId":"0",
                     "ticker":"BTC-USD",
                     "status":"ACTIVE",
-                    "baseAsset":"",
-                    "quoteAsset":"",
                     "lastPrice":"0",
                     "oraclePrice":"20000",
                     "priceChange24H":"0",
@@ -1206,8 +1145,6 @@ internal class MarketsChannelMock {
                     "clobPairId":"1",
                     "ticker":"ETH-USD",
                     "status":"ACTIVE",
-                    "baseAsset":"",
-                    "quoteAsset":"",
                     "lastPrice":"0",
                     "oraclePrice":"1500",
                     "priceChange24H":"0",
@@ -1271,8 +1208,6 @@ internal class MarketsChannelMock {
                     "clobPairId":"0",
                     "ticker":"BTC-USD",
                     "status":"ACTIVE",
-                    "baseAsset":"",
-                    "quoteAsset":"",
                     "lastPrice":"0",
                     "oraclePrice":"10000",
                     "priceChange24H":"0",
@@ -1292,8 +1227,6 @@ internal class MarketsChannelMock {
                     "clobPairId":"1",
                     "ticker":"ETH-USD",
                     "status":"ACTIVE",
-                    "baseAsset":"",
-                    "quoteAsset":"",
                     "lastPrice":"0",
                     "oraclePrice":"1000",
                     "priceChange24H":"0",
@@ -1370,8 +1303,6 @@ internal class MarketsChannelMock {
                     "clobPairId":"0",
                     "ticker":"BTC-USD",
                     "status":"ACTIVE",
-                    "baseAsset":"",
-                    "quoteAsset":"",
                     "lastPrice":"0",
                     "oraclePrice":"10000",
                     "priceChange24H":"0",
@@ -1397,8 +1328,6 @@ internal class MarketsChannelMock {
                     "clobPairId":"1",
                     "ticker":"ETH-USD",
                     "status":"ACTIVE",
-                    "baseAsset":"",
-                    "quoteAsset":"",
                     "lastPrice":"0",
                     "oraclePrice":"1000",
                     "priceChange24H":"0",

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/ValidationsMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/ValidationsMock.kt
@@ -12,8 +12,6 @@ internal class ValidationsMock {
               "BTC-USD": {
                 "market": "BTC-USD",
                 "status": "ONLINE",
-                "baseAsset": "BTC",
-                "quoteAsset": "USD",
                 "stepSize": "0.0001",
                 "tickSize": "1",
                 "indexPrice": "20000.0000",
@@ -38,8 +36,6 @@ internal class ValidationsMock {
               "ETH-USD": {
                 "market": "ETH-USD",
                 "status": "ONLINE",
-                "baseAsset": "ETH",
-                "quoteAsset": "USD",
                 "stepSize": "0.001",
                 "tickSize": "0.1",
                 "indexPrice": "1000.0000",

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '0.4.28'
+    spec.version                  = '0.4.29'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Two fixes
1. Occasionally, if socket v4_markets data comes in before market configuration json, the assets configurations are messed up because baseAsset is no longer used (either missing, or ""). So now we always split the first element of the "ticker" as asset.
2. Filter out markets which didn't have market configuration (missing "name" field). This will filter out "TEST-USD", and also filter out future markets which we didn't prepare the configurations for.