### PR TITLE
Embed Kotlin sources into JavaScript sourcemaps.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+import org.jetbrains.kotlin.gradle.targets.js.ir.JsIrBinary
 
 buildscript {
     repositories {
@@ -71,7 +72,16 @@ kotlin {
         browser()
         generateTypeScriptDefinitions()
         binaries.library()
-        browser()
+
+        binaries.withType<JsIrBinary>().all {
+            linkTask.configure {
+                kotlinOptions {
+                    sourceMap = true
+                    sourceMapEmbedSources = "always"
+                }
+            }
+        }
+
     }
 
     val xcf = XCFramework()


### PR DESCRIPTION
This allows viewing of Kotlin sources in browser dev tools.