### PR TITLE
feat: add new properties to market [OTE-296]

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Market.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Market.kt
@@ -289,6 +289,8 @@ data class MarketPerpetual(
     val nextFundingAtMilliseconds: Double? = null,
     val openInterest: Double,
     val openInterestUSDC: Double,
+    val openInterestLowerCap: Double? = null,
+    val openInterestUpperCap: Double? = null,
     val line: IList<Double>?,
 ) {
     companion object {
@@ -303,6 +305,8 @@ data class MarketPerpetual(
                 val nextFundingRate = parser.asDouble(data["nextFundingRate"])
                 val nextFundingAtMilliseconds =
                     parser.asDatetime(data["nextFundingAt"])?.toEpochMilliseconds()?.toDouble()
+                val openInterestLowerCap = parser.asDouble(data["openInterestLowerCap"])
+                val openInterestUpperCap = parser.asDouble(data["openInterestUpperCap"])
                 val openInterest = parser.asDouble(data["openInterest"])
                 val openInterestUSDC = parser.asDouble(data["openInterestUSDC"])
 
@@ -324,6 +328,8 @@ data class MarketPerpetual(
                             nextFundingAtMilliseconds,
                             openInterest,
                             openInterestUSDC ?: 0.0,
+                            openInterestLowerCap,
+                            openInterestUpperCap,
                             line,
                         )
                     } else {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketProcessor.kt
@@ -7,6 +7,7 @@ import exchange.dydx.abacus.utils.Numeric
 import exchange.dydx.abacus.utils.ServerTime
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
+import exchange.dydx.abacus.utils.Logger
 import kotlin.time.Duration.Companion.seconds
 
 @Suppress("UNCHECKED_CAST")
@@ -111,6 +112,8 @@ internal class MarketProcessor(parser: ParserProtocol, private val calculateSpar
         "double" to mapOf(
             "volume24H" to "volume24H",
             "openInterest" to "openInterest",
+            "openInterestLowerCap" to "openInterestLowerCap",
+            "openInterestUpperCap" to "openInterestUpperCap",
             "nextFundingRate" to "nextFundingRate",
         ),
         "datetime" to mapOf(


### PR DESCRIPTION
Threads in new properties
`openInterestLowerCap`
`openInterestUpperCap`
so we can use them to calculate the effective IMF