### PR TITLE
Update to Equity Tier Limit: Ignore for MARKET and LIMIT (IOC/FOK) orders

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.0.28"
+version = "1.0.30"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeInputDataValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeInputDataValidator.kt
@@ -111,9 +111,13 @@ internal class TradeInputDataValidator(
             maxOrdersForEquityTier(isStatefulOrder(orderType, timeInForce), subaccount, configs)
         val numOrders = orderCount(isStatefulOrder(orderType, timeInForce), subaccount)
 
+        // Equity tier limit is not applicable for `MARKET` orders and `LIMIT` orders with FOK or IOC time in force
+        val isEquityTierLimitApplicable = orderType != "MARKET" &&
+            !(orderType == "LIMIT" && (timeInForce == "FOK" || timeInForce == "IOC"))
+
         val documentation = environment?.links?.documentation
         val link = if (documentation != null) "$documentation/trading/other_limits" else null
-        return if (numOrders >= equityTierLimit) {
+        return if (numOrders >= equityTierLimit && isEquityTierLimitApplicable) {
             listOf(
                 error(
                     "ERROR",

--- a/src/commonTest/kotlin/exchange.dydx.abacus/validation/TradeBracketsTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/validation/TradeBracketsTests.kt
@@ -224,9 +224,6 @@ class TradeBracketsTests: ValidationsTests() {
                             "code": "NO_EQUITY_DEPOSIT_FIRST"
                         },
                         {
-                            "code": "USER_MAX_ORDERS"
-                        },
-                        {
                             "type": "ERROR",
                             "code": "WOULD_NOT_REDUCE_UNCHECK",
                             "fields": [

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.0.28'
+    spec.version                  = '1.0.30'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
https://github.com/dydxprotocol/v4-abacus/assets/13111994/2f56be64-b416-4ce6-ae24-1f6ac097e20e

- Added intermediate variable `isEquityTierLimitApplicable` to determine whether we should check against Equity Tier Limit