### PR TITLE
skip retreive market candles based on appconfigs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.19"
+version = "1.6.20"
 
 repositories {
     google()

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,6 @@ kotlin.code.style=official
 kotlin.js.generate.executable.default=false
 org.gradle.jvmargs=-Xmx2000m
 kotlin.native.ignoreDisabledTargets=true
+
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
@@ -421,7 +421,7 @@ open class StateManagerAdaptor(
             retrieveFeeTiers()
             if (market != null) {
                 retrieveMarketHistoricalFundings()
-                retrieveMarketCandles()
+                maybeRetrieveMarketCandles()
             }
             if (sourceAddress != null) {
                 screenSourceAddress()
@@ -1211,7 +1211,8 @@ open class StateManagerAdaptor(
         return null
     }
 
-    private fun retrieveMarketCandles() {
+    private fun maybeRetrieveMarketCandles() {
+        if (!appConfigs.subscribeToCandles) return
         val market = market ?: return
         val url = configs.publicApiUrl("candles") ?: return
         val candleResolution = candlesResolution
@@ -1243,7 +1244,7 @@ open class StateManagerAdaptor(
                 val changes = stateMachine.candles(response)
                 update(changes, oldState)
                 if (changes.changes.contains(candles)) {
-                    retrieveMarketCandles()
+                    maybeRetrieveMarketCandles()
                 }
             }
         }
@@ -1585,7 +1586,7 @@ open class StateManagerAdaptor(
     }
 
     internal open fun didSetCandlesResolution(oldValue: String) {
-        retrieveMarketCandles()
+        maybeRetrieveMarketCandles()
     }
 
     fun didSetHistoricalTradingRewardsPeriod(period: String) {
@@ -1614,7 +1615,7 @@ open class StateManagerAdaptor(
                 }
             }
             retrieveMarketHistoricalFundings()
-            retrieveMarketCandles()
+            maybeRetrieveMarketCandles()
         }
     }
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.6.19'
+    spec.version                  = '1.6.20'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
- didn't realize we have the `subscribeToCandles` field in V1, we should also skip calling the candles API on indexer config / market set for web
- add back the two properties that were previously removed -- i think that is related to build performance
- fixed yarn lock file, which prev. throws an error when building for js