### PR TITLE
v1.7.6: sort squid asset + chain list alphabetically

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.5"
+version = "1.7.6"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
@@ -82,6 +82,7 @@ data class DepositInputOptions(
                 return if (existing?.needsSize != needsSize ||
                     existing?.needsAddress != needsAddress ||
                     existing?.needsFastSpeed != needsFastSpeed ||
+                    existing?.exchanges != exchanges ||
                     existing?.chains != chains ||
                     existing?.assets != assets
                 ) {
@@ -168,6 +169,7 @@ data class WithdrawalInputOptions(
                 return if (existing?.needsSize != needsSize ||
                     existing?.needsAddress != needsAddress ||
                     existing?.needsFastSpeed != needsFastSpeed ||
+                    existing?.exchanges != exchanges ||
                     existing?.chains != chains ||
                     existing?.assets != assets
                 ) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/squid/SquidProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/squid/SquidProcessor.kt
@@ -25,6 +25,7 @@ internal class SquidProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
             modified = it.mutable()
         }
         val chainOptions = chainOptions()
+
         modified.safeSet("transfer.depositOptions.chains", chainOptions)
         modified.safeSet("transfer.withdrawalOptions.chains", chainOptions)
         val selectedChainId = defaultChainId()
@@ -65,7 +66,6 @@ internal class SquidProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
         if (this.chains != null && this.tokens != null) {
             return existing
         }
-
         this.chains = parser.asNativeList(payload["chains"])
         this.tokens = parser.asNativeList(payload["tokens"])
 
@@ -74,6 +74,7 @@ internal class SquidProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
             modified = it.mutable()
         }
         val chainOptions = chainOptions()
+
         modified.safeSet("transfer.depositOptions.chains", chainOptions)
         modified.safeSet("transfer.withdrawalOptions.chains", chainOptions)
         val selectedChainId = defaultChainId()
@@ -162,8 +163,9 @@ internal class SquidProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
     }
 
     private fun updateTokensDefaults(modified: MutableMap<String, Any>, selectedChainId: String?) {
-        modified.safeSet("transfer.depositOptions.assets", tokenOptions(selectedChainId))
-        modified.safeSet("transfer.withdrawalOptions.assets", tokenOptions(selectedChainId))
+        val tokenOptions = tokenOptions(selectedChainId)
+        modified.safeSet("transfer.depositOptions.assets", tokenOptions)
+        modified.safeSet("transfer.withdrawalOptions.assets", tokenOptions)
         modified.safeSet("transfer.token", defaultTokenAddress(selectedChainId))
         modified.safeSet("transfer.resources.tokenResources", tokenResources(selectedChainId))
     }
@@ -266,6 +268,7 @@ internal class SquidProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
             }
         }
 
+        options.sortBy { parser.asString(parser.asNativeMap(it)?.get("stringKey")) }
         return options
     }
 
@@ -287,6 +290,7 @@ internal class SquidProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
             }
         }
 
+        options.sortBy { parser.asString(parser.asNativeMap(it)?.get("stringKey")) }
         return options
     }
 }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.5'
+    spec.version                  = '1.7.6'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Sorted in abacus so both mobile + web get this change. 

Seemed like `SquidProcessor` was the most logical place to do this - but also open to better ideas 🤔 

## Testing
Pulled and built locally into web and verified that asset options are alphabetical
<img width="603" alt="Screenshot 2024-05-09 at 12 31 36 PM" src="https://github.com/dydxprotocol/v4-abacus/assets/70078372/cd4c82f2-e3e3-4e53-8eab-d6e5d99bd46b">

