### PR TITLE
v1.7.21: Fix mock data, fix subaccountNumber generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.20"
+version = "1.7.21"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
@@ -779,7 +779,7 @@ data class TradeInput(
     val postOnly: Boolean,
     val fee: Double?,
     val marginMode: MarginMode,
-    val targetLeverage: Double?,
+    val targetLeverage: Double,
     val bracket: TradeInputBracket?,
     val marketOrder: TradeInputMarketOrder?,
     val options: TradeInputOptions?,
@@ -818,7 +818,7 @@ data class TradeInput(
                     MarginMode.invoke(it)
                 } ?: MarginMode.cross
 
-                val targetLeverage = parser.asDouble(data["targetLeverage"])
+                val targetLeverage = parser.asDouble(data["targetLeverage"]) ?: 1.0
 
                 val goodTil = TradeInputGoodUntil.create(
                     existing?.goodTil,
@@ -859,7 +859,7 @@ data class TradeInput(
                     existing.postOnly != postOnly ||
                     existing.fee != fee ||
                     existing.marginMode != marginMode ||
-                    existing?.targetLeverage != targetLeverage ||
+                    existing.targetLeverage != targetLeverage ||
                     existing.bracket != bracket ||
                     existing.marketOrder != marketOrder ||
                     existing.options != options ||

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -57,6 +57,7 @@ import exchange.dydx.abacus.utils.GoodTil
 import exchange.dydx.abacus.utils.IList
 import exchange.dydx.abacus.utils.IMap
 import exchange.dydx.abacus.utils.IMutableList
+import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.MAX_SUBACCOUNT_NUMBER
 import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
 import exchange.dydx.abacus.utils.ParsingHelper
@@ -511,7 +512,7 @@ internal class SubaccountSupervisor(
             val openPositions = it.value.openPositions
             val openOrders = it.value.orders?.filter { order ->
                 val status = helper.parser.asString(order.status)
-                status == "OPEN"
+                status == "open" || status == "pending" || status == "untriggered" || status == "partiallyFilled"
             }
 
             val postionMarketIds = openPositions?.map { position ->
@@ -541,7 +542,7 @@ internal class SubaccountSupervisor(
         }
 
         // Find new childSubaccount number available for Isolated Margin Trade
-        val existingSubaccountNumbers = utilizedSubaccountsMarketIdMap?.keys ?: iListOf(subaccountNumber)
+        val existingSubaccountNumbers = utilizedSubaccountsMarketIdMap?.keys ?: iListOf(subaccountNumber.toString())
         for (offset in NUM_PARENT_SUBACCOUNTS..MAX_SUBACCOUNT_NUMBER step NUM_PARENT_SUBACCOUNTS) {
             val tentativeSubaccountNumber = offset + subaccountNumber
             if (!existingSubaccountNumbers.contains(tentativeSubaccountNumber.toString())) {

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -350,9 +350,9 @@ class V4TransactionTests : NetworkTests() {
         testWebSocket?.simulateReceived(mock.connectionMock.connectedMessage)
         testWebSocket?.simulateReceived(mock.marketsChannel.v4_subscribed_r1)
 
-        stateManager.setAddresses(null, "dydx199tqg4wdlnu4qjlxchpd7seg454937hjrknju4")
-        testWebSocket?.simulateReceived(mock.parentSubaccountsChannel.subscribed)
-        testWebSocket?.simulateReceived(mock.parentSubaccountsChannel.channel_data)
+        stateManager.setAddresses(null, "dydx155va0m7wz5n8zcqscn9afswwt04n4usj46wvp5")
+        testWebSocket?.simulateReceived(mock.v4ParentSubaccountsMock.subscribed)
+        testWebSocket?.simulateReceived(mock.v4ParentSubaccountsMock.channel_batch_data)
 
         stateManager.market = "ETH-USD"
     }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AbacusMockData.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AbacusMockData.kt
@@ -48,6 +48,7 @@ class AbacusMockData {
     internal val localizationMock = LocalizationMock()
     internal val launchIncentiveMock = LaunchIncentiveMock()
     internal val v4OnChainMock = V4OnChainMock()
+    internal val v4ParentSubaccountsMock = V4ParentSubaccountsMock()
     internal val v4WithdrawalSafetyChecksMock = V4WithdrawalSafetyChecksMock()
     internal val v4Environment = V4Environment(
         "test",

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/V4ParentSubaccountsMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/V4ParentSubaccountsMock.kt
@@ -1,0 +1,158 @@
+package exchange.dydx.abacus.tests.payloads
+
+import kollections.JsExport
+import kotlinx.serialization.Serializable
+
+@Suppress("PropertyName")
+@JsExport
+@Serializable
+internal class V4ParentSubaccountsMock {
+    internal val subscribed = """
+        {
+            "type": "subscribed",
+            "connection_id": "83f3d084-f1bb-4506-8f56-96f2f2f69017",
+            "message_id": 2,
+            "channel": "v4_parent_subaccounts",
+            "id": "dydx155va0m7wz5n8zcqscn9afswwt04n4usj46wvp5/0",
+            "contents": {
+                "subaccount": {
+                    "address": "dydx155va0m7wz5n8zcqscn9afswwt04n4usj46wvp5",
+                    "parentSubaccountNumber": 0,
+                    "equity": "200",
+                    "freeCollateral": "200",
+                    "childSubaccounts": [
+                        {
+                            "address": "dydx155va0m7wz5n8zcqscn9afswwt04n4usj46wvp5",
+                            "subaccountNumber": 0,
+                            "equity": "50.5",
+                            "freeCollateral": "50.5",
+                            "openPerpetualPositions": {},
+                            "assetPositions": {
+                                "USDC": {
+                                    "size": "50.5",
+                                    "symbol": "USDC",
+                                    "side": "LONG",
+                                    "assetId": "0",
+                                    "subaccountNumber": 0
+                                }
+                            },
+                            "marginEnabled": true,
+                            "updatedAtHeight": "17689"
+                        },
+                        {
+                            "address": "dydx155va0m7wz5n8zcqscn9afswwt04n4usj46wvp5",
+                            "subaccountNumber": 128,
+                            "equity": "149.5",
+                            "freeCollateral": "149.5",
+                            "openPerpetualPositions": {},
+                            "assetPositions": {
+                                "USDC": {
+                                    "size": "149.5",
+                                    "symbol": "USDC",
+                                    "side": "LONG",
+                                    "assetId": "0",
+                                    "subaccountNumber": 128
+                                }
+                            },
+                            "marginEnabled": true,
+                            "updatedAtHeight": "17689"
+                        }
+                    ]
+                },
+                "orders": [
+                    {
+                        "id": "683bc8c4-ed8c-5c3c-86c0-4d0a2d74aa31",
+                        "subaccountId": "b456e984-b4bc-5ad2-8662-6b8378c7e0ad",
+                        "clientId": "6681712",
+                        "clobPairId": "22",
+                        "side": "BUY",
+                        "size": "10",
+                        "totalFilled": "0",
+                        "price": "1",
+                        "type": "LIMIT",
+                        "status": "OPEN",
+                        "timeInForce": "GTT",
+                        "reduceOnly": false,
+                        "orderFlags": "64",
+                        "goodTilBlockTime": "2024-06-13T23:35:58.000Z",
+                        "createdAtHeight": "17691",
+                        "clientMetadata": "0",
+                        "updatedAt": "2024-05-16T23:35:57.872Z",
+                        "updatedAtHeight": "17691",
+                        "postOnly": false,
+                        "ticker": "APE-USD",
+                        "subaccountNumber": 0
+                    },
+                    {
+                        "id": "24b68694-d6ae-5df4-baf5-55b0716296e9",
+                        "subaccountId": "b456e984-b4bc-5ad2-8662-6b8378c7e0ad",
+                        "clientId": "1616027290",
+                        "clobPairId": "6",
+                        "side": "BUY",
+                        "size": "40",
+                        "totalFilled": "0",
+                        "price": "0.44",
+                        "type": "LIMIT",
+                        "status": "OPEN",
+                        "timeInForce": "GTT",
+                        "reduceOnly": false,
+                        "orderFlags": "64",
+                        "goodTilBlockTime": "2024-06-13T20:20:15.000Z",
+                        "createdAtHeight": "6603",
+                        "clientMetadata": "0",
+                        "updatedAt": "2024-05-16T20:20:15.399Z",
+                        "updatedAtHeight": "6603",
+                        "postOnly": false,
+                        "ticker": "ADA-USD",
+                        "subaccountNumber": 128
+                    }
+                ]
+            }
+        }
+    """.trimIndent()
+
+    internal val channel_batch_data = """
+        {
+          "type": "channel_batch_data",
+          "connection_id": "83f3d084-f1bb-4506-8f56-96f2f2f69017",
+          "message_id": 29,
+          "id": "dydx155va0m7wz5n8zcqscn9afswwt04n4usj46wvp5/0",
+          "channel": "v4_parent_subaccounts",
+          "version": "2.4.0",
+          "contents": [
+            {
+              "assetPositions": [
+                {
+                  "address": "dydx155va0m7wz5n8zcqscn9afswwt04n4usj46wvp5",
+                  "subaccountNumber": 0,
+                  "positionId": "2314ffd5-6723-54c7-ab87-7b292ae14ee1",
+                  "assetId": "0",
+                  "symbol": "USDC",
+                  "side": "LONG",
+                  "size": "46"
+                }
+              ]
+            },
+            {
+              "transfers": {
+                "sender": {
+                  "address": "dydx155va0m7wz5n8zcqscn9afswwt04n4usj46wvp5",
+                  "subaccountNumber": 0
+                },
+                "recipient": {
+                  "address": "dydx155va0m7wz5n8zcqscn9afswwt04n4usj46wvp5",
+                  "subaccountNumber": 128
+                },
+                "symbol": "USDC",
+                "size": "4.5",
+                "type": "TRANSFER_OUT",
+                "createdAt": "2024-05-17T04:02:07.208Z",
+                "createdAtHeight": "32866",
+                "transactionHash": "72E80E605FAD46FF82C8C7AE2260519ACB73F5900A8F340ABBF190E84C2C4DFC"
+              }
+            }
+          ],
+          "subaccountNumber": 0
+        }
+    """.trimIndent()
+}

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.20'
+    spec.version                  = '1.7.21'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
- Add a default `targetLeverage` -> 1.0
- Fix filter conditional within `getChildSubaccountNumberForIsolatedMarginTrade`
- Add mock data with deployed schema and use in `V4TransactionTest`