### PR TITLE
Fix IDE indexing by removing extraneous platform sourceset declarations.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,15 +109,6 @@ kotlin {
         }
     }
 
-    val hostOs = System.getProperty("os.name")
-    val isMingwX64 = hostOs.startsWith("Windows")
-    val nativeTarget = when {
-        hostOs == "Mac OS X" -> macosX64("native")
-        hostOs == "Linux" -> linuxX64("native")
-        isMingwX64 -> mingwX64("native")
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-    }
-
 
     sourceSets {
         val ktorVersion = "2.1.1"
@@ -149,13 +140,9 @@ kotlin {
         val jvmTest by getting
         val jsMain by getting
         val jsTest by getting
-        val nativeTest by getting
 
         val androidMain by creating {
             dependsOn(commonMain)
-        }
-        val nativeMain by getting {
-            dependsOn(androidMain)
         }
         val jvmMain by getting {
             dependsOn(androidMain)


### PR DESCRIPTION
I was running into an issue where only the `jvmMain` sourceset was being indexed by Android Studio.

Tried a bunch of different stuff, eventually I noticed that we have some extraneous sourcesets and checks being done in the Gradle config. I removed these and IDE sync works now. I'm guessing something was causing IDE sync to silently fail. 