### PR TITLE
1.6.34: Update SL/TP trigger/limit price errors to be SL/TP specific

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.33"
+version = "1.6.34"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/TriggerOrdersInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/TriggerOrdersInputValidator.kt
@@ -378,6 +378,7 @@ internal class TriggerOrdersInputValidator(
                             triggerToIndex,
                             oraclePrice,
                             tickSize,
+                            type,
                         ),
                     )
                 }
@@ -390,6 +391,7 @@ internal class TriggerOrdersInputValidator(
                             triggerToIndex,
                             oraclePrice,
                             tickSize,
+                            type,
                         ),
                     )
                 }
@@ -403,7 +405,8 @@ internal class TriggerOrdersInputValidator(
     private fun validateLimitPrice(
         triggerOrder: Map<String, Any>,
     ): List<Any>? {
-        return when (parser.asString(triggerOrder["type"])) {
+        val type = parser.asString(triggerOrder["type"])
+        return when (type) {
             "STOP_LIMIT", "TAKE_PROFIT" -> {
                 parser.asString(parser.value(triggerOrder, "side"))?.let { side ->
                     parser.asDouble(parser.value(triggerOrder, "price.limitPrice"))
@@ -417,8 +420,8 @@ internal class TriggerOrdersInputValidator(
                                                 "LIMIT_MUST_ABOVE_TRIGGER_PRICE",
                                                 listOf("price.triggerPrice"),
                                                 "APP.TRADE.MODIFY_TRIGGER_PRICE",
-                                                "ERRORS.TRADE_BOX_TITLE.LIMIT_MUST_ABOVE_TRIGGER_PRICE",
-                                                "ERRORS.TRADE_BOX.LIMIT_MUST_ABOVE_TRIGGER_PRICE",
+                                                if (type === "STOP_LIMIT") "ERRORS.TRIGGERS_FORM_TITLE.STOP_LOSS_LIMIT_MUST_ABOVE_TRIGGER_PRICE" else "ERRORS.TRIGGERS_FORM_TITLE.TAKE_PROFIT_LIMIT_MUST_ABOVE_TRIGGER_PRICE",
+                                                if (type === "STOP_LIMIT") "ERRORS.TRIGGERS_FORM.STOP_LOSS_LIMIT_MUST_ABOVE_TRIGGER_PRICE" else "ERRORS.TRIGGERS_FORM.TAKE_PROFIT_LIMIT_MUST_ABOVE_TRIGGER_PRICE",
                                             ),
                                         )
                                     } else if (side == "SELL" && limitPrice > triggerPrice) {
@@ -428,8 +431,8 @@ internal class TriggerOrdersInputValidator(
                                                 "LIMIT_MUST_BELOW_TRIGGER_PRICE",
                                                 listOf("price.triggerPrice"),
                                                 "APP.TRADE.MODIFY_TRIGGER_PRICE",
-                                                "ERRORS.TRADE_BOX_TITLE.LIMIT_MUST_BELOW_TRIGGER_PRICE",
-                                                "ERRORS.TRADE_BOX.LIMIT_MUST_BELOW_TRIGGER_PRICE",
+                                                if (type === "STOP_LIMIT") "ERRORS.TRIGGERS_FORM_TITLE.STOP_LOSS_LIMIT_MUST_BELOW_TRIGGER_PRICE" else "ERRORS.TRIGGERS_FORM_TITLE.TAKE_PROFIT_LIMIT_MUST_BELOW_TRIGGER_PRICE",
+                                                if (type === "STOP_LIMIT") "ERRORS.TRIGGERS_FORM.STOP_LOSS_LIMIT_MUST_BELOW_TRIGGER_PRICE" else "ERRORS.TRIGGERS_FORM.TAKE_PROFIT_LIMIT_MUST_BELOW_TRIGGER_PRICE",
                                             ),
                                         )
                                     } else {
@@ -528,6 +531,7 @@ internal class TriggerOrdersInputValidator(
         triggerToIndex: RelativeToPrice,
         oraclePrice: Double,
         tickSize: String,
+        type: String,
     ): Map<String, Any> {
         val fields = listOf("price.triggerPrice")
         val action = "APP.TRADE.MODIFY_TRIGGER_PRICE"
@@ -545,8 +549,8 @@ internal class TriggerOrdersInputValidator(
                 "TRIGGER_MUST_ABOVE_INDEX_PRICE",
                 fields,
                 action,
-                "ERRORS.TRADE_BOX_TITLE.TRIGGER_MUST_ABOVE_INDEX_PRICE",
-                "ERRORS.TRADE_BOX.TRIGGER_MUST_ABOVE_INDEX_PRICE",
+                if (type === "STOP_LIMIT" || type === "STOP_MARKET") "ERRORS.TRIGGERS_FORM_TITLE.STOP_LOSS_TRIGGER_MUST_ABOVE_INDEX_PRICE" else "ERRORS.TRIGGERS_FORM_TITLE.TAKE_PROFIT_TRIGGER_MUST_ABOVE_INDEX_PRICE",
+                if (type === "STOP_LIMIT" || type === "STOP_MARKET") "ERRORS.TRIGGERS_FORM.STOP_LOSS_TRIGGER_MUST_ABOVE_INDEX_PRICE" else "ERRORS.TRIGGERS_FORM.TAKE_PROFIT_TRIGGER_MUST_ABOVE_INDEX_PRICE",
                 params,
             )
 
@@ -555,8 +559,8 @@ internal class TriggerOrdersInputValidator(
                 "TRIGGER_MUST_BELOW_INDEX_PRICE",
                 fields,
                 action,
-                "ERRORS.TRADE_BOX_TITLE.TRIGGER_MUST_BELOW_INDEX_PRICE",
-                "ERRORS.TRADE_BOX.TRIGGER_MUST_BELOW_INDEX_PRICE",
+                if (type === "STOP_LIMIT" || type === "STOP_MARKET") "ERRORS.TRIGGERS_FORM_TITLE.STOP_LOSS_TRIGGER_MUST_BELOW_INDEX_PRICE" else "ERRORS.TRIGGERS_FORM_TITLE.TAKE_PROFIT_TRIGGER_MUST_BELOW_INDEX_PRICE",
+                if (type === "STOP_LIMIT" || type === "STOP_MARKET") "ERRORS.TRIGGERS_FORM.STOP_LOSS_TRIGGER_MUST_BELOW_INDEX_PRICE" else "ERRORS.TRIGGERS_FORM.TAKE_PROFIT_TRIGGER_MUST_BELOW_INDEX_PRICE",
                 params,
             )
         }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/validation/TriggerOrdersInputValidationTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/validation/TriggerOrdersInputValidationTests.kt
@@ -147,7 +147,18 @@ class TriggerOrdersInputValidationTests : V4BaseTests() {
                     "errors": [
                         {
                             "type": "ERROR",
-                            "code": "TRIGGER_MUST_BELOW_INDEX_PRICE"
+                            "code": "TRIGGER_MUST_BELOW_INDEX_PRICE",
+                            "resources": {
+                                "title": {
+                                    "stringKey": "ERRORS.TRIGGERS_FORM_TITLE.STOP_LOSS_TRIGGER_MUST_BELOW_INDEX_PRICE"
+                                },
+                                "text": {
+                                    "stringKey": "ERRORS.TRIGGERS_FORM.STOP_LOSS_TRIGGER_MUST_BELOW_INDEX_PRICE"
+                                },
+                                "action": {
+                                    "stringKey": "APP.TRADE.MODIFY_TRIGGER_PRICE"
+                                }
+                            }
                         }
                     ]        
                 }
@@ -260,7 +271,18 @@ class TriggerOrdersInputValidationTests : V4BaseTests() {
                     "errors": [
                         {
                             "type": "ERROR",
-                            "code": "LIMIT_MUST_BELOW_TRIGGER_PRICE"
+                            "code": "LIMIT_MUST_BELOW_TRIGGER_PRICE",
+                            "resources": {
+                                "title": {
+                                    "stringKey": "ERRORS.TRIGGERS_FORM_TITLE.STOP_LOSS_LIMIT_MUST_BELOW_TRIGGER_PRICE"
+                                },
+                                "text": {
+                                    "stringKey": "ERRORS.TRIGGERS_FORM.STOP_LOSS_LIMIT_MUST_BELOW_TRIGGER_PRICE"
+                                },
+                                "action": {
+                                    "stringKey": "APP.TRADE.MODIFY_TRIGGER_PRICE"
+                                }
+                            }
                         }
                     ]        
                 }
@@ -290,7 +312,18 @@ class TriggerOrdersInputValidationTests : V4BaseTests() {
                     "errors": [
                         {
                             "type": "ERROR",
-                            "code": "TRIGGER_MUST_ABOVE_INDEX_PRICE"
+                            "code": "TRIGGER_MUST_ABOVE_INDEX_PRICE",
+                            "resources": {
+                                "title": {
+                                    "stringKey": "ERRORS.TRIGGERS_FORM_TITLE.TAKE_PROFIT_TRIGGER_MUST_ABOVE_INDEX_PRICE"
+                                },
+                                "text": {
+                                    "stringKey": "ERRORS.TRIGGERS_FORM.TAKE_PROFIT_TRIGGER_MUST_ABOVE_INDEX_PRICE"
+                                },
+                                "action": {
+                                    "stringKey": "APP.TRADE.MODIFY_TRIGGER_PRICE"
+                                }
+                            }
                         }
                     ]        
                 }
@@ -360,7 +393,18 @@ class TriggerOrdersInputValidationTests : V4BaseTests() {
                     "errors": [
                         {
                             "type": "ERROR",
-                            "code": "LIMIT_MUST_BELOW_TRIGGER_PRICE"
+                            "code": "LIMIT_MUST_BELOW_TRIGGER_PRICE",
+                            "resources": {
+                                "title": {
+                                    "stringKey": "ERRORS.TRIGGERS_FORM_TITLE.TAKE_PROFIT_LIMIT_MUST_BELOW_TRIGGER_PRICE"
+                                },
+                                "text": {
+                                    "stringKey": "ERRORS.TRIGGERS_FORM.TAKE_PROFIT_LIMIT_MUST_BELOW_TRIGGER_PRICE"
+                                },
+                                "action": {
+                                    "stringKey": "APP.TRADE.MODIFY_TRIGGER_PRICE"
+                                }
+                            }
                         }
                     ]        
                 }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.6.33'
+    spec.version                  = '1.6.34'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Pulling in new translations from [here](https://github.com/dydxprotocol/v4-localization/commit/d122db5c52db9164036380efc717b5e6dce7714c).

Updated existing tests, and built locally  in FE to verify.

<img width="596" alt="Screenshot 2024-04-08 at 9 39 12 PM" src="https://github.com/dydxprotocol/v4-abacus/assets/70078372/8f66ac0e-582c-42c5-b290-7f13cbabb2d1">

<img width="566" alt="Screenshot 2024-04-08 at 9 39 29 PM" src="https://github.com/dydxprotocol/v4-abacus/assets/70078372/83164dd0-1291-49e2-88b5-444c907719dd">
