### PR TITLE
Call historical trading rewards REST endpoint

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManager.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManager.kt
@@ -70,6 +70,20 @@ enum class HistoricalPnlPeriod(val rawValue: String) {
 
 @JsExport
 @Serializable
+enum class HistoricaTradingRewardsPeriod(val rawValue: String) {
+    DAILY("DAILY"),
+    WEEKLY("WEEKLY"),
+    MONTHLY("MONTHLY"),
+    BLOCK("BLOCK");
+
+    companion object {
+        operator fun invoke(rawValue: String) = 
+        HistoricaTradingRewardsPeriod.values().firstOrNull { it.rawValue == rawValue }
+    }
+}
+
+@JsExport
+@Serializable
 enum class CandlesPeriod(val rawValue: String) {
     Period1m("1m"),
     Period5m("5m"),
@@ -261,6 +275,7 @@ class AsyncAbacusStateManager(
                 value?.sourceAddress = sourceAddress
                 value?.subaccountNumber = subaccountNumber
                 value?.orderbookGrouping = orderbookGrouping
+                value?.historicalTradingRewardPeriod = historicalTradingRewardPeriod
                 value?.historicalPnlPeriod = historicalPnlPeriod
                 value?.candlesResolution = candlesResolution
                 value?.readyToConnect = readyToConnect
@@ -323,6 +338,14 @@ class AsyncAbacusStateManager(
             field = value
             ioImplementations.threading?.async(ThreadingType.abacus) {
                 adaptor?.historicalPnlPeriod = field
+            }
+        }
+    
+    var historicalTradingRewardPeriod: HistoricaTradingRewardsPeriod = HistoricaTradingRewardsPeriod.WEEKLY
+        set(value) {
+            field = value
+            ioImplementations.threading?.async(ThreadingType.abacus) {
+                adaptor?.historicalTradingRewardPeriod = field
             }
         }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
@@ -514,6 +514,7 @@ open class StateManagerAdaptor(
             if (accountAddress != null) {
                 screenAccountAddress()
                 retrieveAccount()
+                retrieveAccountHistoricalTradingRewards()
             }
             if (subaccount != null) {
                 retrieveSubaccountFills()
@@ -1412,7 +1413,7 @@ open class StateManagerAdaptor(
         }
     }
 
-    open fun retrieveAccountHistoricalTradingRewards(period: String, previousUrl: String? = null) {
+    open fun retrieveAccountHistoricalTradingRewards(period: String? = "WEEKLY", previousUrl: String? = null) {
         val oldState = stateMachine.state
         var url = historicalTradingRewardsUrl() ?: return
         val params = historicalTradingRewardsParams(period)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
@@ -235,6 +235,18 @@ class V4StateManagerAdaptor(
         return configs.publicApiUrl("screen")
     }
 
+    override fun historicalTradingRewardsUrl(): String? {
+        return configs.privateApiUrl("historicalTradingRewards")
+    }
+
+    override fun historicalTradingRewardsParams(period: String): IMap<String, String>? {
+        val accountAddress = accountAddress
+        return if (accountAddress != null) iMapOf(
+            "address" to accountAddress,
+            "period" to "$period",
+        ) else null
+    }
+
     override fun subaccountParams(): IMap<String, String>? {
         val accountAddress = accountAddress
         val subaccountNumber = subaccountNumber

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
@@ -32,6 +32,7 @@ class V4StateManagerConfigs(
                          "account":"/v4/addresses",
                          "fills":"/v4/fills",
                          "historical-pnl":"/v4/historical-pnl",
+                         "historical-trading-rewards":"/v4/historicalTradingRewards",
                          "transfers":"/v4/transfers"
                       },
                       "faucet":{

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/modal/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/modal/TradingStateMachine.kt
@@ -395,7 +395,8 @@ open class TradingStateMachine(
         payload: String,
         subaccountNumber: Int,
         height: Int?,
-        deploymentUri: String? = null
+        deploymentUri: String? = null,
+        period: String? = null,
     ): StateResponse {
         /*
         For backward compatibility only
@@ -434,6 +435,10 @@ open class TradingStateMachine(
                     parser.asInt(url.params?.firstOrNull { param -> param.key == "subaccountNumber" }?.value)
                         ?: 0
                 changes = transfers(payload, subaccountNumber)
+            }
+
+            "/v4/historicalTradingRewards" -> {
+                changes = historicalTradingRewards(payload, period?: "WEEKLY")
             }
 
             "/configs/markets.json" -> {

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4AccountTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4AccountTests.kt
@@ -1094,9 +1094,14 @@ class V4AccountTests : V4BaseTests() {
 
         test(
             {
-                val changes = perp.historicalTradingRewards(mock.historicalTradingRewards.monthlyCall, "MONTHLY")
-                perp.update(changes)
-                return@test StateResponse(perp.state, changes)
+                perp.rest(
+                    AbUrl.fromString("$testRestUrl/v4/historicalTradingRewards?period=MONTHLY"),
+                    mock.historicalTradingRewards.monthlyCall,
+                    0,
+                    null,
+                    null,
+                    "MONTHLY"
+                )
             },
             """
                 {


### PR DESCRIPTION
- call historical trading rewards endpoint when indexer connect is alive, which should automatically page until there's no data
- add historicalTradingRewardsPeriod setting to state manager, which is passed into the REST call. when it's set in the state manager, it should also trigger the REST call
