### PR TITLE
Fix BigDecimal parsing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.0"
+version = "1.7.1"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/configs/WithdrawalCapacityProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/configs/WithdrawalCapacityProcessor.kt
@@ -19,8 +19,8 @@ internal class WithdrawalCapacityProcessor(parser: ParserProtocol) : BaseProcess
             if (limiterCapacityList.size != 2) {
                 return existing
             }
-            var dailyLimit = parser.asDecimal(parser.asMap(limiterCapacityList[0])?.get("capacity"))
-            var weeklyLimit = parser.asDecimal(parser.asMap(limiterCapacityList[1])?.get("capacity"))
+            val dailyLimit = parser.asDecimal(parser.asMap(limiterCapacityList[0])?.get("capacity"))
+            val weeklyLimit = parser.asDecimal(parser.asMap(limiterCapacityList[1])?.get("capacity"))
             if (dailyLimit != null && weeklyLimit != null) {
                 var maxWithdrawalCapacity: BigDecimal?
                 if (dailyLimit < weeklyLimit) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Parser.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Parser.kt
@@ -138,7 +138,13 @@ class Parser : ParserProtocol {
         val jsonLiteral = data as? JsonPrimitive
         if (jsonLiteral != null) {
             return if (jsonLiteral.isString) {
-                jsonLiteral.content.toBigDecimal(null, null)
+                try {
+                    jsonLiteral.content.toBigDecimal(null, null)
+                } catch (e: Exception) {
+                    Logger.e { "Failed to parse jsonLiteral: $jsonLiteral.content" }
+                    Logger.e { "Exception: $e" }
+                    null
+                }
             } else {
                 jsonLiteral.doubleOrNull?.toBigDecimal(null, null)
             }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/utils/ParserTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/utils/ParserTests.kt
@@ -1,0 +1,37 @@
+package exchange.dydx.abacus.utils
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ParserTests {
+    @Test
+    fun testAsDecimal() {
+        val parser = Parser()
+
+        var x = parser.asDecimal(1000000000000000000L)
+        assertEquals(BigDecimal.fromLong(1000000000000000000), x)
+
+        x = parser.asDecimal(100)
+        assertEquals(BigDecimal.fromLong(100), x)
+
+        x = parser.asDecimal("1000000000000000000")
+        assertEquals(BigDecimal.fromLong(1000000000000000000), x)
+
+        x = parser.asDecimal(0.00000000000000000000002034002340)
+        assertEquals(BigDecimal.parseString("0.0000000000000000000000203400234"), x)
+
+        x = parser.asDecimal("0.00000000000000000000002034002340")
+        assertEquals(BigDecimal.parseString("0.0000000000000000000000203400234"), x)
+
+        x = parser.asDecimal("invalid")
+        assertEquals(null, x)
+
+        x = parser.asDecimal(JsonPrimitive("1000000000000000000"))
+        assertEquals(BigDecimal.fromLong(1000000000000000000), x)
+
+        x = parser.asDecimal(JsonPrimitive("invalid"))
+        assertEquals(null, x)
+    }
+}

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.0'
+    spec.version                  = '1.7.1'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
When the input is a jsonLiteral but with non-numeric string, the code would crash.  It happens with WithdrawalCapacityProcessor when the validator returns invalid data.