### PR TITLE
Expose appSettings in AsyncAbacusStateManagerProtocol, used by apps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.12"
+version = "1.6.13"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManager.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManager.kt
@@ -52,7 +52,7 @@ class AsyncAbacusStateManager(
 
     private var _appSettings: AppSettings? = null
 
-    val appSettings: AppSettings?
+    override val appSettings: AppSettings?
         get() = _appSettings
 
     private var environments: IList<V4Environment> = iListOf()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
@@ -29,6 +29,8 @@ interface AsyncAbacusStateManagerProtocol {
     var historicalTradingRewardPeriod: HistoricalTradingRewardsPeriod
     var candlesResolution: String
 
+    val appSettings: AppSettings?
+
     // input fields
     fun trade(data: String?, type: TradeInputField?)
     fun closePosition(data: String?, type: ClosePositionInputField)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
@@ -66,7 +66,7 @@ class AsyncAbacusStateManagerV2(
 
     private var _appSettings: AppSettings? = null
 
-    val appSettings: AppSettings?
+    override val appSettings: AppSettings?
         get() = _appSettings
 
     private var environments: IList<V4Environment> = iListOf()

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.6.12'
+    spec.version                  = '1.6.13'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
I am changing the app integration to using feature flags. That requires the protocol to expose all the properties we need. Missed appSettings.

With this Abacus PR, apps can integrate with AsyncAbacusStateManagerV2 under feature flags, without potentially breaking existing code