### PR TITLE
Update stop market order liquidity warning + params

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -1,6 +1,11 @@
 package exchange.dydx.abacus.calculator
 
 import abs
+import exchange.dydx.abacus.calculator.SlippageConstants.MARKET_ORDER_MAX_SLIPPAGE
+import exchange.dydx.abacus.calculator.SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER
+import exchange.dydx.abacus.calculator.SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
+import exchange.dydx.abacus.calculator.SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
+import exchange.dydx.abacus.calculator.SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.state.manager.EnvironmentFeatureFlags
 import exchange.dydx.abacus.utils.Numeric
@@ -1408,9 +1413,9 @@ internal class TradeInputCalculator(
                     val side = parser.asString(trade["side"])
                     val payloadPrice = if (price != null) {
                         when (side) {
-                            "BUY" -> price * (Numeric.double.ONE + SlippageConstants.MARKET_ORDER_MAX_SLIPPAGE)
+                            "BUY" -> price * (Numeric.double.ONE + MARKET_ORDER_MAX_SLIPPAGE)
 
-                            else -> price * (Numeric.double.ONE - SlippageConstants.MARKET_ORDER_MAX_SLIPPAGE)
+                            else -> price * (Numeric.double.ONE - MARKET_ORDER_MAX_SLIPPAGE)
                         }
                     } else {
                         null
@@ -1510,16 +1515,15 @@ internal class TradeInputCalculator(
                         }
                         if (majorMarket) {
                             if (type == "STOP_MARKET") {
-                                slippagePercentage + SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
+                                slippagePercentage + STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
                             } else {
-                                slippagePercentage +
-                                    SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
+                                slippagePercentage + TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
                             }
                         } else {
                             if (type == "STOP_MARKET") {
-                                slippagePercentage + SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER
+                                slippagePercentage + STOP_MARKET_ORDER_SLIPPAGE_BUFFER
                             } else {
-                                slippagePercentage + SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
+                                slippagePercentage + TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
                             }
                         }
                     } else {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -31,12 +31,12 @@ enum class TradeCalculation(val rawValue: String) {
     }
 }
 
-object SlippageConstants {
-    internal const val MARKET_ORDER_MAX_SLIPPAGE = 0.05
-    internal const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
-    internal const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
-    internal const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER = 0.2
-    internal const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER = 0.2
+internal object SlippageConstants {
+    const val MARKET_ORDER_MAX_SLIPPAGE = 0.05
+    const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
+    const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
+    const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER = 0.2
+    const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER = 0.2
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -28,7 +28,6 @@ enum class TradeCalculation(val rawValue: String) {
 
 object SlippageConstants {
     internal const val MARKET_ORDER_MAX_SLIPPAGE = 0.05
-    internal const val MARKET_ORDER_SLIPPAGE_WARNING_THRESHOLD = 0.01
     internal const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
     internal const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
     internal const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER = 0.2

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -26,6 +26,15 @@ enum class TradeCalculation(val rawValue: String) {
     }
 }
 
+object SlippageConstants {
+    internal const val MARKET_ORDER_MAX_SLIPPAGE = 0.05
+    internal const val MARKET_ORDER_SLIPPAGE_WARNING_THRESHOLD = 0.01
+    internal const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
+    internal const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
+    internal const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER = 0.2
+    internal const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER = 0.2
+}
+
 @Suppress("UNCHECKED_CAST")
 internal class TradeInputCalculator(
     val parser: ParserProtocol,
@@ -33,24 +42,6 @@ internal class TradeInputCalculator(
     val featureFlags: EnvironmentFeatureFlags,
 ) {
     private val accountTransformer = AccountTransformer()
-
-    @Suppress("LocalVariableName", "PropertyName")
-    private val MARKET_ORDER_MAX_SLIPPAGE = 0.05
-
-    @Suppress("LocalVariableName", "PropertyName")
-    private val MARKET_ORDER_SLIPPAGE_WARNING_THRESHOLD = 0.01
-
-    @Suppress("LocalVariableName", "PropertyName")
-    private val STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.05
-
-    @Suppress("LocalVariableName", "PropertyName")
-    private val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
-
-    @Suppress("LocalVariableName", "PropertyName")
-    private val STOP_MARKET_ORDER_SLIPPAGE_BUFFER = 0.1
-
-    @Suppress("LocalVariableName", "PropertyName")
-    private val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER = 0.2
 
     internal fun calculate(
         state: Map<String, Any>,
@@ -1418,9 +1409,9 @@ internal class TradeInputCalculator(
                     val side = parser.asString(trade["side"])
                     val payloadPrice = if (price != null) {
                         when (side) {
-                            "BUY" -> price * (Numeric.double.ONE + MARKET_ORDER_MAX_SLIPPAGE)
+                            "BUY" -> price * (Numeric.double.ONE + SlippageConstants.MARKET_ORDER_MAX_SLIPPAGE)
 
-                            else -> price * (Numeric.double.ONE - MARKET_ORDER_MAX_SLIPPAGE)
+                            else -> price * (Numeric.double.ONE - SlippageConstants.MARKET_ORDER_MAX_SLIPPAGE)
                         }
                     } else {
                         null
@@ -1520,15 +1511,16 @@ internal class TradeInputCalculator(
                         }
                         if (majorMarket) {
                             if (type == "STOP_MARKET") {
-                                slippagePercentage + STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
+                                slippagePercentage + SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
                             } else {
-                                slippagePercentage + TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
+                                slippagePercentage +
+                                    SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
                             }
                         } else {
                             if (type == "STOP_MARKET") {
-                                slippagePercentage + STOP_MARKET_ORDER_SLIPPAGE_BUFFER
+                                slippagePercentage + SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER
                             } else {
-                                slippagePercentage + TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
+                                slippagePercentage + SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
                             }
                         }
                     } else {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
@@ -1,6 +1,10 @@
 package exchange.dydx.abacus.calculator
 
 import abs
+import exchange.dydx.abacus.calculator.SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER
+import exchange.dydx.abacus.calculator.SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
+import exchange.dydx.abacus.calculator.SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
+import exchange.dydx.abacus.calculator.SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
 import exchange.dydx.abacus.output.input.OrderSide
 import exchange.dydx.abacus.output.input.OrderType
 import exchange.dydx.abacus.protocols.ParserProtocol
@@ -279,15 +283,15 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                 }
                 val slippagePercentage = if (majorMarket) {
                     if (type == OrderType.stopMarket) {
-                        SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
+                        STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
                     } else {
-                        SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
+                        TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
                     }
                 } else {
                     if (type == OrderType.stopMarket) {
-                        SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER
+                        STOP_MARKET_ORDER_SLIPPAGE_BUFFER
                     } else {
-                        SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
+                        TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
                     }
                 }
                 val calculatedLimitPrice = if (triggerPrice != null) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
@@ -11,18 +11,6 @@ import kotlin.math.abs
 
 @Suppress("UNCHECKED_CAST")
 internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
-    @Suppress("LocalVariableName", "PropertyName")
-    private val STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.05
-
-    @Suppress("LocalVariableName", "PropertyName")
-    private val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
-
-    @Suppress("LocalVariableName", "PropertyName")
-    private val STOP_MARKET_ORDER_SLIPPAGE_BUFFER = 0.1
-
-    @Suppress("LocalVariableName", "PropertyName")
-    private val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER = 0.2
-
     internal fun calculate(
         state: Map<String, Any>,
         subaccountNumber: Int?,
@@ -291,15 +279,15 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
                 }
                 val slippagePercentage = if (majorMarket) {
                     if (type == OrderType.stopMarket) {
-                        STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
+                        SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
                     } else {
-                        TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
+                        SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
                     }
                 } else {
                     if (type == OrderType.stopMarket) {
-                        STOP_MARKET_ORDER_SLIPPAGE_BUFFER
+                        SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER
                     } else {
-                        TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
+                        SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
                     }
                 }
                 val calculatedLimitPrice = if (triggerPrice != null) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeTriggerPriceValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeTriggerPriceValidator.kt
@@ -120,10 +120,6 @@ internal class TradeTriggerPriceValidator(
                         }
                     }
                 }
-                when (type) {
-                    "STOP_MARKET" -> errors.add(stopMarketExecutionWarning(parser))
-                    else -> {}
-                }
             }
             return errors
         }
@@ -265,19 +261,5 @@ internal class TradeTriggerPriceValidator(
                 params,
             )
         }
-    }
-
-    private fun stopMarketExecutionWarning(
-        parser: ParserProtocol,
-    ): Map<String, Any> {
-        return error(
-            "WARNING",
-            "STOP_MARKET_ORDER_MAY_NOT_EXECUTE",
-            null,
-            null,
-            "WARNINGS.TRADE_BOX_TITLE.STOP_MARKET_ORDER_MAY_NOT_EXECUTE",
-            "WARNINGS.TRADE_BOX.STOP_MARKET_ORDER_MAY_NOT_EXECUTE",
-            null,
-        )
     }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/TradeInputTests.kt
@@ -1720,7 +1720,7 @@ class TradeInputTests : V3BaseTests() {
                                 "size": 1.0,
                                 "usdcSize": 2000.0,
                                 "price": 2000.0,
-                                "payloadPrice": 2100.0,
+                                "payloadPrice": 2200.0,
                                 "total": -2001.0,
                                 "filled": true
                             },

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/TriggerOrdersInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/TriggerOrdersInputTests.kt
@@ -161,7 +161,7 @@ class TriggerOrderInputTests : V4BaseTests() {
                                 "input": "stopLossOrder.price.triggerPrice"
                             },
                             "summary": {
-                                "price": "900.0"
+                                "price": "800.0"
                             }
                         }
                     }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
@@ -809,7 +809,7 @@ open class V4TradeInputTests : V4BaseTests() {
                 "input": {
                     "trade": {
                         "summary": {
-                            "payloadPrice": 950.0
+                            "payloadPrice": 900.0
                         }
                     }
                 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/validation/TradeRequiredInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/validation/TradeRequiredInputTests.kt
@@ -213,12 +213,7 @@ class TradeRequiredInputTests : V3BaseTests() {
                         "trade": {
                             "type": "STOP_MARKET"
                         },
-                        "errors": [
-                            {
-                                "type": "WARNING",
-                                "code": "STOP_MARKET_ORDER_MAY_NOT_EXECUTE"
-                            }
-                        ]
+                        "errors": null
                     }
                 }
             """.trimIndent(),


### PR DESCRIPTION
As per [product](https://linear.app/dydx/issue/CT-779/remove-warning-for-users-placing-stop-market-orders), update stop market slippages from:
- Major markets: 0.05 -> 0.1
- Non-major markets: 0.1 -> 0.2

For cleanliness, updated constants to be shared between `TriggerOrdersInputCalculator` and `TradeInputCalculator`; removed unused `MARKET_ORDER_SLIPPAGE_WARNING_THRESHOLD`.

Also remove `STOP_MARKET_ORDER_MAY_NOT_EXECUTE ` warning prompting users to use stop limit orders. 