### PR TITLE
v1.6.24: Isolated cancel order

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.23"
+version = "1.6.24"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.22"
+version = "1.6.23"
 
 repositories {
     google()

--- a/docs/Account.md
+++ b/docs/Account.md
@@ -237,7 +237,8 @@ An array of [SubaccountOrder](#SubaccountOrder)
 
 # SubaccountOrder
 
-data class SubaccountOrder(  
+data class SubaccountOrder(
+&emsp;val subaccountNumber: Int,
 &emsp;val id: String,  
 &emsp;val clientId: Int?,  
 &emsp;val type: OrderType,  
@@ -260,6 +261,10 @@ data class SubaccountOrder(
 &emsp;val cancelReason: String?,  
 &emsp;val resources: [SubaccountOrderResources](#SubaccountOrderResources)  
 )
+
+## subaccountNumber
+
+The subaccount number that placed the order
 
 ## id
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
@@ -621,6 +621,7 @@ data class SubaccountOrderResources(
 @JsExport
 @Serializable
 data class SubaccountOrder(
+    val subaccountNumber: Int,
     val id: String,
     val clientId: Int?,
     val type: OrderType,
@@ -657,6 +658,7 @@ data class SubaccountOrder(
         ): SubaccountOrder? {
             Logger.d { "creating Account Order\n" }
             data?.let {
+                val subaccountNumber = parser.asInt(data["subaccountNumber"])
                 val id = parser.asString(data["id"])
                 val clientId = parser.asInt(data["clientId"])
                 val marketId = parser.asString(data["marketId"])
@@ -678,7 +680,7 @@ data class SubaccountOrder(
                 val resources = parser.asMap(data["resources"])?.let {
                     SubaccountOrderResources.create(existing?.resources, parser, it, localizer)
                 }
-                if (id != null && marketId != null && type != null && side != null && status != null && price != null && size != null &&
+                if (subaccountNumber != null && id != null && marketId != null && type != null && side != null && status != null && price != null && size != null &&
                     resources != null
                 ) {
                     val triggerPrice = parser.asDouble(data["triggerPrice"])
@@ -701,7 +703,9 @@ data class SubaccountOrder(
                     val reduceOnly = parser.asBool(data["reduceOnly"]) ?: false
                     val cancelReason = parser.asString(data["cancelReason"])
 
-                    return if (existing?.id != id ||
+                    return if (
+                        existing?.subaccountNumber != subaccountNumber ||
+                        existing.id != id ||
                         existing.clientId != clientId ||
                         existing.type !== type ||
                         existing.side !== side ||
@@ -728,6 +732,7 @@ data class SubaccountOrder(
                         existing.resources !== resources
                     ) {
                         SubaccountOrder(
+                            subaccountNumber,
                             id,
                             clientId,
                             type,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
@@ -621,7 +621,7 @@ data class SubaccountOrderResources(
 @JsExport
 @Serializable
 data class SubaccountOrder(
-    val subaccountNumber: Int,
+    val subaccountNumber: Int?,
     val id: String,
     val clientId: Int?,
     val type: OrderType,
@@ -658,7 +658,8 @@ data class SubaccountOrder(
         ): SubaccountOrder? {
             Logger.d { "creating Account Order\n" }
             data?.let {
-                val subaccountNumber = parser.asInt(data["subaccountNumber"])
+                // TODO: Remove default to 0 for subaccountNumber once new indexer response is consumed. Prevents breaking change
+                val subaccountNumber = parser.asInt(data["subaccountNumber"])?: 0
                 val id = parser.asString(data["id"])
                 val clientId = parser.asInt(data["clientId"])
                 val marketId = parser.asString(data["marketId"])
@@ -680,7 +681,7 @@ data class SubaccountOrder(
                 val resources = parser.asMap(data["resources"])?.let {
                     SubaccountOrderResources.create(existing?.resources, parser, it, localizer)
                 }
-                if (subaccountNumber != null && id != null && marketId != null && type != null && side != null && status != null && price != null && size != null &&
+                if (id != null && marketId != null && type != null && side != null && status != null && price != null && size != null &&
                     resources != null
                 ) {
                     val triggerPrice = parser.asDouble(data["triggerPrice"])

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/OrderProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/OrderProcessor.kt
@@ -11,6 +11,7 @@ import exchange.dydx.abacus.utils.safeSet
 /*
 
       {
+        "subaccountNumber: 0, // new field
         "id": "3c5193d7a49805ffcf231af1ed446188f04aaa6756bf9df7b5913568b2763d7",
         "clientId": "69967309621008383",
         "market": "ETH-USD",
@@ -41,6 +42,7 @@ import exchange.dydx.abacus.utils.safeSet
       to
 
         {
+          "subaccountNumber": 0,
           "id": "45537274a3ef9afca657d9de73fb5fe5762f97336ce5502da0581e394dccdeb",
           "marketId": "ETH-USD",
           "price": 1192.5,
@@ -138,6 +140,7 @@ internal class OrderProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
             "reduceOnly" to "reduceOnly",
         ),
         "int" to mapOf(
+            "subaccountNumber" to "subaccountNumber",
             "clobPairId" to "clobPairId",
             "orderFlags" to "orderFlags",
             "goodTilBlock" to "goodTilBlock",

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -406,7 +406,7 @@ internal class SubaccountSupervisor(
         }
     }
 
-    fun cancelOrder(orderId: String, callback: TransactionCallback) {
+    fun cancelOrder(orderId: String, callback: TransactionCallback): HumanReadableCancelOrderPayload {
         val payload = cancelOrderPayload(orderId)
         val string = Json.encodeToString(payload)
         val analyticsPayload = analyticsUtils.formatCancelOrderPayload(payload)
@@ -448,6 +448,8 @@ internal class SubaccountSupervisor(
                 TransactionParams(TransactionType.CancelOrder, string, transactionCallback, uiClickTimeMs),
             )
         }
+
+        return payload
     }
 
     /**
@@ -810,9 +812,10 @@ internal class SubaccountSupervisor(
         val clobPairId = order.clobPairId ?: throw Exception("clobPairId is null")
         val goodTilBlock = order.goodTilBlock
         val goodTilBlockTime = order.goodTilBlockTime
+        val orderSubaccountNumber = order.subaccountNumber
 
         return HumanReadableCancelOrderPayload(
-            subaccountNumber,
+            orderSubaccountNumber,
             orderId,
             clientId,
             orderFlags,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -1,8 +1,10 @@
 package exchange.dydx.abacus.utils
 
+// Account Constants
+internal const val NUM_PARENT_SUBACCOUNTS = 128
+internal const val MAX_SUBACCOUNT_NUMBER = 128_000
+
 // Short Term Order Duration (Blocks) to add to GTB
 internal const val SHORT_TERM_ORDER_DURATION = 3
 
 internal const val QUANTUM_MULTIPLIER = 1_000_000
-
-internal const val NUM_PARENT_SUBACCOUNTS = 128

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -240,7 +240,9 @@ class V4TransactionTests : NetworkTests() {
         assertNotNull(orderPayload, "Order payload should not be null")
         assertEquals(256, orderPayload?.subaccountNumber, "Should be 256 since 0 and 128 are unavailable")
 
-        val transactions = subaccountSupervisor?.getTransactionsForIsolatedOrder(orderPayload)
-        assertEquals(transactions?.size, 2, "Should have 2 transactions")
+        val transferPayload = subaccountSupervisor?.getTransferPayloadForIsolatedMarginTrade(orderPayload)
+        assertNotNull(transferPayload, "Transfer payload should not be null")
+        assertEquals(0, transferPayload.subaccountNumber, "The parent subaccount 0 should be the origin")
+        assertEquals(256, transferPayload.destinationSubaccountNumber, "Should have 2 transactions")
     }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -245,4 +245,14 @@ class V4TransactionTests : NetworkTests() {
         assertEquals(0, transferPayload.subaccountNumber, "The parent subaccount 0 should be the origin")
         assertEquals(256, transferPayload.destinationSubaccountNumber, "Should have 2 transactions")
     }
+
+    @Test
+    fun testCancelOrderForChildSubaccount() {
+        setStateMachineForIsolatedMarginTests(stateManager)
+        val transactionCallback: TransactionCallback = { _, _, _ -> }
+
+        val cancelPayload = subaccountSupervisor?.cancelOrder("b812bea8-29d3-5841-9549-caa072f6f8a9", transactionCallback)
+        assertNotNull(cancelPayload, "Cancel payload should not be null")
+        assertEquals(128, cancelPayload?.subaccountNumber)
+    }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -19,6 +19,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class V4TransactionTests : NetworkTests() {
@@ -87,7 +88,7 @@ class V4TransactionTests : NetworkTests() {
         stateManager.setAddresses(null, testCosmoAddress)
     }
 
-    fun tradeInput(isShortTerm: Boolean, size: String = "0.01", limitPrice: String = "2000") {
+    private fun tradeInput(isShortTerm: Boolean, size: String = "0.01", limitPrice: String = "2000") {
         if (isShortTerm) {
             stateManager.trade("MARKET", TradeInputField.type)
         } else {
@@ -98,12 +99,12 @@ class V4TransactionTests : NetworkTests() {
         stateManager.trade(size, TradeInputField.size)
     }
 
-    fun assertTransactionQueueStarted(message: String? = null) {
+    private fun assertTransactionQueueStarted(message: String? = null) {
         assertEquals(0, subaccountSupervisor?.transactionQueue?.size)
         assertTrue(subaccountSupervisor?.transactionQueue?.isProcessing ?: false, message)
     }
 
-    fun assertTransactionQueueEmpty(message: String? = null) {
+    private fun assertTransactionQueueEmpty(message: String? = null) {
         assertEquals(0, subaccountSupervisor?.transactionQueue?.size)
         assertFalse(subaccountSupervisor?.transactionQueue?.isProcessing ?: false, message)
     }
@@ -201,5 +202,45 @@ class V4TransactionTests : NetworkTests() {
         testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
         assertEquals(2, transactionCalledCount)
         assertTransactionQueueEmpty()
+    }
+
+    private fun setStateMachineForIsolatedMarginTests(stateManager: AsyncAbacusStateManagerV2) {
+        stateManager.readyToConnect = true
+        testWebSocket?.simulateConnected(true)
+        testWebSocket?.simulateReceived(mock.connectionMock.connectedMessage)
+        testWebSocket?.simulateReceived(mock.marketsChannel.v4_subscribed_r1)
+
+        stateManager.setAddresses(null, "dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4")
+        testWebSocket?.simulateReceived(mock.parentSubaccountsChannel.subscribed)
+        testWebSocket?.simulateReceived(mock.parentSubaccountsChannel.channel_data)
+
+        stateManager.market = "ETH-USD"
+    }
+
+    private fun prepareIsolatedMarginTrade(isShortTerm: Boolean) {
+        stateManager.trade("2000", TradeInputField.limitPrice)
+        stateManager.trade("0.01", TradeInputField.size)
+        stateManager.trade("ISOLATED", TradeInputField.marginMode)
+        stateManager.trade("2", TradeInputField.targetLeverage)
+
+        if (isShortTerm) {
+            stateManager.trade("MARKET", TradeInputField.timeInForceType)
+        } else {
+            stateManager.trade("LIMIT", TradeInputField.type)
+            stateManager.trade("GTT", TradeInputField.timeInForceType)
+        }
+    }
+
+    @Test
+    fun testIsolatedMarginPlaceOrderTransactions() {
+        setStateMachineForIsolatedMarginTests(stateManager)
+        prepareIsolatedMarginTrade(false)
+
+        val orderPayload = subaccountSupervisor?.placeOrderPayload(0)
+        assertNotNull(orderPayload, "Order payload should not be null")
+        assertEquals(256, orderPayload?.subaccountNumber, "Should be 256 since 0 and 128 are unavailable")
+
+        val transactions = subaccountSupervisor?.getTransactionsForIsolatedOrder(orderPayload)
+        assertEquals(transactions?.size, 2, "Should have 2 transactions")
     }
 }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.6.22'
+    spec.version                  = '1.6.23'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.6.23'
+    spec.version                  = '1.6.24'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
- Expose `subaccountNumber` from SubaccountOrder
- Use `subaccountNumber` from `SubaccountOrder` as param for `HumanReadableCancelOrderPayload`