### PR TITLE
TRCL-2781 We shouldn't filter the markets.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 group = "exchange.dydx.abacus"
-version = "0.6.0"
+version = "0.6.1"
 
 repositories {
     google()

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '0.6.0'
+    spec.version                  = '0.6.1'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Per PM (Corey) request, we shouldn't filter out markets for which the asset configs are not ready.

Removed filtering in Abacus.

Separate [web tickets](https://linear.app/dydx/issue/TRCL-2784/remove-filtering-from-web-app) for web to unfilter
[iOS ticket](https://linear.app/dydx/issue/TRCL-2785/make-sure-ios-handles-market-without-assets-nicely) to display the markets correctly - right now it doesn't show the market name. 