### PR TITLE
fix abacus version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.43"
+version = "1.6.44"
 
 repositories {
     google()

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.6.43'
+    spec.version                  = '1.6.44'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
oops realized in https://github.com/dydxprotocol/v4-abacus/pull/309, I did not actually properly bump the version (https://github.com/dydxprotocol/v4-abacus/pull/306 was also 1.6.43). Tested out in testnet and looks like you don't get the updates in web until version is properly bumped :(