### PR TITLE
TRCL-3110 do not send an calculated nextFundingAt if data is not available

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.0.2"
+version = "1.0.3"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketProcessor.kt
@@ -146,20 +146,6 @@ internal class MarketProcessor(parser: ParserProtocol, private val calculateSpar
         return calculate(output)
     }
 
-    private fun calculateNextFundingAt(): Instant {
-        val now: Instant = ServerTime.now()
-        val time = now.toLocalDateTime(TimeZone.UTC)
-        val minute = time.minute
-        val second = time.second
-        val nanosecond = time.nanosecond
-        val duration =
-            nanosecond.toDuration(DurationUnit.NANOSECONDS) +
-                    second.toDuration(DurationUnit.SECONDS) +
-                    minute.toDuration(DurationUnit.MINUTES)
-
-        return now.minus(duration).plus(1.toDuration(DurationUnit.HOURS))
-    }
-
     internal fun receivedDelta(
         market: Map<String, Any>?,
         payload: Map<String, Any>,
@@ -255,9 +241,6 @@ internal class MarketProcessor(parser: ParserProtocol, private val calculateSpar
             parser.asDouble(perpetual["openInterest"])?.let {
                 perpetual["openInterestUSDC"] = it * oraclePrice
             }
-        }
-        if (perpetual["nextFundingAt"] == null) {
-            perpetual.safeSet("nextFundingAt", calculateNextFundingAt())
         }
         return perpetual
     }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.0.2'
+    spec.version                  = '1.0.3'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Parent ticket: [TRCL-3109](https://linear.app/dydx/issue/TRCL-3109/update-funding-rate-and-next-funding-at)

V4 nextFundingAt is not in payload and we should just use the next hour mark. Right. now, Abacus fills in one and it actually causes issues with FE when current time goes over the hour mark