### PR TITLE
[Trading Rewards][0/n] Add Account layer to address response 

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/WalletProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/WalletProcessor.kt
@@ -56,12 +56,12 @@ internal class WalletProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
         }
     }
 
-    internal fun receivedSubaccounts(
+    internal fun receivedAccount(
         existing: Map<String, Any>?,
-        payload: List<Any>?,
+        payload: Map<String, Any>?,
     ): Map<String, Any>? {
         return receivedObject(existing, "account", payload) { existing, payload ->
-            v4accountProcessor.receivedSubaccounts(parser.asNativeMap(existing), payload as? List<Any>)
+            v4accountProcessor.receivedAccount(parser.asNativeMap(existing), payload as? Map<String, Any>?)
         }
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/AccountProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/AccountProcessor.kt
@@ -918,14 +918,14 @@ internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser
         return modified
     }
 
-    internal fun receivedSubaccounts(
+    internal fun receivedAccount(
         existing: Map<String, Any>?,
-        payload: List<Any>?,
+        payload: Map<String, Any>?,
     ): Map<String, Any>? {
         val modified = existing?.mutable() ?: mutableMapOf()
         val subaccounts = parser.asNativeMap(parser.value(existing, "subaccounts"))
-        val modifiedsubaccounts = subaccountsProcessor.receivedSubaccounts(subaccounts, payload)
-        modified.safeSet("subaccounts", modifiedsubaccounts)
+        val modifiedSubaccounts = subaccountsProcessor.receivedSubaccounts(subaccounts, parser.asList(payload?.get("subaccounts")))
+        modified.safeSet("subaccounts", modifiedSubaccounts)
         return modified
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
@@ -52,7 +52,7 @@ import exchange.dydx.abacus.state.modal.receivedTradesChanges
 import exchange.dydx.abacus.state.modal.receivedTransfers
 import exchange.dydx.abacus.state.modal.setOrderbookGrouping
 import exchange.dydx.abacus.state.modal.sparklines
-import exchange.dydx.abacus.state.modal.subaccounts
+import exchange.dydx.abacus.state.modal.account
 import exchange.dydx.abacus.state.modal.trade
 import exchange.dydx.abacus.state.modal.tradeInMarket
 import exchange.dydx.abacus.state.modal.transfer
@@ -504,7 +504,7 @@ open class StateManagerAdaptor(
             }
             if (accountAddress != null) {
                 screenAccountAddress()
-                retrieveSubaccounts()
+                retrieveAccount()
             }
             if (subaccount != null) {
                 retrieveSubaccountFills()
@@ -1384,18 +1384,18 @@ open class StateManagerAdaptor(
     }
 
 
-    open fun retrieveSubaccounts() {
+    open fun retrieveAccount() {
         val oldState = stateMachine.state
-        val url = subaccountsUrl()
+        val url = accountUrl()
         if (url != null) {
             get(url, null, null, callback = { _, response, httpCode ->
                 if (success(httpCode) && response != null) {
-                    update(stateMachine.subaccounts(response), oldState)
+                    update(stateMachine.account(response), oldState)
                     updateConnectedSubaccountNumber()
                 } else {
                     subaccountsTimer =
                         ioImplementations.timer?.schedule(subaccountsPollingDelay, null) {
-                            retrieveSubaccounts()
+                            retrieveAccount()
                             false
                         }
                 }
@@ -1403,7 +1403,7 @@ open class StateManagerAdaptor(
         }
     }
 
-    open fun subaccountsUrl(): String? {
+    open fun accountUrl(): String? {
         return null
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
@@ -216,8 +216,8 @@ class V4StateManagerAdaptor(
         } else 0
     }
 
-    override fun subaccountsUrl(): String? {
-        val url = configs.privateApiUrl("subaccounts")
+    override fun accountUrl(): String? {
+        val url = configs.privateApiUrl("account")
         return if (accountAddress != null && url != null) {
             "$url/$accountAddress"
         } else null
@@ -385,7 +385,7 @@ class V4StateManagerAdaptor(
                 screenSourceAddress()
             }
             if (readyToConnect) {
-                retrieveSubaccounts()
+                retrieveAccount()
                 if (validatorConnected) {
                     pollAccountBalances()
                     pollNobleBalance()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
@@ -23,13 +23,13 @@ class V4StateManagerConfigs(
                          "historical-funding":"/v4/historicalFunding",
                          "historical-pnl":"/v4/historical-pnl",
                          "sparklines":"/v4/sparklines",
-                         "subaccounts":"/v4/addresses",
+                         "account":"/v4/addresses",
                          "time":"/v4/time",
                          "screen":"/v4/screen",
                          "height":"/v4/height"
                       },
                       "private":{
-                         "subaccounts":"/v4/addresses",
+                         "account":"/v4/addresses",
                          "fills":"/v4/fills",
                          "historical-pnl":"/v4/historical-pnl",
                          "transfers":"/v4/transfers"

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/modal/TradingStateMachine+Account.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/modal/TradingStateMachine+Account.kt
@@ -16,17 +16,17 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 
 
-internal fun TradingStateMachine.subaccounts(payload: String): StateChanges {
-    val json = parser.asList(parser.asMap(Json.parseToJsonElement(payload))?.get("subaccounts"))
+internal fun TradingStateMachine.account(payload: String): StateChanges {
+    val json = parser.asMap(Json.parseToJsonElement(payload))
     return if (json != null) {
-        receivedSubaccounts(json)
+        receivedAccount(json)
     } else StateChanges(iListOf<Changes>(), null, null)
 }
 
-internal fun TradingStateMachine.receivedSubaccounts(
-    payload: List<Any>
+internal fun TradingStateMachine.receivedAccount(
+    payload: Map<String, Any>
 ): StateChanges {
-    this.wallet = walletProcessor.receivedSubaccounts(wallet, payload)
+    this.wallet = walletProcessor.receivedAccount(wallet, payload)
     return StateChanges(iListOf(Changes.subaccount))
 }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/modal/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/modal/TradingStateMachine.kt
@@ -448,7 +448,7 @@ open class TradingStateMachine(
                 else if (url.path.contains("/v3/candles/") || url.path.contains("/v4/candles/"))
                     changes = candles(payload)
                 else if (url.path.contains("/v4/addresses/"))
-                    changes = subaccounts(payload)
+                    changes = account(payload)
                 else
                     error = ParsingError(
                         ParsingErrorType.UnhandledEndpoint,


### PR DESCRIPTION
`/v4/addresses/:address`
```
// Old response schema
interface AddressResponse {
    subaccounts: SubaccountResponse[]
}

// Updated response schema
interface AddressResponse {
    subaccounts: SubaccountResponse[],
    totalTradingRewards: string, // new field
}
```

- previously the response only has `subaccounts`, and therefore we parsed the payload as list directly in `TradingStateMachine.subaccounts`
- since there is now `totalTradingRewards` in the response, we want to add back the Account layer instead of just treating the AddressResponse as subaccounts response
- Subsequent PRs will update the account as something like:
```
 {
    "wallet": {
        "account": {
            "tradingRewards": {
                "total": 2800.8,
                "historalRewards": {
                     "DAILY": {...},
                     "WEEKLY": {...},
                     "MONTHLY": {...},
                  }
              },
             "subaccounts": {...}
             ...
        },
    }
}
```