### PR TITLE
Add requestId to TransferInput.route.requestPayload

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
@@ -211,14 +211,14 @@ data class TransferOutInputOptions(
                     "chain",
                     chainName,
                     null,
-                    environment?.chainLogo
+                    environment.chainLogo
                 )
             } else {
                 return null
             }
             val chains: IList<SelectionOption> = iListOf(chainOption)
 
-            val assets: IList<SelectionOption> = environment?.tokens?.keys?.map { key ->
+            val assets: IList<SelectionOption> = environment.tokens.keys.map { key ->
                 val token = environment.tokens[key]!!
                 SelectionOption(
                     key,
@@ -226,12 +226,12 @@ data class TransferOutInputOptions(
                     null,
                     token.imageUrl
                 )
-            }?.toIList() ?: iListOf()
+            }.toIList()
 
             return if (existing?.needsSize != needsSize ||
-                existing?.needsAddress != needsAddress ||
-                existing?.chains != chains ||
-                existing?.assets != assets
+                existing.needsAddress != needsAddress ||
+                existing.chains != chains ||
+                existing.assets != assets
             ) {
                 TransferOutInputOptions(
                     needsSize,
@@ -408,7 +408,8 @@ data class TransferInputRequestPayload(
     val toChainId: String?,
     val fromAddress: String?,
     val toAddress: String?,
-    val isV2Route: Boolean?
+    val isV2Route: Boolean?,
+    val requestId: String?,
 ) {
     companion object {
         internal fun create(
@@ -432,7 +433,8 @@ data class TransferInputRequestPayload(
                 val fromAddress = parser.asString(data["fromAddress"])
                 val toAddress = parser.asString(data["toAddress"])
                 val isV2Route = parser.asBool(data["isV2Route"])
-
+                val requestId = parser.asString(data["requestId"])
+                
                 return if (
                     existing?.routeType != routeType ||
                     existing?.targetAddress != targetAddress ||
@@ -446,7 +448,8 @@ data class TransferInputRequestPayload(
                     existing?.toChainId != toChainId ||
                     existing?.fromAddress != fromAddress ||
                     existing?.toAddress != toAddress ||
-                    existing?.isV2Route != isV2Route
+                    existing?.isV2Route != isV2Route ||
+                    existing?.requestId != requestId
                 ) {
                     TransferInputRequestPayload(
                         routeType,
@@ -461,7 +464,8 @@ data class TransferInputRequestPayload(
                         toChainId,
                         fromAddress,
                         toAddress,
-                        isV2Route
+                        isV2Route,
+                        requestId,
                     )
                 } else {
                     existing

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/squid/SquidRouteV2Processor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/squid/SquidRouteV2Processor.kt
@@ -26,7 +26,7 @@ internal class SquidRouteV2Processor(parser: ParserProtocol) : BaseProcessor(par
 
     override fun received(
         existing: Map<String, Any>?,
-        payload: Map<String, Any>
+        payload: Map<String, Any>,
     ): Map<String, Any> {
         val modified = transform(existing, payload, keyMap)
         val payloadProcessor = SquidRouteV2PayloadProcessor(parser)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
@@ -75,10 +75,11 @@ interface SynchronizedFileSystemProtocol {
 
 @JsExport
 interface RestProtocol {
+
     fun get(
         url: String,
         headers: IMap<String, String>?,
-        callback: ((response: String?, httpCode: Int) -> Unit),
+        callback: RestCallback,
     )
 
 
@@ -86,22 +87,24 @@ interface RestProtocol {
         url: String,
         headers: IMap<String, String>?,
         body: String?,
-        callback: ((response: String?, httpCode: Int) -> Unit),
+        callback: RestCallback,
     )
 
     fun put(
         url: String,
         headers: IMap<String, String>?,
         body: String?,
-        callback: ((response: String?, httpCode: Int) -> Unit),
+        callback: RestCallback,
     )
 
     fun delete(
         url: String,
         headers: IMap<String, String>?,
-        callback: ((response: String?, httpCode: Int) -> Unit),
+        callback: RestCallback,
     )
 }
+
+typealias RestCallback = (response: String?, httpCode: Int, headers: Map<String, String>?) -> Unit
 
 @JsExport
 interface WebSocketProtocol {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/app/helper/DynamicLocalizer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/app/helper/DynamicLocalizer.kt
@@ -91,7 +91,7 @@ class DynamicLocalizer(
         if (!loadLocalOnly) {
             // Try to update from online
             val url = "$endpoint$languagePath"
-            ioImplementations.rest?.get(url, null) { response, code ->
+            ioImplementations.rest?.get(url, null) { response, code, _ ->
                 if (code in 200..299 && response != null) {
                     val list = parser.decodeJsonArray(response)
                     if (list != null && list.size != 0) {
@@ -185,7 +185,7 @@ class DynamicLocalizer(
         var resultCount = 0
         for (file in files) {
             val url = "$endpoint/$file"
-            ioImplementations.rest?.get(url, null) { response, code ->
+            ioImplementations.rest?.get(url, null) { response, code, _ ->
                 ioImplementations.threading?.async(ThreadingType.main) {
                     if (code in 200..299 && response != null) {
                         val data = parser.decodeJsonObject(response)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManager.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManager.kt
@@ -439,7 +439,7 @@ class AsyncAbacusStateManager(
         if (appConfigs.loadRemote) {
             loadFromRemoteConfigFile(configFile)
             val configFileUrl = "$deploymentUri$path"
-            ioImplementations.rest?.get(configFileUrl, null, callback = { response, httpCode ->
+            ioImplementations.rest?.get(configFileUrl, null, callback = { response, httpCode, _ ->
                 if (success(httpCode) && response != null) {
                     if (parse(response, configFile)) {
                         writeToLocalFile(response, path)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
@@ -673,7 +673,7 @@ class V4StateManagerAdaptor(
         if (url != null) {
             indexerState.previousRequestTime = indexerState.requestTime
             indexerState.requestTime = Clock.System.now()
-            get(url, null, null) { _, response, httpCode ->
+            get(url, null, null) { _, response, httpCode, _ ->
                 if (success(httpCode) && response != null) {
                     val json = parser.decodeJsonObject(response)
                     if (json != null) {
@@ -707,7 +707,7 @@ class V4StateManagerAdaptor(
         val squidIntegratorId = environment.squidIntegratorId
         if (url != null && squidIntegratorId != null) {
             val header = iMapOf("x-integrator-id" to squidIntegratorId)
-            get(url, null, header) { _, response, httpCode ->
+            get(url, null, header) { _, response, httpCode, _ ->
                 if (success(httpCode) && response != null) {
                     update(stateMachine.squidChains(response), oldState)
                 }
@@ -721,7 +721,7 @@ class V4StateManagerAdaptor(
         val squidIntegratorId = environment.squidIntegratorId
         if (url != null && squidIntegratorId != null) {
             val header = iMapOf("x-integrator-id" to squidIntegratorId)
-            get(url, null, header) { _, response, httpCode ->
+            get(url, null, header) { _, response, httpCode, _ ->
                 if (success(httpCode) && response != null) {
                     update(stateMachine.squidV2SdkInfo(response), oldState)
                 }
@@ -735,7 +735,7 @@ class V4StateManagerAdaptor(
         val squidIntegratorId = environment.squidIntegratorId
         if (url != null && squidIntegratorId != null) {
             val header = iMapOf("x-integrator-id" to squidIntegratorId)
-            get(url, null, header) { _, response, httpCode ->
+            get(url, null, header) { _, response, httpCode, _ ->
                 if (success(httpCode) && response != null) {
                     update(stateMachine.squidTokens(response), oldState)
                 }
@@ -1313,9 +1313,9 @@ class V4StateManagerAdaptor(
     override fun getWithFullUrl(
         fullUrl: String,
         headers: Map<String, String>?,
-        callback: (url: String, response: String?, code: Int) -> Unit
+        callback: (url: String, response: String?, code: Int, headers: Map<String, String>?)  -> Unit
     ) {
-        super.getWithFullUrl(fullUrl, headers) { url, response, httpCode ->
+        super.getWithFullUrl(fullUrl, headers) { url, response, httpCode, headers ->
             when (httpCode) {
                 403 -> {
                     indexerRestriction = restrictionReason(response)
@@ -1333,7 +1333,7 @@ class V4StateManagerAdaptor(
                     restRetryTimers[url] = localTimer
                 }
 
-                else -> callback(url, response, httpCode)
+                else -> callback(url, response, httpCode, headers)
             }
 
         }
@@ -1402,7 +1402,7 @@ class V4StateManagerAdaptor(
             post(url, iMapOf(
                 "content-type" to "application/json",
                 "protocol" to "dydx-v4",
-            ), requestBody) { _, response, httpCode ->
+            ), requestBody) { _, response, httpCode, _ ->
                 if (success(httpCode) && response != null) {
                     val oldState = stateMachine.state
                     update(stateMachine.launchIncentiveSeasons(response), oldState)
@@ -1420,7 +1420,7 @@ class V4StateManagerAdaptor(
         if (url != null && address != null) {
             get("${url}/${address}", iMapOf(
                 "n" to season,
-            ), null) { _, response, httpCode ->
+            ), null) { _, response, httpCode, _ ->
                 if (success(httpCode) && response != null) {
                     val oldState = stateMachine.state
                     update(stateMachine.launchIncentivePoints(season, response), oldState)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Squid.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Squid.kt
@@ -32,10 +32,14 @@ internal fun TradingStateMachine.squidV2SdkInfo(payload: String): StateChanges? 
     } else StateChanges.noChange
 }
 
-internal fun TradingStateMachine.squidRoute(payload: String, subaccountNumber: Int): StateChanges? {
+internal fun TradingStateMachine.squidRoute(
+    payload: String,
+    subaccountNumber: Int,
+    requestId: String?,
+): StateChanges? {
     val json = parser.decodeJsonObject(payload)
     return if (json != null) {
-        input = squidProcessor.receivedRoute(input, json)
+        input = squidProcessor.receivedRoute(input, json, requestId)
         StateChanges(
             iListOf(Changes.input, Changes.subaccount),
             subaccountNumbers = iListOf(subaccountNumber)
@@ -45,11 +49,12 @@ internal fun TradingStateMachine.squidRoute(payload: String, subaccountNumber: I
 
 internal fun TradingStateMachine.squidRouteV2(
     payload: String,
-    subaccountNumber: Int
+    subaccountNumber: Int,
+    requestId: String?
 ): StateChanges? {
     val json = parser.decodeJsonObject(payload)
     return if (json != null) {
-        input = squidProcessor.receivedRouteV2(input, json)
+        input = squidProcessor.receivedRouteV2(input, json, requestId)
         StateChanges(
             iListOf(Changes.input, Changes.subaccount),
             subaccountNumbers = iListOf(subaccountNumber)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/TestFactory.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/TestFactory.kt
@@ -8,6 +8,7 @@ import exchange.dydx.abacus.protocols.FileLocation
 import exchange.dydx.abacus.protocols.FileSystemProtocol
 import exchange.dydx.abacus.protocols.LocalTimerProtocol
 import exchange.dydx.abacus.protocols.QueryType
+import exchange.dydx.abacus.protocols.RestCallback
 import exchange.dydx.abacus.protocols.RestProtocol
 import exchange.dydx.abacus.protocols.StateNotificationProtocol
 import exchange.dydx.abacus.protocols.ThreadingProtocol
@@ -202,10 +203,10 @@ class TestRest() : RestProtocol {
     override fun get(
         url: String,
         headers: IMap<String, String>?,
-        callback: (response: String?, httpCode: Int) -> Unit,
+        callback: RestCallback,
     ) {
         if (url.contains("env.json")) {
-            callback(mock.environments.environments, 200)
+            callback(mock.environments.environments, 200, null)
             return
         }
         if (!url.contains("localization")) {
@@ -216,12 +217,12 @@ class TestRest() : RestProtocol {
             responses.remove(url)
             val code = parser.asInt(response)
             if (code != null) {
-                callback(null, code)
+                callback(null, code, null)
             } else {
-                callback(response, 200)
+                callback(response, 200, null)
             }
         } else {
-            callback(null, 404)
+            callback(null, 404, null)
         }
     }
 
@@ -229,7 +230,7 @@ class TestRest() : RestProtocol {
         url: String,
         headers: IMap<String, String>?,
         body: String?,
-        callback: (response: String?, httpCode: Int) -> Unit,
+        callback: RestCallback,
     ) {
         requests.add(url)
 
@@ -238,12 +239,12 @@ class TestRest() : RestProtocol {
             responses.remove(url)
             val code = parser.asInt(response)
             if (code != null) {
-                callback(null, code)
+                callback(null, code, null)
             } else {
-                callback(response, 200)
+                callback(response, 200, null)
             }
         } else {
-            callback(null, 404)
+            callback(null, 404, null)
         }
     }
 
@@ -251,7 +252,7 @@ class TestRest() : RestProtocol {
         url: String,
         headers: IMap<String, String>?,
         body: String?,
-        callback: (response: String?, httpCode: Int) -> Unit,
+        callback: RestCallback,
     ) {
         requests.add(url)
     }
@@ -259,7 +260,7 @@ class TestRest() : RestProtocol {
     override fun delete(
         url: String,
         headers: IMap<String, String>?,
-        callback: (response: String?, httpCode: Int) -> Unit,
+        callback: RestCallback,
     ) {
         requests.add(url)
     }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4SquidTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4SquidTests.kt
@@ -82,7 +82,7 @@ class V4SquidTests : V4BaseTests() {
         var stateChange = perp.squidV2SdkInfo(mock.squidV2AssetsMock.payload)
         assertNotNull(stateChange)
 
-        stateChange = perp.squidRouteV2(mock.squidV2RouteMock.payload, 0)
+        stateChange = perp.squidRouteV2(mock.squidV2RouteMock.payload, 0, null)
         assertNotNull(stateChange)
 
         test({
@@ -119,7 +119,7 @@ class V4SquidTests : V4BaseTests() {
         stateChange = perp.squidTokens(mock.squidTokensMock.payload)
         assertNotNull(stateChange)
 
-        stateChange = perp.squidRoute(mock.squidRouteMock.payload, 0)
+        stateChange = perp.squidRoute(mock.squidRouteMock.payload, 0, null)
         assertNotNull(stateChange)
 
         test({
@@ -155,7 +155,7 @@ class V4SquidTests : V4BaseTests() {
         stateChange = perp.squidTokens(mock.squidTokensMock.payload)
         assertNotNull(stateChange)
 
-        stateChange = perp.squidRoute(mock.squidRouteMock.errors_payload, 0)
+        stateChange = perp.squidRoute(mock.squidRouteMock.errors_payload, 0, null)
         assertNotNull(stateChange)
 
         test({


### PR DESCRIPTION
Squid wants the x-request-id from the response headers to be sent when querying the route status.  So, we are updating the REST protocol to return the response headers.

@johnqh  This is also a breaking change, so let's sync on the landing strategy. 