### PR TITLE
v1.6.37: Fix sltp percentage calculation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.36"
+version = "1.6.37"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
@@ -118,8 +118,8 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         modified.safeSet(
                             "percentDiff",
                             when (positionSide) {
-                                "long" -> leverage.times(size.times(entryPrice.minus(triggerPrice))).div(notionalTotal).times(100)
-                                "short" -> leverage.times(size.times(triggerPrice.minus(entryPrice))).div(notionalTotal).times(100)
+                                "long" -> leverage.times(entryPrice.minus(triggerPrice)).div(notionalTotal).times(100)
+                                "short" -> leverage.times(triggerPrice.minus(entryPrice)).div(notionalTotal).times(100)
                                 else -> null
                             },
                         )
@@ -138,8 +138,8 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         modified.safeSet(
                             "percentDiff",
                             when (positionSide) {
-                                "long" -> leverage.times(size.times(triggerPrice.minus(entryPrice))).div(notionalTotal).times(100)
-                                "short" -> leverage.times(size.times(entryPrice.minus(triggerPrice))).div(notionalTotal).times(100)
+                                "long" -> leverage.times(triggerPrice.minus(entryPrice)).div(notionalTotal).times(100)
+                                "short" -> leverage.times(entryPrice.minus(triggerPrice)).div(notionalTotal).times(100)
                                 else -> null
                             },
                         )
@@ -157,7 +157,7 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         )
                         modified.safeSet(
                             "percentDiff",
-                            leverage.times(usdcDiff).div(notionalTotal).times(100),
+                            leverage.times(usdcDiff).div(size.times(notionalTotal)).times(100),
                         )
                     }
                 }
@@ -173,7 +173,7 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         )
                         modified.safeSet(
                             "percentDiff",
-                            leverage.times(usdcDiff).div(notionalTotal).times(100),
+                            leverage.times(usdcDiff).div(size.times(notionalTotal)).times(100),
                         )
                     }
                 }
@@ -182,14 +182,14 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         modified.safeSet(
                             "triggerPrice",
                             when (positionSide) {
-                                "long" -> entryPrice.minus(percentDiff.times(notionalTotal).div(size.times(leverage)))
-                                "short" -> entryPrice.plus(percentDiff.times(notionalTotal).div(size.times(leverage)))
+                                "long" -> entryPrice.minus(percentDiff.times(notionalTotal).div(leverage))
+                                "short" -> entryPrice.plus(percentDiff.times(notionalTotal).div(leverage))
                                 else -> null
                             },
                         )
                         modified.safeSet(
                             "usdcDiff",
-                            percentDiff.times(notionalTotal).div(leverage),
+                            size.times(percentDiff.times(notionalTotal)).div(leverage),
                         )
                     }
                 }
@@ -198,14 +198,14 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         modified.safeSet(
                             "triggerPrice",
                             when (positionSide) {
-                                "long" -> entryPrice.plus(percentDiff.times(notionalTotal).div(size.times(leverage)))
-                                "short" -> entryPrice.minus(percentDiff.times(notionalTotal).div(size.times(leverage)))
+                                "long" -> entryPrice.plus(percentDiff.times(notionalTotal).div(leverage))
+                                "short" -> entryPrice.minus(percentDiff.times(notionalTotal).div(leverage))
                                 else -> null
                             },
                         )
                         modified.safeSet(
                             "usdcDiff",
-                            percentDiff.times(notionalTotal).div(leverage),
+                            size.times(percentDiff.times(notionalTotal)).div(leverage),
                         )
                     }
                 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
@@ -92,7 +92,7 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
         val inputType = parser.asString(parser.value(modified, "input"))
         val positionSide = parser.asString(parser.value(position, "resources.indicator.current"))
         val notionalTotal = parser.asDouble(parser.value(position, "notionalTotal.current")) ?: return modified
-        val leverage = parser.asDouble(parser.value(position, "leverage.current")) ?: return modified
+        val leverage = parser.asDouble(parser.value(position, "leverage.current"))?.abs() ?: return modified
 
         if (size == null || size == Numeric.double.ZERO || notionalTotal == Numeric.double.ZERO || leverage == Numeric.double.ZERO) {
             // A valid position size should never have 0 size, notional value or leverage.

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
@@ -123,6 +123,15 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                                 else -> null
                             },
                         )
+                    } else {
+                        modified.safeSet(
+                            "usdcDiff",
+                            null,
+                        )
+                        modified.safeSet(
+                            "percentDiff",
+                            null,
+                        )
                     }
                 }
                 "takeProfitOrder.price.triggerPrice" -> {
@@ -143,6 +152,15 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                                 else -> null
                             },
                         )
+                    } else {
+                        modified.safeSet(
+                            "usdcDiff",
+                            null,
+                        )
+                        modified.safeSet(
+                            "percentDiff",
+                            null,
+                        )
                     }
                 }
                 "stopLossOrder.price.usdcDiff" -> {
@@ -158,6 +176,15 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         modified.safeSet(
                             "percentDiff",
                             leverage.times(usdcDiff).div(size.times(notionalTotal)).times(100),
+                        )
+                    } else {
+                        modified.safeSet(
+                            "triggerPrice",
+                            null,
+                        )
+                        modified.safeSet(
+                            "percentDiff",
+                            null,
                         )
                     }
                 }
@@ -175,6 +202,15 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                             "percentDiff",
                             leverage.times(usdcDiff).div(size.times(notionalTotal)).times(100),
                         )
+                    } else {
+                        modified.safeSet(
+                            "triggerPrice",
+                            null,
+                        )
+                        modified.safeSet(
+                            "percentDiff",
+                            null,
+                        )
                     }
                 }
                 "stopLossOrder.price.percentDiff" -> {
@@ -191,6 +227,15 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                             "usdcDiff",
                             size.times(percentDiff.times(notionalTotal)).div(leverage),
                         )
+                    } else {
+                        modified.safeSet(
+                            "triggerPrice",
+                            null,
+                        )
+                        modified.safeSet(
+                            "usdcDiff",
+                            null,
+                        )
                     }
                 }
                 "takeProfitOrder.price.percentDiff" -> {
@@ -206,6 +251,15 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         modified.safeSet(
                             "usdcDiff",
                             size.times(percentDiff.times(notionalTotal)).div(leverage),
+                        )
+                    } else {
+                        modified.safeSet(
+                            "triggerPrice",
+                            null,
+                        )
+                        modified.safeSet(
+                            "usdcDiff",
+                            null,
                         )
                     }
                 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/TriggerOrdersInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/TriggerOrdersInputTests.kt
@@ -195,7 +195,7 @@ class TriggerOrderInputTests : V4BaseTests() {
                                 "limitPrice": "300.0",
                                 "triggerPrice": "400.0",
                                 "usdcDiff": "300",
-                                "percentDiff": "35.15790352",
+                                "percentDiff": "70.31580704",
                                 "input": "stopLossOrder.price.triggerPrice"
                             },
                             "summary": {
@@ -225,7 +225,7 @@ class TriggerOrderInputTests : V4BaseTests() {
                                 "limitPrice": "300.0",
                                 "triggerPrice": "200.0",
                                 "usdcDiff": "400",
-                                "percentDiff": "46.87720469",
+                                "percentDiff": "93.75440939",
                                 "input": "stopLossOrder.price.usdcDiff"
                             },
                             "summary": {
@@ -253,8 +253,8 @@ class TriggerOrderInputTests : V4BaseTests() {
                             "side": "SELL",
                             "price": {
                                 "limitPrice": "300.0",
-                                "triggerPrice": "573.3534",
-                                "usdcDiff": "213.3233",
+                                "triggerPrice": "786.6767",
+                                "usdcDiff": "106.6617",
                                 "percentDiff": "25.0",
                                 "input": "stopLossOrder.price.percentDiff"
                             },
@@ -331,7 +331,7 @@ class TriggerOrderInputTests : V4BaseTests() {
                                 "limitPrice": "1600.0",
                                 "triggerPrice": "1800.0",
                                 "usdcDiff": "400",
-                                "percentDiff": "46.87720469",
+                                "percentDiff": "93.75440939",
                                 "input": "takeProfitOrder.price.triggerPrice"
                             },
                             "summary": {
@@ -361,7 +361,7 @@ class TriggerOrderInputTests : V4BaseTests() {
                                 "limitPrice": "1600.0",
                                 "triggerPrice": "1600.0",
                                 "usdcDiff": "300.0",
-                                "percentDiff": "35.15790352",
+                                "percentDiff": "70.31580704",
                                 "input": "takeProfitOrder.price.usdcDiff"
                             },
                             "summary": {
@@ -389,8 +389,8 @@ class TriggerOrderInputTests : V4BaseTests() {
                             "side": "SELL",
                             "price": {
                                 "limitPrice": "1600.0",
-                                "triggerPrice": "1426.6466",
-                                "usdcDiff": "213.3233",
+                                "triggerPrice": "1213.3233",
+                                "usdcDiff": "106.6617",
                                 "percentDiff": "25.0",
                                 "input": "takeProfitOrder.price.percentDiff"
                             },

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.6.36'
+    spec.version                  = '1.6.37'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
my bad; synced with Se - percentage calculation should be independent of size of order. 

Formula is:
`percentageDiff = (leverage * abs(entryPrice - triggerPrice) / notionalTotal) * 100`

also:
- Updated to clear (set to null) other price inputs when one is set to null
- Also fixed bug where leverage is negative on short positions (and I didn't notice)


Tested on frontend - this time it looks correct 🙃 


https://github.com/dydxprotocol/v4-abacus/assets/70078372/9a64fabc-8f8f-4de0-82ea-e12eaec45ddb



