### PR TITLE
v1.6.40: Fix percentage calculations, fix double payload return on commitTriggerOrders

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.38"
+version = "1.6.39"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.39"
+version = "1.6.40"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
@@ -178,7 +178,7 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         )
                         modified.safeSet(
                             "percentDiff",
-                            usdcDiff.div(scaledNotionalTotal).times(leverage).times(100)
+                            usdcDiff.div(scaledNotionalTotal).times(leverage).times(100),
                         )
                     } else {
                         modified.safeSet(
@@ -203,7 +203,7 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         )
                         modified.safeSet(
                             "percentDiff",
-                            usdcDiff.div(scaledNotionalTotal).times(leverage).times(100)
+                            usdcDiff.div(scaledNotionalTotal).times(leverage).times(100),
                         )
                     } else {
                         modified.safeSet(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
@@ -91,6 +91,7 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
         val entryPrice = parser.asDouble(parser.value(position, "entryPrice.current"))
         val inputType = parser.asString(parser.value(modified, "input"))
         val positionSide = parser.asString(parser.value(position, "resources.indicator.current"))
+        val positionSize = parser.asDouble(parser.value(position, "size.current"))?.abs() ?: return modified
         val notionalTotal = parser.asDouble(parser.value(position, "notionalTotal.current")) ?: return modified
         val leverage = parser.asDouble(parser.value(position, "leverage.current"))?.abs() ?: return modified
 
@@ -98,6 +99,8 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
             // A valid position size should never have 0 size, notional value or leverage.
             return modified;
         }
+
+        val scaledNotionalTotal = size.div(positionSize).times(notionalTotal);
 
         if (entryPrice != null) {
             val triggerPrice = parser.asDouble(parser.value(modified, "triggerPrice"))
@@ -118,8 +121,8 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         modified.safeSet(
                             "percentDiff",
                             when (positionSide) {
-                                "long" -> leverage.times(entryPrice.minus(triggerPrice)).div(notionalTotal).times(100)
-                                "short" -> leverage.times(triggerPrice.minus(entryPrice)).div(notionalTotal).times(100)
+                                "long" -> size.times(leverage.times(entryPrice.minus(triggerPrice))).div(scaledNotionalTotal).times(100)
+                                "short" -> size.times(leverage.times(triggerPrice.minus(entryPrice))).div(scaledNotionalTotal).times(100)
                                 else -> null
                             },
                         )
@@ -147,8 +150,8 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         modified.safeSet(
                             "percentDiff",
                             when (positionSide) {
-                                "long" -> leverage.times(triggerPrice.minus(entryPrice)).div(notionalTotal).times(100)
-                                "short" -> leverage.times(entryPrice.minus(triggerPrice)).div(notionalTotal).times(100)
+                                "long" -> size.times(leverage.times(triggerPrice.minus(entryPrice))).div(scaledNotionalTotal).times(100)
+                                "short" -> size.times(leverage.times(entryPrice.minus(triggerPrice))).div(scaledNotionalTotal).times(100)
                                 else -> null
                             },
                         )
@@ -175,7 +178,7 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         )
                         modified.safeSet(
                             "percentDiff",
-                            leverage.times(usdcDiff).div(size.times(notionalTotal)).times(100),
+                            usdcDiff.div(scaledNotionalTotal).times(leverage).times(100)
                         )
                     } else {
                         modified.safeSet(
@@ -200,7 +203,7 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         )
                         modified.safeSet(
                             "percentDiff",
-                            leverage.times(usdcDiff).div(size.times(notionalTotal)).times(100),
+                            usdcDiff.div(scaledNotionalTotal).times(leverage).times(100)
                         )
                     } else {
                         modified.safeSet(
@@ -218,14 +221,14 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         modified.safeSet(
                             "triggerPrice",
                             when (positionSide) {
-                                "long" -> entryPrice.minus(percentDiff.times(notionalTotal).div(leverage))
-                                "short" -> entryPrice.plus(percentDiff.times(notionalTotal).div(leverage))
+                                "long" -> entryPrice.minus(percentDiff.times(scaledNotionalTotal).div(leverage.times(size)))
+                                "short" -> entryPrice.plus(percentDiff.times(scaledNotionalTotal).div(leverage.times(size)))
                                 else -> null
                             },
                         )
                         modified.safeSet(
                             "usdcDiff",
-                            size.times(percentDiff.times(notionalTotal)).div(leverage),
+                            percentDiff.times(scaledNotionalTotal).div(leverage),
                         )
                     } else {
                         modified.safeSet(
@@ -243,14 +246,14 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                         modified.safeSet(
                             "triggerPrice",
                             when (positionSide) {
-                                "long" -> entryPrice.plus(percentDiff.times(notionalTotal).div(leverage))
-                                "short" -> entryPrice.minus(percentDiff.times(notionalTotal).div(leverage))
+                                "long" -> entryPrice.plus(percentDiff.times(scaledNotionalTotal).div(leverage.times(size)))
+                                "short" -> entryPrice.minus(percentDiff.times(scaledNotionalTotal).div(leverage.times(size)))
                                 else -> null
                             },
                         )
                         modified.safeSet(
                             "usdcDiff",
-                            size.times(percentDiff.times(notionalTotal)).div(leverage),
+                            percentDiff.times(scaledNotionalTotal).div(leverage),
                         )
                     } else {
                         modified.safeSet(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
@@ -1195,7 +1195,10 @@ class V4StateManagerAdaptor(
             submitPlaceOrder(callback, it, analyticsPayload, true)
         }
 
-        send(null, callback, payloads)
+        if (payloads.cancelOrderPayloads.isEmpty() && payloads.placeOrderPayloads.isEmpty()) {
+            send(null, callback, payloads)
+        }
+
         return payloads
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -783,7 +783,10 @@ internal class SubaccountSupervisor(
             submitPlaceOrder(callback, payload, analyticsPayload, true)
         }
 
-        helper.send(null, callback, payloads)
+        if (payloads.cancelOrderPayloads.isEmpty() && payloads.placeOrderPayloads.isEmpty()) {
+            helper.send(null, callback, payloads)
+        }
+
         return payloads
     }
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/V4TransactionTests.kt
@@ -224,13 +224,14 @@ class V4TransactionTests : NetworkTests() {
         assertTransactionQueueStarted()
 
         // Creating New Orders
-        simulateNewBtcOrder(slLimitPrice = null, tpLimitPrice = null) // 2 new market orders created
+        simulateNewBtcOrder(slLimitPrice = null, tpLimitPrice = null) // 1 new market order created
         assertEquals(2, transactionQueue?.size)
-        assertEquals(3, transactionCalledCount)
+        assertEquals(1, transactionCalledCount)
         clearTransactions(2)
 
         simulateNewBtcOrder() // 2 new limit orders created
         assertEquals(2, transactionQueue?.size)
+        assertEquals(3, transactionCalledCount)
         clearTransactions(2)
 
         // Updating Existing Order
@@ -281,14 +282,14 @@ class V4TransactionTests : NetworkTests() {
         assertEquals(2, v4Adapter?.transactionQueue?.size)
 
         testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
-        assertEquals(2, transactionCalledCount)
+        assertEquals(1, transactionCalledCount)
         assertEquals(1, v4Adapter?.transactionQueue?.size)
 
         testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
-        assertEquals(3, transactionCalledCount)
+        assertEquals(2, transactionCalledCount)
 
         testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
-        assertEquals(4, transactionCalledCount)
+        assertEquals(3, transactionCalledCount)
         assertTransactionQueueEmpty()
     }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -247,13 +247,14 @@ class V4TransactionTests : NetworkTests() {
         assertTransactionQueueStarted()
 
         // Creating New Orders
-        simulateNewBtcOrder(slLimitPrice = null, tpLimitPrice = null) // 2 new market orders created
+        simulateNewBtcOrder(slLimitPrice = null, tpLimitPrice = null) // 1 new market order created
         assertEquals(2, transactionQueue?.size)
-        assertEquals(3, transactionCalledCount)
+        assertEquals(1, transactionCalledCount)
         clearTransactions(2)
 
         simulateNewBtcOrder() // 2 new limit orders created
         assertEquals(2, transactionQueue?.size)
+        assertEquals(3, transactionCalledCount)
         clearTransactions(2)
 
         // Updating Existing Order
@@ -303,14 +304,14 @@ class V4TransactionTests : NetworkTests() {
         assertEquals(2, subaccountSupervisor?.transactionQueue?.size)
 
         testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
-        assertEquals(2, transactionCalledCount)
+        assertEquals(1, transactionCalledCount)
         assertEquals(1, subaccountSupervisor?.transactionQueue?.size)
 
         testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
-        assertEquals(3, transactionCalledCount)
+        assertEquals(2, transactionCalledCount)
 
         testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
-        assertEquals(4, transactionCalledCount)
+        assertEquals(3, transactionCalledCount)
         assertTransactionQueueEmpty()
     }
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.6.39'
+    spec.version                  = '1.6.40'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.6.38'
+    spec.version                  = '1.6.39'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
This is the last time I'll fix percentage calculations; worked with Se for an afternoon and we finally feel confident on it. Missing part to the calculation was that:
- We were using the fixed notionalTotal rather than the scaled notionalTotal (scaled to user order size)
- We were missing (order) size in several calculations

None of the tests had to be updated because `size` of ETH in our tests is just 1, go figure (this is mocked out in the channels data, I don't feel super strongly about mocking some new data to test a non-1 size, but can if others feel strongly; reasoning: I don't think this calculation should change anymore/be reused anywhere else).

Also fixed double callback being returned in `commitTriggerOrders`: `send` is called from both `submitCancelOrder` and  `submitPlaceOrder`, so we should only be calling the final `send` if there were in fact, no cancel or place orders in our trigger orders payload. (Without this change, web ends up sending double notifications because we trigger notifications based on the payloads recieved back).