### PR TITLE
v1.6.11: Display position margin and position leverage in TradeInputs Summary

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.10"
+version = "1.6.11"
 
 repositories {
     google()

--- a/docs/Input/TradeInput.md
+++ b/docs/Input/TradeInput.md
@@ -330,7 +330,7 @@ Whether this trade can be filled
 
 ## positionMargin
 
-The amount of margin used for the trade (Isolated Margin)
+The amount of margin used for the overall position (Isolated Margin)
 
 ## positionLeverage
 

--- a/docs/Input/TradeInput.md
+++ b/docs/Input/TradeInput.md
@@ -295,7 +295,9 @@ data class TradeInputSummary(
 &emsp;val slippage: Double?,  
 &emsp;val fee: Double?,  
 &emsp;val total: Double?,  
-&emsp;val filled: Boolean  
+&emsp;val filled: Boolean
+&emsp;val positionMargin: Double?,
+&emsp;val positionLeverage: Double?,
 )
 
 ## price
@@ -325,3 +327,11 @@ Total amount of the trade
 ## filled
 
 Whether this trade can be filled
+
+## positionMargin
+
+The amount of margin used for the trade (Isolated Margin)
+
+## positionLeverage
+
+The overall leverage of the position (Isolated Margin)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
@@ -302,6 +302,8 @@ data class TradeInputSummary(
     val total: Double?,
     val reward: Double?,
     val filled: Boolean,
+    val positionMargin: Double?,
+    val positionLeverage: Double?,
 ) {
     companion object {
         internal fun create(
@@ -321,6 +323,8 @@ data class TradeInputSummary(
                 val total = parser.asDouble(data["total"])
                 val reward = parser.asDouble(data["reward"])
                 val filled = parser.asBool(data["filled"]) ?: false
+                val positionMargin = parser.asDouble(data["positionMargin"])
+                val positionLeverage = parser.asDouble(data["positionLeverage"])
 
                 return if (
                     existing?.price != price ||
@@ -330,6 +334,8 @@ data class TradeInputSummary(
                     existing?.slippage != slippage ||
                     existing?.fee != fee ||
                     existing?.total != total ||
+                    existing?.positionMargin != positionMargin ||
+                    existing?.positionLeverage != positionLeverage ||
                     existing?.filled != filled
                 ) {
                     TradeInputSummary(
@@ -342,6 +348,8 @@ data class TradeInputSummary(
                         total,
                         reward,
                         filled,
+                        positionMargin,
+                        positionLeverage
                     )
                 } else {
                     existing

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.6.10'
+    spec.version                  = '1.6.11'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Update TradeInput to expose `PositionMargin` and `PositionLeverage`. These will be exposed directly from the `Subaccount` object since there can only be one Isolated Position.