### PR TITLE
chore: use relative path

### DIFF
--- a/integration/iOS/Podfile
+++ b/integration/iOS/Podfile
@@ -4,7 +4,7 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
 def abacus_pods
-  pod 'abacus', :path => '~/v4-abacus'
+  pod 'abacus', :path => '../../v4-abacus'
   #pod 'abacus', :git => 'https://github.com/dydxprotocol/v4-abacus.git'
 end
 


### PR DESCRIPTION
sister pr to https://github.com/dydxprotocol/v4-web/pull/495

converting to building via relative path. this allows devs to have their abacus and web repos wherever they want as long as they are in the same dir, which keeps us in line with what we claim in our readme