### PR TITLE
Add v4WebHotSwap Gradle Tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.9.13"
+version = "1.9.14"
 
 repositories {
     google()
@@ -230,4 +230,30 @@ publishing {
             }
         }
     }
+}
+
+/**
+ * These tasks are meant for continuous development with from the v4-web repo.
+ * Instead of going through packJsPackage and npm installation, we shortcut by just
+ * copying our JS files directly into v4-web/node_modules.
+ *
+ * This reduces iteration time quite a bit, while being a bit riskier since manipulating
+ * node_modules directly is not recommended.
+ *
+ * Run via ./gradlew v4WebHotSwapTrigger --continuous
+ */
+tasks.register<Copy>("v4WebHotSwapCopy") {
+    dependsOn("jsBrowserDevelopmentLibraryDistribution")
+
+    from("build/dist/js/developmentLibrary")
+    into("../v4-web/node_modules/@dydxprotocol/v4-abacus/")
+
+    include("**/*.js", "**/*.map", "**/*.ts")
+}
+
+tasks.register<Exec>("v4WebHotSwapTrigger") {
+    group = "abacus"
+    dependsOn("v4WebHotSwapCopy")
+
+    commandLine = listOf("./trigger_v4web_reload.sh")
 }

--- a/trigger_v4web_reload.sh
+++ b/trigger_v4web_reload.sh
@@ -1,0 +1,1 @@
+shasum build/dist/js/developmentLibrary/abacusjs.js > ../v4-web/local-abacus-hash

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.9.13'
+    spec.version                  = '1.9.14'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Add v4WebHotSwapTrigger task which copies development build JS directly into v4-web's node_modules.

This enables fully integrated continuous builds from v4-web: make a change in abacus and it will trigger compilation and fast path "installation" of the library into v4-web and trigger a Vite restart.

Can manually run via `./gradlew v4WebHotSwapTrigger --continuous` (will update `install-local-abacus` on the v4-web side).