### PR TITLE
chore(sltp): update HumanReadableTriggerOrdersPayload [place/cancel]OrderPayloads list return type

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.2"
+version = "1.7.3"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/app/helper/TriggerOrderToastGenerator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/app/helper/TriggerOrderToastGenerator.kt
@@ -133,7 +133,7 @@ class TriggerOrderToastGenerator(
         val tickSize = parser.asString(market.configs?.tickSize)
 
         val toasts = mutableListOf<Toast>()
-        responsePayload.cancelOrderPayloads?.forEach { cancelOrderPayload ->
+        responsePayload.cancelOrderPayloads.forEach { cancelOrderPayload ->
             val toast = generateForCancelOrder(
                 cancelOrderPayload,
                 takeProfitOrders,
@@ -144,7 +144,7 @@ class TriggerOrderToastGenerator(
                 toasts.add(toast)
             }
         }
-        responsePayload?.placeOrderPayloads?.forEach { placeOrderPayload ->
+        responsePayload.placeOrderPayloads.forEach { placeOrderPayload ->
             val toast = generateForPlaceOrder(
                 placeOrderPayload,
                 tickSize,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
@@ -1884,8 +1884,8 @@ open class StateManagerAdaptor(
 
     @Throws(Exception::class)
     fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload {
-        val placeOrderPayloads = mutableListOf<HumanReadablePlaceOrderPayload>()
-        val cancelOrderPayloads = mutableListOf<HumanReadableCancelOrderPayload>()
+        val placeOrderPayloads = iMutableListOf<HumanReadablePlaceOrderPayload>()
+        val cancelOrderPayloads = iMutableListOf<HumanReadableCancelOrderPayload>()
         val triggerOrders = requireNotNull(stateMachine.state?.input?.triggerOrders) { "triggerOrders input was null" }
 
         val marketId = requireNotNull(triggerOrders.marketId) { "triggerOrders.marektId was null" }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
@@ -43,6 +43,7 @@ import exchange.dydx.abacus.utils.iMapOf
 import exchange.dydx.abacus.utils.isAddressValid
 import exchange.dydx.abacus.utils.mutableMapOf
 import exchange.dydx.abacus.utils.safeSet
+import kollections.iListOf
 import kollections.toIMap
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -1049,8 +1050,8 @@ class V4StateManagerAdaptor(
                         HumanReadableTriggerOrdersPayload(
                             marketId,
                             positionSize,
-                            listOf(payload),
-                            emptyList(),
+                            iListOf(payload),
+                            iListOf(),
                         )
                     } else {
                         payload
@@ -1117,8 +1118,8 @@ class V4StateManagerAdaptor(
                         HumanReadableTriggerOrdersPayload(
                             marketId,
                             positionSize,
-                            emptyList(),
-                            listOf(payload),
+                            iListOf(),
+                            iListOf(payload),
                         )
                     } else {
                         payload

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
@@ -1,5 +1,6 @@
 package exchange.dydx.abacus.state.manager
 
+import exchange.dydx.abacus.utils.IList
 import kollections.JsExport
 import kotlinx.serialization.Serializable
 
@@ -77,8 +78,8 @@ data class HumanReadableCancelOrderPayload(
 data class HumanReadableTriggerOrdersPayload(
     val marketId: String,
     val positionSize: Double?,
-    val placeOrderPayloads: List<HumanReadablePlaceOrderPayload>,
-    val cancelOrderPayloads: List<HumanReadableCancelOrderPayload>,
+    val placeOrderPayloads: IList<HumanReadablePlaceOrderPayload>,
+    val cancelOrderPayloads: IList<HumanReadableCancelOrderPayload>,
 )
 
 @JsExport

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -601,8 +601,8 @@ internal class SubaccountSupervisor(
                     HumanReadableTriggerOrdersPayload(
                         marketId,
                         positionSize,
-                        listOf(payload),
-                        emptyList(),
+                        iListOf(payload),
+                        iListOf(),
                     )
                 } else {
                     payload
@@ -749,8 +749,8 @@ internal class SubaccountSupervisor(
                         HumanReadableTriggerOrdersPayload(
                             marketId,
                             positionSize,
-                            emptyList(),
-                            listOf(payload),
+                            iListOf(),
+                            iListOf(payload),
                         )
                     } else {
                         payload
@@ -1017,8 +1017,8 @@ internal class SubaccountSupervisor(
 
     @Throws(Exception::class)
     fun triggerOrdersPayload(currentHeight: Int?): HumanReadableTriggerOrdersPayload {
-        val placeOrderPayloads = mutableListOf<HumanReadablePlaceOrderPayload>()
-        val cancelOrderPayloads = mutableListOf<HumanReadableCancelOrderPayload>()
+        val placeOrderPayloads = iMutableListOf<HumanReadablePlaceOrderPayload>()
+        val cancelOrderPayloads = iMutableListOf<HumanReadableCancelOrderPayload>()
         val triggerOrders = requireNotNull(stateMachine.state?.input?.triggerOrders) { "triggerOrders input was null" }
 
         val marketId = requireNotNull(triggerOrders.marketId) { "triggerOrders.marketId was null" }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/helper/TriggerOrderToastGeneratorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/helper/TriggerOrderToastGeneratorTests.kt
@@ -11,6 +11,7 @@ import exchange.dydx.abacus.tests.mock.PresentationProtocolMock
 import exchange.dydx.abacus.tests.mock.ThreadingProtocolMock
 import exchange.dydx.abacus.utils.DummyFormatter
 import exchange.dydx.abacus.utils.Parser
+import kollections.iListOf
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -100,8 +101,8 @@ class TriggerOrderToastGeneratorTests {
             payload = HumanReadableTriggerOrdersPayload(
                 marketId = "ETH-USD",
                 positionSize = 94.57,
-                cancelOrderPayloads = emptyList(),
-                placeOrderPayloads = emptyList(),
+                cancelOrderPayloads = iListOf(),
+                placeOrderPayloads = iListOf(),
             ),
             state = state,
         )
@@ -112,7 +113,7 @@ class TriggerOrderToastGeneratorTests {
             payload = HumanReadableTriggerOrdersPayload(
                 marketId = "ETH-USD",
                 positionSize = 94.57,
-                cancelOrderPayloads = listOf(
+                cancelOrderPayloads = iListOf(
                     HumanReadableCancelOrderPayload(
                         subaccountNumber = 0,
                         clientId = 0,
@@ -124,7 +125,7 @@ class TriggerOrderToastGeneratorTests {
                         goodTilBlockTime = null,
                     ),
                 ),
-                placeOrderPayloads = listOf(
+                placeOrderPayloads = iListOf(
                     HumanReadablePlaceOrderPayload(
                         subaccountNumber = 0,
                         marketId = "ETH-USD",
@@ -170,8 +171,8 @@ class TriggerOrderToastGeneratorTests {
             payload = HumanReadableTriggerOrdersPayload(
                 marketId = "ETH-USD",
                 positionSize = 94.57,
-                cancelOrderPayloads = emptyList(),
-                placeOrderPayloads = emptyList(),
+                cancelOrderPayloads = iListOf(),
+                placeOrderPayloads = iListOf(),
             ),
             state = state,
         )
@@ -183,7 +184,7 @@ class TriggerOrderToastGeneratorTests {
             data = HumanReadableTriggerOrdersPayload(
                 marketId = "ETH-USD",
                 positionSize = 94.57,
-                cancelOrderPayloads = listOf(
+                cancelOrderPayloads = iListOf(
                     HumanReadableCancelOrderPayload(
                         subaccountNumber = 0,
                         clientId = 0,
@@ -195,7 +196,7 @@ class TriggerOrderToastGeneratorTests {
                         goodTilBlockTime = null,
                     ),
                 ),
-                placeOrderPayloads = emptyList(),
+                placeOrderPayloads = iListOf(),
             ),
         )
         assertEquals(presentation.showToastCallCount, 1)
@@ -213,8 +214,8 @@ class TriggerOrderToastGeneratorTests {
             data = HumanReadableTriggerOrdersPayload(
                 marketId = "ETH-USD",
                 positionSize = 94.57,
-                cancelOrderPayloads = emptyList(),
-                placeOrderPayloads = listOf(
+                cancelOrderPayloads = iListOf(),
+                placeOrderPayloads = iListOf(
                     HumanReadablePlaceOrderPayload(
                         subaccountNumber = 0,
                         marketId = "ETH-USD",
@@ -254,8 +255,8 @@ class TriggerOrderToastGeneratorTests {
             payload = HumanReadableTriggerOrdersPayload(
                 marketId = "ETH-USD",
                 positionSize = 94.57,
-                cancelOrderPayloads = emptyList(),
-                placeOrderPayloads = emptyList(),
+                cancelOrderPayloads = iListOf(),
+                placeOrderPayloads = iListOf(),
             ),
             state = state,
         )
@@ -267,7 +268,7 @@ class TriggerOrderToastGeneratorTests {
             data = HumanReadableTriggerOrdersPayload(
                 marketId = "ETH-USD",
                 positionSize = 94.57,
-                cancelOrderPayloads = listOf(
+                cancelOrderPayloads = iListOf(
                     HumanReadableCancelOrderPayload(
                         subaccountNumber = 0,
                         type = "TAKE_PROFIT",
@@ -279,7 +280,7 @@ class TriggerOrderToastGeneratorTests {
                         goodTilBlockTime = null,
                     ),
                 ),
-                placeOrderPayloads = emptyList(),
+                placeOrderPayloads = iListOf(),
             ),
         )
         assertEquals(presentation.showToastCallCount, 1)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/V4TransactionTests.kt
@@ -201,14 +201,18 @@ class V4TransactionTests : NetworkTests() {
         val ethStopLimitTriggerPrice = "3300"
         val ethStopLimitLimitPrice = "2100"
 
-        fun simulateNewBtcOrder(slTriggerPrice: String? = btcStopLossTriggerPrice, tpTriggerPrice: String? = btcTakeProfitTriggerPrice, slLimitPrice: String? = btcStopLossLimitPrice, tpLimitPrice: String? = btcTakeProfitLimitPrice): HumanReadableTriggerOrdersPayload? {
+        fun simulateNewBtcOrder(slTriggerPrice: String? = btcStopLossTriggerPrice, tpTriggerPrice: String? = btcTakeProfitTriggerPrice, slLimitPrice: String? = btcStopLossLimitPrice, tpLimitPrice: String? = btcTakeProfitLimitPrice): HumanReadableTriggerOrdersPayload {
             triggerOrdersInput("BTC-USD", slTriggerPrice, tpTriggerPrice, slLimitPrice, tpLimitPrice)
-            return v4Adapter?.commitTriggerOrders(transactionCallback)
+            val payload = v4Adapter?.commitTriggerOrders(transactionCallback)
+            requireNotNull(payload)
+            return payload
         }
 
-        fun simulateStopLimitOrderReplacement(triggerPrice: String? = ethStopLimitTriggerPrice, limitPrice: String? = ethStopLimitLimitPrice, size: String? = ethStopLimitOrderSize): HumanReadableTriggerOrdersPayload? {
+        fun simulateStopLimitOrderReplacement(triggerPrice: String? = ethStopLimitTriggerPrice, limitPrice: String? = ethStopLimitLimitPrice, size: String? = ethStopLimitOrderSize): HumanReadableTriggerOrdersPayload {
             triggerOrdersInput(marketId = "ETH-USD", stopLossTriggerPrice = triggerPrice, stopLossLimitPrice = limitPrice, stopLossOrderId = ethStopLimitOrderId, size = size)
-            return v4Adapter?.commitTriggerOrders(transactionCallback)
+            val payload = v4Adapter?.commitTriggerOrders(transactionCallback)
+            requireNotNull(payload)
+            return payload
         }
 
         fun validateMarketOrderDefaults(payload: HumanReadablePlaceOrderPayload) {
@@ -242,16 +246,16 @@ class V4TransactionTests : NetworkTests() {
 
         // Creating New Orders
         val marketOrders = simulateNewBtcOrder(slLimitPrice = null, tpLimitPrice = null) // 2 new market orders created
-        assertEquals(2, marketOrders?.placeOrderPayloads?.size)
-        marketOrders?.placeOrderPayloads?.forEach { it -> validateMarketOrderDefaults(it) }
+        assertEquals(2, marketOrders.placeOrderPayloads.size)
+        marketOrders.placeOrderPayloads.forEach { it -> validateMarketOrderDefaults(it) }
 
         assertEquals(2, transactionQueue?.size)
         assertEquals(1, transactionCalledCount)
         clearTransactions(2)
 
         val limitOrders = simulateNewBtcOrder() // 2 new limit orders created
-        assertEquals(2, limitOrders?.placeOrderPayloads?.size)
-        limitOrders?.placeOrderPayloads?.forEach { it -> validateLimitOrderDefaults(it) }
+        assertEquals(2, limitOrders.placeOrderPayloads.size)
+        limitOrders.placeOrderPayloads.forEach { it -> validateLimitOrderDefaults(it) }
 
         assertEquals(2, transactionQueue?.size)
         assertEquals(3, transactionCalledCount)
@@ -264,8 +268,9 @@ class V4TransactionTests : NetworkTests() {
         assertEquals(0, transactionQueue?.size)
 
         val replacedOrders = simulateStopLimitOrderReplacement(limitPrice = null) // Replaces order due to removing limit price (limit -> market)
-        assertEquals(1, replacedOrders?.placeOrderPayloads?.size)
-        assertEquals(1, replacedOrders?.cancelOrderPayloads?.size)
+        requireNotNull(replacedOrders)
+        assertEquals(1, replacedOrders.placeOrderPayloads.size)
+        assertEquals(1, replacedOrders.cancelOrderPayloads.size)
 
         assertEquals(2, transactionQueue?.size)
         clearTransactions(2)
@@ -284,7 +289,7 @@ class V4TransactionTests : NetworkTests() {
 
         // Canceling Existing Orders
         val cancelledOrders = simulateStopLimitOrderReplacement(triggerPrice = null, limitPrice = null) // Cancels existing order due to null price inputs
-        assertEquals(1, cancelledOrders?.cancelOrderPayloads?.size)
+        assertEquals(1, cancelledOrders.cancelOrderPayloads.size)
         assertEquals(1, transactionQueue?.size)
     }
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -227,15 +227,13 @@ class V4TransactionTests : NetworkTests() {
         fun simulateNewBtcOrder(slTriggerPrice: String? = btcStopLossTriggerPrice, tpTriggerPrice: String? = btcTakeProfitTriggerPrice, slLimitPrice: String? = btcStopLossLimitPrice, tpLimitPrice: String? = btcTakeProfitLimitPrice): HumanReadableTriggerOrdersPayload {
             triggerOrdersInput("BTC-USD", slTriggerPrice, tpTriggerPrice, slLimitPrice, tpLimitPrice)
             val payload = subaccountSupervisor?.commitTriggerOrders(0, transactionCallback)
-            requireNotNull(payload)
-            return payload
+            return requireNotNull(payload)
         }
 
         fun simulateStopLimitOrderReplacement(triggerPrice: String? = ethStopLimitTriggerPrice, limitPrice: String? = ethStopLimitLimitPrice, size: String? = ethStopLimitOrderSize): HumanReadableTriggerOrdersPayload {
             triggerOrdersInput(marketId = "ETH-USD", stopLossTriggerPrice = triggerPrice, stopLossLimitPrice = limitPrice, stopLossOrderId = ethStopLimitOrderId, size = size)
             val payload = subaccountSupervisor?.commitTriggerOrders(0, transactionCallback)
-            requireNotNull(payload)
-            return payload
+            return requireNotNull(payload)
         }
 
         fun validateMarketOrderDefaults(payload: HumanReadablePlaceOrderPayload) {

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -224,14 +224,18 @@ class V4TransactionTests : NetworkTests() {
         val ethStopLimitTriggerPrice = "3300"
         val ethStopLimitLimitPrice = "2100"
 
-        fun simulateNewBtcOrder(slTriggerPrice: String? = btcStopLossTriggerPrice, tpTriggerPrice: String? = btcTakeProfitTriggerPrice, slLimitPrice: String? = btcStopLossLimitPrice, tpLimitPrice: String? = btcTakeProfitLimitPrice): HumanReadableTriggerOrdersPayload? {
+        fun simulateNewBtcOrder(slTriggerPrice: String? = btcStopLossTriggerPrice, tpTriggerPrice: String? = btcTakeProfitTriggerPrice, slLimitPrice: String? = btcStopLossLimitPrice, tpLimitPrice: String? = btcTakeProfitLimitPrice): HumanReadableTriggerOrdersPayload {
             triggerOrdersInput("BTC-USD", slTriggerPrice, tpTriggerPrice, slLimitPrice, tpLimitPrice)
-            return subaccountSupervisor?.commitTriggerOrders(0, transactionCallback)
+            val payload = subaccountSupervisor?.commitTriggerOrders(0, transactionCallback)
+            requireNotNull(payload)
+            return payload
         }
 
-        fun simulateStopLimitOrderReplacement(triggerPrice: String? = ethStopLimitTriggerPrice, limitPrice: String? = ethStopLimitLimitPrice, size: String? = ethStopLimitOrderSize): HumanReadableTriggerOrdersPayload? {
+        fun simulateStopLimitOrderReplacement(triggerPrice: String? = ethStopLimitTriggerPrice, limitPrice: String? = ethStopLimitLimitPrice, size: String? = ethStopLimitOrderSize): HumanReadableTriggerOrdersPayload {
             triggerOrdersInput(marketId = "ETH-USD", stopLossTriggerPrice = triggerPrice, stopLossLimitPrice = limitPrice, stopLossOrderId = ethStopLimitOrderId, size = size)
-            return subaccountSupervisor?.commitTriggerOrders(0, transactionCallback)
+            val payload = subaccountSupervisor?.commitTriggerOrders(0, transactionCallback)
+            requireNotNull(payload)
+            return payload
         }
 
         fun validateMarketOrderDefaults(payload: HumanReadablePlaceOrderPayload) {
@@ -265,16 +269,16 @@ class V4TransactionTests : NetworkTests() {
 
         // Creating New Orders
         val marketOrders = simulateNewBtcOrder(slLimitPrice = null, tpLimitPrice = null) // 2 new market orders created
-        assertEquals(2, marketOrders?.placeOrderPayloads?.size)
-        marketOrders?.placeOrderPayloads?.forEach { it -> validateMarketOrderDefaults(it) }
+        assertEquals(2, marketOrders.placeOrderPayloads.size)
+        marketOrders.placeOrderPayloads.forEach { it -> validateMarketOrderDefaults(it) }
 
         assertEquals(2, transactionQueue?.size)
         assertEquals(1, transactionCalledCount)
         clearTransactions(2)
 
         val limitOrders = simulateNewBtcOrder() // 2 new limit orders created
-        assertEquals(2, limitOrders?.placeOrderPayloads?.size)
-        limitOrders?.placeOrderPayloads?.forEach { it -> validateLimitOrderDefaults(it) }
+        assertEquals(2, limitOrders.placeOrderPayloads.size)
+        limitOrders.placeOrderPayloads.forEach { it -> validateLimitOrderDefaults(it) }
 
         assertEquals(2, transactionQueue?.size)
         assertEquals(3, transactionCalledCount)
@@ -286,8 +290,8 @@ class V4TransactionTests : NetworkTests() {
         assertEquals(0, transactionQueue?.size)
 
         val replacedOrders = simulateStopLimitOrderReplacement(limitPrice = null) // Replaces order due to removing limit price (limit -> market)
-        assertEquals(1, replacedOrders?.placeOrderPayloads?.size)
-        assertEquals(1, replacedOrders?.cancelOrderPayloads?.size)
+        assertEquals(1, replacedOrders.placeOrderPayloads.size)
+        assertEquals(1, replacedOrders.cancelOrderPayloads.size)
 
         assertEquals(2, transactionQueue?.size)
         clearTransactions(2)
@@ -306,7 +310,7 @@ class V4TransactionTests : NetworkTests() {
 
         // Canceling Existing Orders
         val cancelledOrders = simulateStopLimitOrderReplacement(triggerPrice = null, limitPrice = null) // Cancels existing order due to null price inputs
-        assertEquals(1, cancelledOrders?.cancelOrderPayloads?.size)
+        assertEquals(1, cancelledOrders.cancelOrderPayloads.size)
         assertEquals(1, transactionQueue?.size)
     }
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.2'
+    spec.version                  = '1.7.3'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
context: comment here: https://github.com/dydxprotocol/v4-web/pull/496#discussion_r1589768792

[Update](https://github.com/dydxprotocol/v4-abacus/pull/341/files#diff-11a8cac3e8953445d9f31efa06c9797a6fa600812b158940ccd407f839c7feeeL80) abacus to return `kollections.List` instead of `kotlin.collections.List` so that the web code can use `toArray()` (instead of some janky conversion).
- Involved updating `listOf` to `iListOf` 
- Cleaned up some `?.` checks

### Testing
- built locally on FE and confirmed everything works 👍 
- unsure how to test on mobile / if edits need to be made