### PR TITLE
Tech debt, to move V3AccountProcessor out of main code path for clarification

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.1.16"
+version = "1.1.17"
 
 repositories {
     google()

--- a/integration/iOS/Pods/Pods.xcodeproj/project.pbxproj
+++ b/integration/iOS/Pods/Pods.xcodeproj/project.pbxproj
@@ -9,10 +9,9 @@
 /* Begin PBXAggregateTarget section */
 		4084846DAF1774840D25DF1BF2460325 /* abacus */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 127F9C06E33E9DC2AB3876F089264EB1 /* Build configuration list for PBXAggregateTarget "abacus" */;
+			buildConfigurationList = B36D4FC54F44832C64D6BFCFC7EF4665 /* Build configuration list for PBXAggregateTarget "abacus" */;
 			buildPhases = (
-				DB36ACE8A857E9B93C25EA309FF42C2A /* [CP-User] Build abacus */,
-				903ECA29140368245E4B69BE2D0DBCA4 /* [CP] Copy dSYMs */,
+				1403E0AEBF8A2087DF8CACA188B609E8 /* [CP-User] Build abacus */,
 			);
 			dependencies = (
 			);
@@ -143,13 +142,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		174DE097054DE7A0410C57AF4AEF5A1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 469F25E790D19440507BF938A40578A7;
-			remoteInfo = "Pods-abacus.ios";
-		};
 		8437FCB39ECA4A44D93FCDCBF6066E92 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
@@ -164,6 +156,13 @@
 			remoteGlobalIDString = 4084846DAF1774840D25DF1BF2460325;
 			remoteInfo = abacus;
 		};
+		F99C8B5A9E9146040BECE7ABFD8E196E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 469F25E790D19440507BF938A40578A7;
+			remoteInfo = "Pods-abacus.ios";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -177,7 +176,6 @@
 		0A52523A80E0465BAEC42025DAD553B2 /* Pods-abacus.iosTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-abacus.iosTests-Info.plist"; sourceTree = "<group>"; };
 		0D4EF333478AFFA4893B29F877CE2E3B /* Pods-abacus.iosTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-abacus.iosTests.modulemap"; sourceTree = "<group>"; };
 		0ECEA0D8830DCE37C7297C5F1342B08E /* Pods-abacus.ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-abacus.ios.release.xcconfig"; sourceTree = "<group>"; };
-		11333350D08ED43FECC329C61635AA5E /* abacus.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = abacus.debug.xcconfig; sourceTree = "<group>"; };
 		11D1C88CAB0B1EB3C0E2DD9AA5686065 /* ASN1Encoder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ASN1Encoder.swift; path = Sources/CryptoSwift/ASN1/ASN1Encoder.swift; sourceTree = "<group>"; };
 		13185CACC68AF906E8A5D6F729D5D2D6 /* CTR.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CTR.swift; path = Sources/CryptoSwift/BlockMode/CTR.swift; sourceTree = "<group>"; };
 		14349433B0E86BC9031B5B428268C64D /* Pods-abacus.iosTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-abacus.iosTests-acknowledgements.plist"; sourceTree = "<group>"; };
@@ -185,6 +183,7 @@
 		15A46B32EBC892483620A52F24AFC350 /* ECB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ECB.swift; path = Sources/CryptoSwift/BlockMode/ECB.swift; sourceTree = "<group>"; };
 		161A656240E3B4B64ECE6858B65DC977 /* Pods-abacus.ios-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-abacus.ios-dummy.m"; sourceTree = "<group>"; };
 		186DE576AF9B0EC2149708CD77D2BC1F /* Shifts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Shifts.swift; path = Sources/CryptoSwift/CS_BigInt/Shifts.swift; sourceTree = "<group>"; };
+		18AD58FF9452C719E07E75C68F463197 /* abacus.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = abacus.debug.xcconfig; sourceTree = "<group>"; };
 		1B6D2B0A7ACC4ACD9BC9FA5D52199C08 /* Cipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cipher.swift; path = Sources/CryptoSwift/Cipher.swift; sourceTree = "<group>"; };
 		1C5732A96CD4AA2A534F0887522F1C39 /* CryptoSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.debug.xcconfig; sourceTree = "<group>"; };
 		1CF2318F38D1207A2F8BF92B7B8A294E /* Array+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extension.swift"; path = "Sources/CryptoSwift/Array+Extension.swift"; sourceTree = "<group>"; };
@@ -221,6 +220,7 @@
 		5E828917FF2AA3CC6B23ECF8A598B684 /* CryptoSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.release.xcconfig; sourceTree = "<group>"; };
 		61300E9B71B8A176D5EAA3B605958848 /* AES.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.swift; path = Sources/CryptoSwift/AES.swift; sourceTree = "<group>"; };
 		64F91D24D56FF58C2F34255BCC0CA8D2 /* Strideable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strideable.swift; path = Sources/CryptoSwift/CS_BigInt/Strideable.swift; sourceTree = "<group>"; };
+		676E1890C9700A3A84C72C7B944DF207 /* abacus.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = abacus.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		6793D5A483FC322067B570388A6B3706 /* ISO78164Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ISO78164Padding.swift; path = Sources/CryptoSwift/ISO78164Padding.swift; sourceTree = "<group>"; };
 		6904BFCC87FB786B28D1207D0AB43B33 /* Scrypt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Scrypt.swift; path = Sources/CryptoSwift/Scrypt.swift; sourceTree = "<group>"; };
 		6A3143416A23313EEA6BA63B1040BDE9 /* ASN1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ASN1.swift; path = Sources/CryptoSwift/ASN1/ASN1.swift; sourceTree = "<group>"; };
@@ -239,14 +239,13 @@
 		82E21560551522E26DA29FC2711C8B79 /* UInt64+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt64+Extension.swift"; path = "Sources/CryptoSwift/UInt64+Extension.swift"; sourceTree = "<group>"; };
 		8401ED14FF39BBF39217A88493885CA8 /* BlockDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockDecryptor.swift; path = Sources/CryptoSwift/BlockDecryptor.swift; sourceTree = "<group>"; };
 		8829F5E52FB40D40BE9F6752C2C053EE /* Pods-abacus.ios-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-abacus.ios-umbrella.h"; sourceTree = "<group>"; };
+		89410D0A4EEF5C7783289BFFA8C65132 /* abacus.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = abacus.release.xcconfig; sourceTree = "<group>"; };
 		8A57B68075D5163750469D071E976128 /* BlockCipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockCipher.swift; path = Sources/CryptoSwift/BlockCipher.swift; sourceTree = "<group>"; };
 		8D06FF8AD7D871B54C7ACCBAC7006F7A /* Pods-abacus.iosTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-abacus.iosTests-umbrella.h"; sourceTree = "<group>"; };
 		8D306C05CD4B555FB15107F16BC703AB /* Codable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Codable.swift; path = Sources/CryptoSwift/CS_BigInt/Codable.swift; sourceTree = "<group>"; };
 		8F65805D7220C67B723A6979E4421297 /* Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Poly1305.swift; path = Sources/CryptoSwift/Poly1305.swift; sourceTree = "<group>"; };
-		901797921B8846CD2EE02D8CE0E2EE96 /* abacus-copy-dsyms.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "abacus-copy-dsyms.sh"; sourceTree = "<group>"; };
 		9820368D031573F06B550D96A82EA775 /* Digest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Digest.swift; path = Sources/CryptoSwift/Digest.swift; sourceTree = "<group>"; };
 		9A206833CEC035FD64E37E4BDD8F76E4 /* Pods-abacus.ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-abacus.ios.debug.xcconfig"; sourceTree = "<group>"; };
-		9AAC9FD04C0243EE3C839EB2854E9A82 /* Abacus.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Abacus.framework; path = build/cocoapods/framework/Abacus.framework; sourceTree = "<group>"; };
 		9AF04E90D87F0C8F2E7A6D3AD919E91A /* BlockModeOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockModeOptions.swift; path = Sources/CryptoSwift/BlockMode/BlockModeOptions.swift; sourceTree = "<group>"; };
 		9B72F989074262D8602B67073AE02491 /* Bit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Bit.swift; path = Sources/CryptoSwift/Bit.swift; sourceTree = "<group>"; };
 		9C377F319DD000557B6F34A6AA03DD2D /* Pods-abacus.ios-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-abacus.ios-Info.plist"; sourceTree = "<group>"; };
@@ -266,7 +265,6 @@
 		B08BBA0B72E8D4BE9811F9B7F68AA02C /* Blowfish+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Blowfish+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Blowfish+Foundation.swift"; sourceTree = "<group>"; };
 		B26CFCBE4B1911C8EC2A1C029CEB4E75 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extension.swift"; path = "Sources/CryptoSwift/String+Extension.swift"; sourceTree = "<group>"; };
 		B4190E33292A68FD34FE52C6E5F07C60 /* AEAD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEAD.swift; path = Sources/CryptoSwift/AEAD/AEAD.swift; sourceTree = "<group>"; };
-		B6FB1BE416CF26A6725B0EF1AFFA64C3 /* abacus.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = abacus.release.xcconfig; sourceTree = "<group>"; };
 		BA40B51A627278CB13C358186114CC93 /* ZeroPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ZeroPadding.swift; path = Sources/CryptoSwift/ZeroPadding.swift; sourceTree = "<group>"; };
 		BB6B2F3D2320BF20700A070862FD5E51 /* CCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CCM.swift; path = Sources/CryptoSwift/BlockMode/CCM.swift; sourceTree = "<group>"; };
 		BBE77F01DBCA6B4CBDAFEFFF91FD51E2 /* ChaCha20.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChaCha20.swift; path = Sources/CryptoSwift/ChaCha20.swift; sourceTree = "<group>"; };
@@ -297,12 +295,12 @@
 		E595AD44CC42D6071C4AE6FF94574E3E /* Bitwise Ops.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bitwise Ops.swift"; path = "Sources/CryptoSwift/CS_BigInt/Bitwise Ops.swift"; sourceTree = "<group>"; };
 		E64FF95343A43E9FD11A590F1CCB375E /* CryptoSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-prefix.pch"; sourceTree = "<group>"; };
 		E7D1F2F85B2B5D9DBCE3CD1629F37B12 /* Authenticator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authenticator.swift; path = Sources/CryptoSwift/Authenticator.swift; sourceTree = "<group>"; };
+		E84ED7F0DA01628D38C57BFA8C0A2885 /* Abacus.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Abacus.framework; path = build/cocoapods/framework/Abacus.framework; sourceTree = "<group>"; };
 		E86F49595E9BDFBFA2F248DF23D6940E /* Pods-abacus.ios.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-abacus.ios.modulemap"; sourceTree = "<group>"; };
 		E8C491607FDEEACF4F90CE02524CDBF3 /* Prime Test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Prime Test.swift"; path = "Sources/CryptoSwift/CS_BigInt/Prime Test.swift"; sourceTree = "<group>"; };
 		EBE2877F7E8A200D74C4E18847B81123 /* CompactMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompactMap.swift; path = Sources/CryptoSwift/CompactMap.swift; sourceTree = "<group>"; };
 		ED147C179BB27BE9D0AA43E406100179 /* HKDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HKDF.swift; path = Sources/CryptoSwift/HKDF.swift; sourceTree = "<group>"; };
 		EE3BBB66D7173C016DB618A76707AAD3 /* UInt16+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt16+Extension.swift"; path = "Sources/CryptoSwift/UInt16+Extension.swift"; sourceTree = "<group>"; };
-		EE700277FA858221DBCF3A8A4C8C1CE2 /* abacus.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = abacus.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		EF5AB0E7CC9AF239517DD7DF9245C8FF /* Array+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Array+Foundation.swift"; sourceTree = "<group>"; };
 		EFF7D0D9D63091066805D424BE501AF6 /* CBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBC.swift; path = Sources/CryptoSwift/BlockMode/CBC.swift; sourceTree = "<group>"; };
 		F147AFFBAF5C8233E7152D1F827C039C /* CryptoSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CryptoSwift-dummy.m"; sourceTree = "<group>"; };
@@ -341,14 +339,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		352EDBF1D06D986260C56AD5B07C7A44 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				9AAC9FD04C0243EE3C839EB2854E9A82 /* Abacus.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		578452D2E740E91742655AC8F1636D1F /* iOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -360,21 +350,18 @@
 		5ABB1F8B85A50B132154AD0F354134DA /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				681EB62DD4E64F0154D97F4850267691 /* abacus */,
+				BB0D37B984AC21D51D35F563098A09F4 /* abacus */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		681EB62DD4E64F0154D97F4850267691 /* abacus */ = {
+		76A3B71FC16F03C932D838CB3EBF74A1 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				352EDBF1D06D986260C56AD5B07C7A44 /* Frameworks */,
-				911FF5733822DC8474EB633FC612DDBA /* Pod */,
-				C915E57918FD784F503279C7C4963233 /* Support Files */,
+				676E1890C9700A3A84C72C7B944DF207 /* abacus.podspec */,
 			);
-			name = abacus;
-			path = "/Users/johnhuang/v4-abacus";
-			sourceTree = "<absolute>";
+			name = Pod;
+			sourceTree = "<group>";
 		};
 		77BFA6027665EBACC42B94A7C2372871 /* Pods-abacus.iosTests */ = {
 			isa = PBXGroup;
@@ -400,14 +387,6 @@
 				E216D81D3656F56D4335CA097BDACFA9 /* Pods-abacus.iosTests */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		911FF5733822DC8474EB633FC612DDBA /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				EE700277FA858221DBCF3A8A4C8C1CE2 /* abacus.podspec */,
-			);
-			name = Pod;
 			sourceTree = "<group>";
 		};
 		915C28C583640C124E56AE6BB9F0DAB2 /* CryptoSwift */ = {
@@ -555,16 +534,16 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		C915E57918FD784F503279C7C4963233 /* Support Files */ = {
+		BB0D37B984AC21D51D35F563098A09F4 /* abacus */ = {
 			isa = PBXGroup;
 			children = (
-				901797921B8846CD2EE02D8CE0E2EE96 /* abacus-copy-dsyms.sh */,
-				11333350D08ED43FECC329C61635AA5E /* abacus.debug.xcconfig */,
-				B6FB1BE416CF26A6725B0EF1AFFA64C3 /* abacus.release.xcconfig */,
+				F223BCFEB610D86D0439F551571306C9 /* Frameworks */,
+				76A3B71FC16F03C932D838CB3EBF74A1 /* Pod */,
+				F5ABF3A663095C6FAD156352681853E7 /* Support Files */,
 			);
-			name = "Support Files";
-			path = "integration/iOS/Pods/Target Support Files/abacus";
-			sourceTree = "<group>";
+			name = abacus;
+			path = "/Users/johnhuang/v4-abacus";
+			sourceTree = "<absolute>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
 			isa = PBXGroup;
@@ -607,6 +586,24 @@
 			);
 			name = "Support Files";
 			path = "../Target Support Files/CryptoSwift";
+			sourceTree = "<group>";
+		};
+		F223BCFEB610D86D0439F551571306C9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E84ED7F0DA01628D38C57BFA8C0A2885 /* Abacus.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F5ABF3A663095C6FAD156352681853E7 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				18AD58FF9452C719E07E75C68F463197 /* abacus.debug.xcconfig */,
+				89410D0A4EEF5C7783289BFFA8C65132 /* abacus.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "integration/iOS/Pods/Target Support Files/abacus";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -671,7 +668,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				1F67D19EAC36A41088EB458D7432B293 /* PBXTargetDependency */,
+				AC2EBD83354400DAA47E7F9069901F4A /* PBXTargetDependency */,
 			);
 			name = "Pods-abacus.iosTests";
 			productName = Pods_abacus_iosTests;
@@ -751,24 +748,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		903ECA29140368245E4B69BE2D0DBCA4 /* [CP] Copy dSYMs */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/abacus/abacus-copy-dsyms-input-files.xcfilelist",
-			);
-			name = "[CP] Copy dSYMs";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/abacus/abacus-copy-dsyms-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/abacus/abacus-copy-dsyms.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		DB36ACE8A857E9B93C25EA309FF42C2A /* [CP-User] Build abacus */ = {
+		1403E0AEBF8A2087DF8CACA188B609E8 /* [CP-User] Build abacus */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -918,11 +898,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		1F67D19EAC36A41088EB458D7432B293 /* PBXTargetDependency */ = {
+		AC2EBD83354400DAA47E7F9069901F4A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-abacus.ios";
 			target = 469F25E790D19440507BF938A40578A7 /* Pods-abacus.ios */;
-			targetProxy = 174DE097054DE7A0410C57AF4AEF5A1A /* PBXContainerItemProxy */;
+			targetProxy = F99C8B5A9E9146040BECE7ABFD8E196E /* PBXContainerItemProxy */;
 		};
 		CF848ADCA9D462971E67CA041BBB55DD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -975,6 +955,23 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
+		};
+		22B0388248EDA44270493DDECC58CF78 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 89410D0A4EEF5C7783289BFFA8C65132 /* abacus.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
 		};
 		4C06C857647A16E5CF368D22DFA55BAF /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -1046,6 +1043,22 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5B331F72A7F4402311EBC4A06282E60D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 18AD58FF9452C719E07E75C68F463197 /* abacus.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -1215,39 +1228,6 @@
 			};
 			name = Debug;
 		};
-		96B05028328C5704FCE6A41A515364C0 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 11333350D08ED43FECC329C61635AA5E /* abacus.debug.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		B0264023D64B16BF2F6C8B4C076E862A /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B6FB1BE416CF26A6725B0EF1AFFA64C3 /* abacus.release.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
 		F3A0E769E09875E7B65318E499E93FAC /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5E828917FF2AA3CC6B23ECF8A598B684 /* CryptoSwift.release.xcconfig */;
@@ -1324,15 +1304,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		127F9C06E33E9DC2AB3876F089264EB1 /* Build configuration list for PBXAggregateTarget "abacus" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				96B05028328C5704FCE6A41A515364C0 /* Debug */,
-				B0264023D64B16BF2F6C8B4C076E862A /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		2ECD87CECC0DF0128DB6EE0BDC2D9E8A /* Build configuration list for PBXNativeTarget "CryptoSwift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1347,6 +1318,15 @@
 			buildConfigurations = (
 				934ED2B84836A780113D1F63484628B2 /* Debug */,
 				92486E5E72E54FAF60E1A7D022C21B10 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B36D4FC54F44832C64D6BFCFC7EF4665 /* Build configuration list for PBXAggregateTarget "abacus" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5B331F72A7F4402311EBC4A06282E60D /* Debug */,
+				22B0388248EDA44270493DDECC58CF78 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/WalletProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/WalletProcessor.kt
@@ -1,8 +1,8 @@
 package exchange.dydx.abacus.processor.wallet
 
 import exchange.dydx.abacus.processor.base.BaseProcessor
-import exchange.dydx.abacus.processor.wallet.account.V3AccountProcessor
 import exchange.dydx.abacus.processor.wallet.account.V4AccountProcessor
+import exchange.dydx.abacus.processor.wallet.account.deprecated.V3AccountProcessor
 import exchange.dydx.abacus.processor.wallet.user.UserProcessor
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.responses.SocketInfo
@@ -171,7 +171,7 @@ internal class WalletProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
         subaccountNumber: Int,
     ): Map<String, Any>? {
         return receivedObject(existing, "account", payload) { existing, payload ->
-            v3accountProcessor.receivedHistoricalPnls(
+            v4accountProcessor.receivedHistoricalPnls(
                 parser.asNativeMap(existing),
                 parser.asNativeMap(payload),
                 subaccountNumber
@@ -185,7 +185,7 @@ internal class WalletProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
         subaccountNumber: Int,
     ): Map<String, Any>? {
         return receivedObject(existing, "account", payload) { existing, payload ->
-            v3accountProcessor.receivedFills(
+            v4accountProcessor.receivedFills(
                 parser.asNativeMap(existing),
                 parser.asNativeMap(payload),
                 subaccountNumber
@@ -199,7 +199,7 @@ internal class WalletProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
         subaccountNumber: Int,
     ): Map<String, Any>? {
         return receivedObject(existing, "account", payload) { existing, payload ->
-            v3accountProcessor.receivedTransfers(
+            v4accountProcessor.receivedTransfers(
                 parser.asNativeMap(existing),
                 parser.asNativeMap(payload),
                 subaccountNumber

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/AccountProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/AccountProcessor.kt
@@ -178,79 +178,6 @@ import exchange.dydx.abacus.utils.safeSet
       },
  */
 
-/*
-V3AccountProcess is used to process generic account data, which is used by both V3 and V4
- */
-@Suppress("UNCHECKED_CAST")
-internal class V3AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
-    private val subaccountProcessor = V3SubaccountProcessor(parser)
-
-    internal fun subscribed(
-        existing: Map<String, Any>?,
-        content: Map<String, Any>,
-        height: BlockAndTime?,
-    ): Map<String, Any>? {
-        val modified = existing?.mutable() ?: mutableMapOf()
-        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.0"))
-        val modifiedsubaccount = subaccountProcessor.subscribed(subaccount, content, height)
-        modified.safeSet("subaccounts.0", modifiedsubaccount)
-        return modified
-    }
-
-    internal fun channel_data(
-        existing: Map<String, Any>?,
-        content: Map<String, Any>,
-        height: BlockAndTime?,
-    ): Map<String, Any>? {
-        val modified = existing?.mutable() ?: mutableMapOf()
-        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.0"))
-        val modifiedsubaccount = subaccountProcessor.channel_data(subaccount, content, height)
-        modified.safeSet("subaccounts.0", modifiedsubaccount)
-        return modified
-    }
-
-    internal fun receivedHistoricalPnls(
-        existing: Map<String, Any>?,
-        payload: Map<String, Any>?,
-        subaccountNumber: Int,
-    ): Map<String, Any>? {
-        val modified = existing?.mutable() ?: mutableMapOf()
-        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.0"))
-        val modifiedsubaccount = subaccountProcessor.receivedHistoricalPnls(subaccount, payload)
-        modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
-        return modified
-    }
-
-    internal fun receivedFills(
-        existing: Map<String, Any>?,
-        payload: Map<String, Any>?,
-        subaccountNumber: Int,
-    ): Map<String, Any>? {
-        val modified = existing?.mutable() ?: mutableMapOf()
-        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.$subaccountNumber"))
-        val modifiedsubaccount = subaccountProcessor.receivedFills(subaccount, payload)
-        modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
-        return modified
-    }
-
-    internal fun receivedTransfers(
-        existing: Map<String, Any>?,
-        payload: Map<String, Any>?,
-        subaccountNumber: Int,
-    ): Map<String, Any>? {
-        val modified = existing?.mutable() ?: mutableMapOf()
-        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.$subaccountNumber"))
-        val modifiedsubaccount = subaccountProcessor.receivedTransfers(subaccount, payload)
-        modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
-        return modified
-    }
-
-    override fun accountAddressChanged() {
-        super.accountAddressChanged()
-        subaccountProcessor.accountAddress = accountAddress
-    }
-}
-
 @Suppress("UNCHECKED_CAST")
 internal open class SubaccountProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
     internal val assetPositionsProcessor = AssetPositionsProcessor(parser)
@@ -692,9 +619,6 @@ internal open class SubaccountProcessor(parser: ParserProtocol) : BaseProcessor(
     }
 }
 
-internal class V3SubaccountProcessor(parser: ParserProtocol) : SubaccountProcessor(parser) {
-}
-
 internal class V4SubaccountProcessor(parser: ParserProtocol) : SubaccountProcessor(parser) {
     override fun received(
         existing: Map<String, Any>,
@@ -891,7 +815,8 @@ private class V4AccountDelegationsProcessor(parser: ParserProtocol) : BaseProces
 }
 
 private class V4AccountTradingRewardsProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
-    private val historicalTradingRewardsProcessor = HistoricalTradingRewardsProcessor(parser = parser)
+    private val historicalTradingRewardsProcessor =
+        HistoricalTradingRewardsProcessor(parser = parser)
 
     fun receivedTotalTradingRewards(
         existing: Map<String, Any>?,
@@ -905,11 +830,14 @@ private class V4AccountTradingRewardsProcessor(parser: ParserProtocol) : BasePro
         return modified
     }
 
-    fun recievedHistoricalTradingRewards( 
+    fun recievedHistoricalTradingRewards(
         existing: List<Any>?,
         payload: List<Any>?,
     ): List<Any>? {
-        return if (payload != null) historicalTradingRewardsProcessor.received(existing, payload) else null
+        return if (payload != null) historicalTradingRewardsProcessor.received(
+            existing,
+            payload
+        ) else null
     }
 }
 
@@ -942,14 +870,55 @@ internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser
         return modified
     }
 
+    internal fun receivedHistoricalPnls(
+        existing: Map<String, Any>?,
+        payload: Map<String, Any>?,
+        subaccountNumber: Int,
+    ): Map<String, Any>? {
+        val modified = existing?.mutable() ?: mutableMapOf()
+        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.$subaccountNumber"))
+        val modifiedsubaccount = subaccountsProcessor.receivedHistoricalPnls(subaccount, payload)
+        modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
+        return modified
+    }
+
+    internal fun receivedFills(
+        existing: Map<String, Any>?,
+        payload: Map<String, Any>?,
+        subaccountNumber: Int,
+    ): Map<String, Any>? {
+        val modified = existing?.mutable() ?: mutableMapOf()
+        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.$subaccountNumber"))
+        val modifiedsubaccount = subaccountsProcessor.receivedFills(subaccount, payload)
+        modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
+        return modified
+    }
+
+    internal fun receivedTransfers(
+        existing: Map<String, Any>?,
+        payload: Map<String, Any>?,
+        subaccountNumber: Int,
+    ): Map<String, Any>? {
+        val modified = existing?.mutable() ?: mutableMapOf()
+        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.$subaccountNumber"))
+        val modifiedsubaccount = subaccountsProcessor.receivedTransfers(subaccount, payload)
+        modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
+        return modified
+    }
+
     internal fun receivedHistoricalTradingRewards(
         existing: Map<String, Any>?,
         payload: List<Any>?,
         period: String?,
     ): Map<String, Any>? {
         val modified = existing?.mutable() ?: mutableMapOf()
-        val historicalTradingRewards = parser.asNativeList(parser.value(existing, "tradingRewards.historical.$period"))
-        val modifiedHistoricalTradingRewards = tradingRewardsProcessor.recievedHistoricalTradingRewards(historicalTradingRewards, payload)
+        val historicalTradingRewards =
+            parser.asNativeList(parser.value(existing, "tradingRewards.historical.$period"))
+        val modifiedHistoricalTradingRewards =
+            tradingRewardsProcessor.recievedHistoricalTradingRewards(
+                historicalTradingRewards,
+                payload
+            )
         modified.safeSet("tradingRewards.historical.$period", modifiedHistoricalTradingRewards)
         return modified
     }
@@ -960,11 +929,17 @@ internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser
     ): Map<String, Any>? {
         val modified = existing?.mutable() ?: mutableMapOf()
         val subaccounts = parser.asNativeMap(parser.value(existing, "subaccounts"))
-        val modifiedSubaccounts = subaccountsProcessor.receivedSubaccounts(subaccounts, parser.asList(payload?.get("subaccounts")))
+        val modifiedSubaccounts = subaccountsProcessor.receivedSubaccounts(
+            subaccounts,
+            parser.asList(payload?.get("subaccounts"))
+        )
         modified.safeSet("subaccounts", modifiedSubaccounts)
 
         val tradingRewards = parser.asNativeMap(parser.value(existing, "tradingRewards"))
-        val modifiedTradingRewards = tradingRewardsProcessor.receivedTotalTradingRewards(tradingRewards, payload?.get("totalTradingRewards"))
+        val modifiedTradingRewards = tradingRewardsProcessor.receivedTotalTradingRewards(
+            tradingRewards,
+            payload?.get("totalTradingRewards")
+        )
         modified.safeSet("tradingRewards", modifiedTradingRewards)
         return modified
     }
@@ -1010,7 +985,10 @@ internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser
     ): Triple<Map<String, Any>, Boolean, List<Int>?> {
         val subaccounts = parser.asNativeMap(parser.value(existing, "subaccounts"))
         if (subaccounts != null) {
-            val (modifiedSubaccounts, updated, subaccountIds) = subaccountsProcessor.updateSubaccountsHeight(subaccounts, height)
+            val (modifiedSubaccounts, updated, subaccountIds) = subaccountsProcessor.updateSubaccountsHeight(
+                subaccounts,
+                height
+            )
             if (updated) {
                 val modified = existing.mutable()
                 modified.safeSet("subaccounts", modifiedSubaccounts)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/deprecated/V3AccountProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/deprecated/V3AccountProcessor.kt
@@ -1,0 +1,84 @@
+package exchange.dydx.abacus.processor.wallet.account.deprecated
+
+import exchange.dydx.abacus.processor.base.BaseProcessor
+import exchange.dydx.abacus.processor.wallet.account.SubaccountProcessor
+import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.state.manager.BlockAndTime
+import exchange.dydx.abacus.utils.mutable
+import exchange.dydx.abacus.utils.safeSet
+
+/*
+V3AccountProcess is used to process generic account data, which is used by both V3 and V4
+ */
+@Suppress("UNCHECKED_CAST")
+internal class V3AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
+    private val subaccountProcessor = V3SubaccountProcessor(parser)
+
+    internal fun subscribed(
+        existing: Map<String, Any>?,
+        content: Map<String, Any>,
+        height: BlockAndTime?,
+    ): Map<String, Any>? {
+        val modified = existing?.mutable() ?: mutableMapOf()
+        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.0"))
+        val modifiedsubaccount = subaccountProcessor.subscribed(subaccount, content, height)
+        modified.safeSet("subaccounts.0", modifiedsubaccount)
+        return modified
+    }
+
+    internal fun channel_data(
+        existing: Map<String, Any>?,
+        content: Map<String, Any>,
+        height: BlockAndTime?,
+    ): Map<String, Any>? {
+        val modified = existing?.mutable() ?: mutableMapOf()
+        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.0"))
+        val modifiedsubaccount = subaccountProcessor.channel_data(subaccount, content, height)
+        modified.safeSet("subaccounts.0", modifiedsubaccount)
+        return modified
+    }
+
+    internal fun receivedHistoricalPnls(
+        existing: Map<String, Any>?,
+        payload: Map<String, Any>?,
+        subaccountNumber: Int,
+    ): Map<String, Any>? {
+        val modified = existing?.mutable() ?: mutableMapOf()
+        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.0"))
+        val modifiedsubaccount = subaccountProcessor.receivedHistoricalPnls(subaccount, payload)
+        modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
+        return modified
+    }
+
+    internal fun receivedFills(
+        existing: Map<String, Any>?,
+        payload: Map<String, Any>?,
+        subaccountNumber: Int,
+    ): Map<String, Any>? {
+        val modified = existing?.mutable() ?: mutableMapOf()
+        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.$subaccountNumber"))
+        val modifiedsubaccount = subaccountProcessor.receivedFills(subaccount, payload)
+        modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
+        return modified
+    }
+
+    internal fun receivedTransfers(
+        existing: Map<String, Any>?,
+        payload: Map<String, Any>?,
+        subaccountNumber: Int,
+    ): Map<String, Any>? {
+        val modified = existing?.mutable() ?: mutableMapOf()
+        val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.$subaccountNumber"))
+        val modifiedsubaccount = subaccountProcessor.receivedTransfers(subaccount, payload)
+        modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
+        return modified
+    }
+
+    override fun accountAddressChanged() {
+        super.accountAddressChanged()
+        subaccountProcessor.accountAddress = accountAddress
+    }
+}
+
+internal class V3SubaccountProcessor(parser: ParserProtocol) : SubaccountProcessor(parser) {
+}

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.1.16'
+    spec.version                  = '1.1.17'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
This change makes it clear that in the future, we should only modify V4AccountProcess and V4SubaccountProcessor

Unfortunately, a lot of unit tests are still using V3 mock. Need to keep those to make sure the calculations are correct. So we cannot remove V3AccountProcessor completely until we move all the calculations tests.