### PR TITLE
MOB-288 : investigate trading rewards not showing

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/LaunchIncentivePointProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/LaunchIncentivePointProcessor.kt
@@ -5,7 +5,7 @@ import exchange.dydx.abacus.protocols.ParserProtocol
 
 internal class LaunchIncentivePointProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
     private val pointsKeyMap = mapOf(
-        "int" to mapOf(
+        "double" to mapOf(
             "incentivePoints" to "incentivePoints",
             "marketMakingIncentivePoints" to "marketMakingIncentivePoints",
         ),

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/LaunchIncentiveMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/LaunchIncentiveMock.kt
@@ -22,7 +22,7 @@ internal class LaunchIncentiveMock {
 
     internal val points = """
         {
-           "incentivePoints":10,
+           "incentivePoints":0.01,
            "marketMakingIncentivePoints":0
         }
     """.trimIndent()

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tickets/TRCL3551Tests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tickets/TRCL3551Tests.kt
@@ -43,7 +43,7 @@ internal class TRCL3551Tests : TRCL2998Tests() {
                     "account": {
                         "launchIncentivePoints": {
                             "2": {
-                                "incentivePoints": 10,
+                                "incentivePoints": 0.01,
                                 "marketMakingIncentivePoints": 0
                             }
                         }


### PR DESCRIPTION
[MOB-288 : investigate trading rewards not showing](https://linear.app/dydx/issue/MOB-288/investigate-trading-rewards-not-showing)

issue was that we were expecting ints for the chaos labs API payload values from API

```
/query/api/dydx/points/<address>?n=3
```

-> 

```
{
	"incentivePoints": 0.982044,
	"marketMakingIncentivePoints": 0.009789599999999999,
	"dydxRewards": 0
}
```

change was to parse values as doubles

now tests are passing with the double mock values