### PR TITLE
Cleanup sourcesets.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.17"
+version = "1.6.18"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,11 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 buildscript {
-    val agp_version by extra("7.2.2")
     repositories {
-        //gradlePluginPortal()
-        //google()
         mavenCentral()
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10")
-        classpath("com.android.tools.build:gradle:$agp_version")
     }
 }
 
@@ -59,8 +55,6 @@ repositories {
 }
 
 kotlin {
-    //android()
-
     jvm {
         compilations.all {
             kotlinOptions.jvmTarget = "1.8"
@@ -74,13 +68,7 @@ kotlin {
 
     js(IR) {
         moduleName = "abacusjs"
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
+        browser()
         generateTypeScriptDefinitions()
         binaries.library()
         browser()
@@ -88,32 +76,23 @@ kotlin {
 
     val xcf = XCFramework()
 
-    iosArm64 {
-        binaries.framework {
+    val iosTargets = listOf(
+        iosArm64(),
+        iosSimulatorArm64(),
+    )
+
+    iosTargets.forEach {
+        it.binaries.framework {
             baseName = "abacus"
             xcf.add(this)
         }
     }
-
-    iosX64 {
-        binaries.framework {
-            baseName = "abacus"
-            xcf.add(this)
-        }
-    }
-
-    iosSimulatorArm64 {
-        binaries.framework {
-            baseName = "abacus"
-            xcf.add(this)
-        }
-    }
-
 
     sourceSets {
         val ktorVersion = "2.1.1"
         val napierVersion = "2.6.1"
         all {
+            // Since commonMain needs the opt-in, all dependent sets also need it.
             languageSettings.apply {
                 optIn("kotlin.js.ExperimentalJsExport")
             }
@@ -137,23 +116,13 @@ kotlin {
                 implementation("org.jetbrains.kotlin:kotlin-test-annotations-common")
             }
         }
-        val jvmTest by getting
         val jsMain by getting
-        val jsTest by getting
-
-        val androidMain by creating {
-            dependsOn(commonMain)
-        }
-        val jvmMain by getting {
-            dependsOn(androidMain)
-        }
+        val jvmMain by getting
+        val jvmTest by getting
         val iosMain by creating {
             dependsOn(commonMain)
         }
         val iosArm64Main by getting {
-            dependsOn(iosMain)
-        }
-        val iosX64Main by getting {
             dependsOn(iosMain)
         }
         val iosSimulatorArm64Main by getting {
@@ -165,14 +134,6 @@ kotlin {
         gradleVersion = "7.5.1"
         distributionType = Wrapper.DistributionType.ALL
     }
-
-
-    /*
-    tasks.named<KotlinJsCompile>("compileKotlinJs").configure {
-        kotlinOptions.moduleKind = "plain"
-    }
-
-     */
 
     cocoapods {
         // Required properties
@@ -226,7 +187,7 @@ npmPublish {
 }
 
 //
-// For Android app
+// JVM publishing
 //
 
 publishing {

--- a/src/androidMain/kotlin/exchange.dydx.abacus/state/manager/SystemUtils.android.kt
+++ b/src/androidMain/kotlin/exchange.dydx.abacus/state/manager/SystemUtils.android.kt
@@ -1,7 +1,0 @@
-package exchange.dydx.abacus.state.manager
-
-actual class SystemUtils {
-    actual companion object {
-        actual val platform: Platform = Platform.android
-    }
-}

--- a/src/jvmMain/kotlin/exchange/dydx/abacus/state/manager/SystemUtils.kt
+++ b/src/jvmMain/kotlin/exchange/dydx/abacus/state/manager/SystemUtils.kt
@@ -1,0 +1,10 @@
+package exchange.dydx.abacus.state.manager
+
+actual class SystemUtils {
+    actual companion object {
+        // Temp hack: Hard-coding this value for all JVM consumers is not what we want.
+        // Ultimately, this value is passed into the txnMemo. This should just be a configurable
+        // field when creating AsyncAbacusStateManager.
+        actual val platform: Platform = Platform.android
+    }
+}


### PR DESCRIPTION
A bit of pre-req work to replacing Napier with our own multiplatform logger.

In addition to some general build.gradle.kts cleanup, this PR mainly:
- Removes iosX64 target (trivial to add this back later if needed)
- Removes androidMain sourceset and Android Gradle Plugin dependencies. We're a pure JVM library, so shouldn't need Android knowledge. (Also, jvmMain was configured to depend on androidMain, which is opposite of convention)