### PR TITLE
fix order canceling after order canceled

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.4.13"
+version = "1.4.14"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/OrderProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/OrderProcessor.kt
@@ -296,7 +296,10 @@ internal class OrderProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
         existing: Map<String, Any>,
     ): Map<String, Any> {
         val modified = existing.mutable()
-        modified["status"] = "BEST_EFFORT_CANCELED"
+        if (modified["status"] !== "CANCELED") {
+            modified["status"] = "BEST_EFFORT_CANCELED"
+        }
+
         modified["cancelReason"] = "USER_CANCELED"
         updateResource(modified)
         return modified

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.4.13'
+    spec.version                  = '1.4.14'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
motivation: we're updating web logic to send long term cancels one at a time using a queue, and with the update that long term cancels are default to use BroadcastTxCommit mode, it's possible that `orderCanceled` is called too late and updates a canceled order back to canceling ("BEST_EFFORT_CANCELED")

this change updates `OrderProcessor.canceled` to only update status to "BEST_EFFORT_CANCELED" when order status is not "CANCELED"

tested on local web