### PR TITLE
update web MarketsConfigs to not retrieve sparklines or candles for v2

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/Configs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/Configs.kt
@@ -52,8 +52,8 @@ data class MarketsConfigs(
             subscribeToCandles = true,
         )
         val forWeb = MarketsConfigs(
-            retrieveSparklines = true,
-            retrieveCandles = true,
+            retrieveSparklines = false,
+            retrieveCandles = false,
             retrieveHistoricalFundings = true,
             subscribeToMarkets = true,
             subscribeToOrderbook = true,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/MarketSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/MarketSupervisor.kt
@@ -69,7 +69,9 @@ internal open class MarketSupervisor(
         }
 
     internal fun didSetCandlesResolution(oldValue: String) {
-        retrieveCandles()
+        if (configs.retrieveCandles) {
+            retrieveCandles()
+        }
 
         if (socketConnected) {
             candlesChannelSubscription(oldValue, false)


### PR DESCRIPTION
turn off retrieve sparklines/candles for web

- web had to retrieve candles differently using TradingView api, so should skip the candles api calls to avoid unnecessary network calls
- web also doesn't show sparklines currently -- and only fetches 7 day sparklines as needed for determining whether a market is new, so can skip the abacus call until showing mini chart feature is added