### PR TITLE
[analytics] track order status changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.8"
+version = "1.7.9"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
@@ -221,6 +221,15 @@ enum class AnalyticsEvent(val rawValue: String) {
     TradeCancelOrderConfirmed("TradeCancelOrderConfirmed"),
     TradePlaceOrderConfirmed("TradePlaceOrderConfirmed"),
 
+    // Order status change
+    TradePlaceOrderStatusCanceled("TradePlaceOrderStatusCanceled"),
+    TradePlaceOrderStatusCanceling("TradePlaceOrderStatusCanceling"),
+    TradePlaceOrderStatusFilled("TradePlaceOrderStatusFilled"),
+    TradePlaceOrderStatusOpen("TradePlaceOrderStatusOpen"),
+    TradePlaceOrderStatusPending("TradePlaceOrderStatusPending"),
+    TradePlaceOrderStatusUntriggered("TradePlaceOrderStatusUntriggered"),
+    TradePlaceOrderStatusPartiallyFilled("TradePlaceOrderStatusPartiallyFilled"),
+
     // Trigger Order
     TriggerOrderClick("TriggerOrderClick"),
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
@@ -10,6 +10,7 @@ import exchange.dydx.abacus.output.Restriction
 import exchange.dydx.abacus.output.SubaccountOrder
 import exchange.dydx.abacus.output.TransferRecordType
 import exchange.dydx.abacus.output.UsageRestriction
+import exchange.dydx.abacus.output.input.OrderStatus
 import exchange.dydx.abacus.output.input.OrderType
 import exchange.dydx.abacus.output.input.TradeInputGoodUntil
 import exchange.dydx.abacus.output.input.TriggerOrder
@@ -2400,16 +2401,41 @@ open class StateManagerAdaptor(
                         trackingParams(interval),
                         fromSlTpDialogParams(placeOrderRecord.fromSlTpDialog),
                     )
-                    tracking(
-                        AnalyticsEvent.TradePlaceOrderConfirmed.rawValue,
-                        ParsingHelper.merge(
-                            extraParams,
-                            orderAnalyticsPayload,
-                        )?.toIMap(),
-                    )
-                    placeOrderRecords.remove(placeOrderRecord)
+                    val analyticsPayload = ParsingHelper.merge(extraParams, orderAnalyticsPayload)?.toIMap()
+
+                    if (placeOrderRecord.lastOrderStatus != order.status) {
+                        // when order is first indexed
+                        if (placeOrderRecord.lastOrderStatus == null) {
+                            tracking(
+                                AnalyticsEvent.TradePlaceOrderConfirmed.rawValue,
+                                analyticsPayload,
+                            )
+                        }
+
+                        val orderStatusChangeEvent = when (order.status) {
+                            OrderStatus.cancelled -> AnalyticsEvent.TradePlaceOrderStatusCanceled
+                            OrderStatus.canceling -> AnalyticsEvent.TradePlaceOrderStatusCanceling
+                            OrderStatus.filled -> AnalyticsEvent.TradePlaceOrderStatusFilled
+                            OrderStatus.open -> AnalyticsEvent.TradePlaceOrderStatusOpen
+                            OrderStatus.pending -> AnalyticsEvent.TradePlaceOrderStatusPending
+                            OrderStatus.untriggered -> AnalyticsEvent.TradePlaceOrderStatusUntriggered
+                            OrderStatus.partiallyFilled -> AnalyticsEvent.TradePlaceOrderStatusPartiallyFilled
+                        }
+
+                        tracking(orderStatusChangeEvent.rawValue, analyticsPayload)
+
+                        when (order.status) {
+                            // order reaches final state, can remove / skip further tracking
+                            OrderStatus.cancelled, OrderStatus.filled -> {
+                                placeOrderRecords.remove(placeOrderRecord)
+                            }
+                            else -> {}
+                        }
+                        placeOrderRecord.lastOrderStatus = order.status
+                    }
                     break
                 }
+
                 val cancelOrderRecord = cancelOrderRecords.firstOrNull {
                     it.clientId == order.clientId
                 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/V4StateManagerAdaptor.kt
@@ -1034,6 +1034,7 @@ class V4StateManagerAdaptor(
                             clientId,
                             submitTimeMs,
                             fromSlTpDialog = isTriggerOrder,
+                            lastOrderStatus = null,
                         ),
                     )
                 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
@@ -1,5 +1,6 @@
 package exchange.dydx.abacus.state.manager
 
+import exchange.dydx.abacus.output.input.OrderStatus
 import exchange.dydx.abacus.utils.IList
 import kollections.JsExport
 import kotlinx.serialization.Serializable
@@ -20,6 +21,7 @@ data class PlaceOrderRecord(
     val clientId: Int,
     val timestampInMilliseconds: Double,
     val fromSlTpDialog: Boolean,
+    var lastOrderStatus: OrderStatus?,
 )
 
 data class CancelOrderRecord(

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.8'
+    spec.version                  = '1.7.9'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
- better tracking of round trip time (e.g. a short term order being filled vs. just indexed)
- also useful for other future tracking (how often is an order filled during the same FE session)

tested locally:
<img width="1101" alt="image" src="https://github.com/dydxprotocol/v4-abacus/assets/9400120/26694ee9-4604-456c-a086-8cd2d446e49e">
