### PR TITLE
fix setting default language

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/app/helper/DynamicLocalizer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/app/helper/DynamicLocalizer.kt
@@ -258,6 +258,9 @@ class DynamicLocalizer(
                 // Not a valid language
                 callback(false, null)
             }
+        } else {
+            // Not a valid language
+            callback(false, null)
         }
     }
 


### PR DESCRIPTION
if the language was not found in the languages map, the failure callback was never called resulting in no language being set