### PR TITLE
add isSlTpLimitOrdersEnabled feature flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.6.49"
+version = "1.6.50"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Enviroment.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Enviroment.kt
@@ -106,6 +106,7 @@ data class EnvironmentFeatureFlags(
     val useOptimisticCollateralCheck: Boolean,
     val withdrawalSafetyEnabled: Boolean,
     val isSlTpEnabled: Boolean,
+    val isSlTpLimitOrdersEnabled: Boolean,
 ) {
     companion object {
         fun parse(
@@ -117,6 +118,7 @@ data class EnvironmentFeatureFlags(
             val useOptimisticCollateralCheck = parser.asBool(data?.get("useOptimisticCollateralCheck")) ?: false
             val withdrawalSafetyEnabled = parser.asBool(data?.get("withdrawalSafetyEnabled")) ?: false
             val isSlTpEnabled = parser.asBool(data?.get("isSlTpEnabled")) ?: false
+            val isSlTpLimitOrdersEnabled = parser.asBool(data?.get("isSlTpLimitOrdersEnabled")) ?: false
 
             return EnvironmentFeatureFlags(
                 reduceOnlySupported,
@@ -124,6 +126,7 @@ data class EnvironmentFeatureFlags(
                 useOptimisticCollateralCheck,
                 withdrawalSafetyEnabled,
                 isSlTpEnabled,
+                isSlTpLimitOrdersEnabled,
             )
         }
     }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AbacusMockData.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AbacusMockData.kt
@@ -108,6 +108,7 @@ class AbacusMockData {
             useOptimisticCollateralCheck = true,
             withdrawalSafetyEnabled = true,
             isSlTpEnabled = true,
+            isSlTpLimitOrdersEnabled = true,
         ),
     )
 }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.6.49'
+    spec.version                  = '1.6.50'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
related: [DSGN-707 : enable env.json feature flag isSltpEnabled](https://linear.app/dydx/issue/DSGN-707/enable-envjson-feature-flag-issltpenabled)

exposes isSlTpLimitOrdersEnabled feature flag for enabling sl/tp from env.json