### PR TITLE
TRCL-3124 emit TradePlaceOrder and TradeCancelOrder event

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.0.7"
+version = "1.0.8"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
@@ -199,6 +199,10 @@ enum class AnalyticsEvent(val rawValue: String) {
     // App
     NetworkStatus("NetworkStatus"),
 
+    // Transactions
+    TradePlaceOrder("TradePlaceOrder"),
+    TradeCancelOrder("TradeCancelOrder"),
+
     // Transfers
     TransferFaucetConfirmed("TransferFaucetConfirmed"),
 
@@ -295,14 +299,14 @@ fun FileSystemProtocol.readCachedTextFile(
     path: String,
 ): String? {
     var data = this.readTextFile(FileLocation.AppDocs, path)
-    if (data == null) {
+    return if (data == null) {
         data = this.readTextFile(FileLocation.AppBundle, path)
         if (data != null) {
             this.writeTextFile(path, data)
         }
-        return data
+        data
     } else {
-        return data
+        data
     }
 }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManager.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManager.kt
@@ -539,22 +539,22 @@ class AsyncAbacusStateManager(
     }
 
     fun commitPlaceOrder(callback: TransactionCallback): HumanReadablePlaceOrderPayload? {
-        try {
-            return adaptor?.commitPlaceOrder(callback)
+        return try {
+            adaptor?.commitPlaceOrder(callback)
         } catch (e: Exception) {
             val error = V4TransactionErrors.error(null, e.toString())
             callback(false, error, null)
-            return null
+            null
         }
     }
 
     fun commitClosePosition(callback: TransactionCallback): HumanReadablePlaceOrderPayload? {
-        try {
-            return adaptor?.commitClosePosition(callback)
+        return try {
+            adaptor?.commitClosePosition(callback)
         } catch (e: Exception) {
             val error = V4TransactionErrors.error(null, e.toString())
             callback(false, error, null)
-            return null
+            null
         }
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
@@ -809,6 +809,10 @@ class V4StateManagerAdaptor(
         transaction(TransactionType.PlaceOrder, string) { response ->
             val error = parseTransactionResponse(response)
             if (error == null) {
+                tracking(
+                    AnalyticsEvent.TradePlaceOrder.rawValue,
+                    null,
+                )
                 ioImplementations.threading?.async(ThreadingType.abacus) {
                     this.placeOrderRecords.add(
                         PlaceOrderRecord(
@@ -835,6 +839,10 @@ class V4StateManagerAdaptor(
         transaction(TransactionType.PlaceOrder, string) { response ->
             val error = parseTransactionResponse(response)
             if (error == null) {
+                tracking(
+                    AnalyticsEvent.TradePlaceOrder.rawValue,
+                    null,
+                )
                 ioImplementations.threading?.async(ThreadingType.abacus) {
                     this.placeOrderRecords.add(
                         PlaceOrderRecord(
@@ -949,6 +957,10 @@ class V4StateManagerAdaptor(
         transaction(TransactionType.CancelOrder, string) { response ->
             val error = parseTransactionResponse(response)
             if (error == null) {
+                tracking(
+                    AnalyticsEvent.TradeCancelOrder.rawValue,
+                    null,
+                )
                 ioImplementations.threading?.async(ThreadingType.abacus) {
                     this.orderCanceled(orderId)
                     this.cancelOrderRecords.add(

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.0.7'
+    spec.version                  = '1.0.8'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Abacus will send these events.

There are separate ticket [TRCL-3125](https://linear.app/dydx/issue/TRCL-3125/remove-tradeplaceorder-and-tradecancelorder-in-ios-code) and [TRCL-3126](https://linear.app/dydx/issue/TRCL-3126/remove-tradeplaceorder-and-tradecancelorder-in-web-code) to remove these events from FE code.