### PR TITLE
Update npm-publish plugin. This fixes an issue where the generated pa…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     kotlin("native.cocoapods") version "1.9.10"
     kotlin("plugin.serialization") version "1.9.10"
     id("maven-publish")
-    id("dev.petuska.npm.publish") version "3.1.0"
+    id("dev.petuska.npm.publish") version "3.4.2"
     id("com.diffplug.spotless") version "6.25.0"
 }
 


### PR DESCRIPTION
…ckage.json did not include transitive NPM dependencies needed for KotlinJS libs.