### PR TITLE
MOB-514 : add `expiresAt` at to abacus

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.28"
+version = "1.7.29"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Compliance.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Compliance.kt
@@ -29,4 +29,5 @@ data class Compliance(
     val geo: String?,
     val status: ComplianceStatus,
     val updatedAt: String?,
+    val expiresAt: String?,
 )

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Enviroment.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Enviroment.kt
@@ -68,6 +68,7 @@ data class EnvironmentLinks(
     val launchIncentive: String?,
     val statusPage: String?,
     val withdrawalGateLearnMore: String?,
+    val complianceSupportEmail: String?,
 ) {
     companion object {
         fun parse(
@@ -86,6 +87,7 @@ data class EnvironmentLinks(
             val launchIncentive = parser.asString(data["launchIncentive"])
             val statusPage = parser.asString(data["statusPage"])
             val withdrawalGateLearnMore = parser.asString(data["withdrawalGateLearnMore"])
+            val complianceSupportEmail = parser.asString(data["complianceSupportEmail"])
             return EnvironmentLinks(
                 tos,
                 privacy,
@@ -99,6 +101,7 @@ data class EnvironmentLinks(
                 launchIncentive,
                 statusPage,
                 withdrawalGateLearnMore,
+                complianceSupportEmail,
             )
         }
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
@@ -81,6 +81,7 @@ import exchange.dydx.abacus.utils.IMap
 import exchange.dydx.abacus.utils.IMutableList
 import exchange.dydx.abacus.utils.IOImplementations
 import exchange.dydx.abacus.utils.JsonEncoder
+import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.Parser
 import exchange.dydx.abacus.utils.ParsingHelper
 import exchange.dydx.abacus.utils.SHORT_TERM_ORDER_DURATION
@@ -262,7 +263,7 @@ open class StateManagerAdaptor(
             }
         }
 
-    private var compliance: Compliance = Compliance(null, ComplianceStatus.COMPLIANT, null)
+    private var compliance: Compliance = Compliance(null, ComplianceStatus.COMPLIANT, null, null)
         set(value) {
             if (field != value) {
                 field = value
@@ -2518,42 +2519,36 @@ open class StateManagerAdaptor(
                 null,
                 null,
                 callback = { _, response, httpCode, _ ->
-                    compliance = if (success(httpCode) && response != null) {
+                    var geo: String? = null
+                    if (success(httpCode) && response != null) {
                         val payload = parser.decodeJsonObject(response)?.toIMap()
-                        if (payload != null) {
-                            val country = parser.asString(parser.value(payload, "geo.country"))
-                            Compliance(country, compliance.status, compliance.updatedAt)
-                        } else {
-                            Compliance(null, compliance.status, compliance.updatedAt)
-                        }
-                    } else {
-                        Compliance(null, compliance.status, compliance.updatedAt)
+                        geo = parser.asString(payload?.get("geo"))
                     }
+                    compliance = Compliance(geo, compliance.status, compliance.updatedAt, compliance.expiresAt)
                 },
             )
         }
     }
 
     private fun handleComplianceResponse(response: String?, httpCode: Int): ComplianceStatus {
-        compliance = if (success(httpCode) && response != null) {
+        var complianceStatus = ComplianceStatus.UNKNOWN
+        var updatedAt: String? = null
+        var expiresAt: String? = null
+        if (success(httpCode) && response != null) {
             val res = parser.decodeJsonObject(response)?.toIMap()
-            if (res != null) {
-                val status = parser.asString(res["status"])
-                val updatedAt = parser.asString(res["updatedAt"])
-                val complianceStatus =
-                    if (status != null) {
-                        ComplianceStatus.valueOf(status)
-                    } else {
-                        ComplianceStatus.UNKNOWN
-                    }
-                Compliance(compliance.geo, complianceStatus, updatedAt ?: compliance.updatedAt)
-            } else {
-                Compliance(compliance.geo, ComplianceStatus.UNKNOWN, compliance.updatedAt)
+            complianceStatus = parser.asString(res?.get("status"))?.let { ComplianceStatus.valueOf(it) } ?: ComplianceStatus.UNKNOWN
+            updatedAt = parser.asString(res?.get("updatedAt"))
+            if (updatedAt != null) {
+                expiresAt = try {
+                    Instant.parse(updatedAt).plus(7.days).toString()
+                } catch (e: Exception) {
+                    Logger.e { "Error parsing compliance updatedAt: $updatedAt" }
+                    null
+                }
             }
-        } else {
-            Compliance(compliance.geo, ComplianceStatus.UNKNOWN, compliance.updatedAt)
         }
-        return compliance.status
+        compliance = Compliance(compliance.geo, complianceStatus, updatedAt, expiresAt)
+        return complianceStatus
     }
 
     private fun updateCompliance(address: DydxAddress, status: ComplianceStatus, complianceAction: ComplianceAction) {
@@ -2603,10 +2598,10 @@ open class StateManagerAdaptor(
                         },
                     )
                 } else {
-                    compliance = Compliance(compliance.geo, ComplianceStatus.UNKNOWN, compliance.updatedAt)
+                    compliance = Compliance(compliance.geo, ComplianceStatus.UNKNOWN, compliance.updatedAt, compliance.expiresAt)
                 }
             } else {
-                compliance = Compliance(compliance.geo, ComplianceStatus.UNKNOWN, compliance.updatedAt)
+                compliance = Compliance(compliance.geo, ComplianceStatus.UNKNOWN, compliance.updatedAt, compliance.expiresAt)
             }
         }
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
@@ -2524,7 +2524,7 @@ open class StateManagerAdaptor(
                         val payload = parser.decodeJsonObject(response)?.toIMap()
                         geo = parser.asString(payload?.get("geo"))
                     }
-                    compliance = Compliance(geo, compliance.status, compliance.updatedAt, compliance.expiresAt)
+                    compliance = compliance.copy(geo = geo)
                 },
             )
         }
@@ -2547,7 +2547,7 @@ open class StateManagerAdaptor(
                 }
             }
         }
-        compliance = Compliance(compliance.geo, complianceStatus, updatedAt, expiresAt)
+        compliance = compliance.copy(status = complianceStatus, updatedAt = updatedAt, expiresAt = expiresAt)
         return complianceStatus
     }
 
@@ -2598,10 +2598,10 @@ open class StateManagerAdaptor(
                         },
                     )
                 } else {
-                    compliance = Compliance(compliance.geo, ComplianceStatus.UNKNOWN, compliance.updatedAt, compliance.expiresAt)
+                    compliance = compliance.copy(status = ComplianceStatus.UNKNOWN)
                 }
             } else {
-                compliance = Compliance(compliance.geo, ComplianceStatus.UNKNOWN, compliance.updatedAt, compliance.expiresAt)
+                compliance = compliance.copy(status = ComplianceStatus.UNKNOWN)
             }
         }
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
@@ -497,10 +497,6 @@ open class TradingStateMachine(
                 }
             }
 
-            "/v4/compliance/geoblock" -> {
-                print("compliance")
-            }
-
             else -> {
                 if (url.path.contains("/v3/historical-funding/") || url.path.contains("/v4/historicalFunding/")) {
                     changes = historicalFundings(payload)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
@@ -441,6 +441,9 @@ open class TradingStateMachine(
         return Pair(market, resolution)
     }
 
+    /**
+     * function specifically for testing spoofed rest response processing
+     */
     fun rest(
         url: AbUrl,
         payload: String,
@@ -492,6 +495,11 @@ open class TradingStateMachine(
                 if (deploymentUri != null) {
                     changes = configurations(payload, subaccountNumber, deploymentUri)
                 }
+            }
+
+            "/v4/compliance/geoblock" -> {
+                print("compliance")
+//                this.state.compliance = compliance(payload)
             }
 
             else -> {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
@@ -499,7 +499,6 @@ open class TradingStateMachine(
 
             "/v4/compliance/geoblock" -> {
                 print("compliance")
-//                this.state.compliance = compliance(payload)
             }
 
             else -> {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
@@ -671,7 +671,7 @@ internal class StateManagerAdaptorV2(
             state?.transferStatuses,
             state?.restriction,
             state?.launchIncentive,
-            Compliance(geo, state?.compliance?.status ?: ComplianceStatus.COMPLIANT, state?.compliance?.updatedAt),
+            Compliance(geo, state?.compliance?.status ?: ComplianceStatus.COMPLIANT, state?.compliance?.updatedAt, state?.compliance?.expiresAt),
         )
         ioImplementations.threading?.async(ThreadingType.main) {
             stateNotification?.stateChanged(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -912,7 +912,7 @@ internal open class AccountSupervisor(
             state?.transferStatuses,
             state?.restriction,
             state?.launchIncentive,
-            compliance,
+            Compliance(state?.compliance?.geo, compliance.status, compliance.updatedAt, compliance.expiresAt),
         )
         helper.ioImplementations.threading?.async(ThreadingType.main) {
             helper.stateNotification?.stateChanged(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -604,7 +604,7 @@ internal open class AccountSupervisor(
             if (updatedAt != null) {
                 expiresAt = try {
                     Instant.parse(updatedAt).plus(7.days).toString()
-                } catch (e: Exception) {
+                } catch (e: IllegalArgumentException) {
                     Logger.e { "Error parsing compliance updatedAt: $updatedAt" }
                     null
                 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -610,7 +610,7 @@ internal open class AccountSupervisor(
                 }
             }
         }
-        compliance = Compliance(compliance.geo, complianceStatus, updatedAt, expiresAt)
+        compliance = compliance.copy(status = complianceStatus, updatedAt = updatedAt, expiresAt = expiresAt)
         return complianceStatus
     }
 
@@ -662,10 +662,10 @@ internal open class AccountSupervisor(
                         },
                     )
                 } else {
-                    compliance = Compliance(compliance.geo, ComplianceStatus.UNKNOWN, compliance.updatedAt, compliance.expiresAt)
+                    compliance = compliance.copy(status = ComplianceStatus.UNKNOWN)
                 }
             } else {
-                compliance = Compliance(compliance.geo, ComplianceStatus.UNKNOWN, compliance.updatedAt, compliance.expiresAt)
+                compliance = compliance.copy(status = ComplianceStatus.UNKNOWN)
             }
         }
     }
@@ -912,7 +912,7 @@ internal open class AccountSupervisor(
             state?.transferStatuses,
             state?.restriction,
             state?.launchIncentive,
-            Compliance(state?.compliance?.geo, compliance.status, compliance.updatedAt, compliance.expiresAt),
+            compliance,
         )
         helper.ioImplementations.threading?.async(ThreadingType.main) {
             helper.stateNotification?.stateChanged(

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/TestFactory.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/TestFactory.kt
@@ -313,6 +313,7 @@ class TestChain : DYDXChainTransactionsProtocol {
     var cancelOrderResponse: String? = null
     var depositResponse: String? = null
     var withdrawResponse: String? = null
+    var signCompliancePayload: String? = null
 
     var transactionCallback: ((response: String?) -> Unit)? = null
 
@@ -377,7 +378,19 @@ class TestChain : DYDXChainTransactionsProtocol {
                 withdraw(paramsInJson!!, callback)
             }
 
+            TransactionType.SignCompliancePayload -> {
+                signCompliancePayload(paramsInJson!!, callback)
+            }
+
             else -> {}
+        }
+    }
+
+    fun signCompliancePayload(json: String, callback: (response: String?) -> Unit) {
+        if (signCompliancePayload != null) {
+            callback(signCompliancePayload)
+        } else {
+            callback(dummyError)
         }
     }
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/V4RestrictionsTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/V4RestrictionsTests.kt
@@ -4,7 +4,6 @@ import exchange.dydx.abacus.output.ComplianceAction
 import exchange.dydx.abacus.output.ComplianceStatus
 import exchange.dydx.abacus.output.Restriction
 import exchange.dydx.abacus.payload.BaseTests
-import exchange.dydx.abacus.responses.ParsingError
 import exchange.dydx.abacus.state.manager.AppConfigs
 import exchange.dydx.abacus.state.manager.AsyncAbacusStateManager
 import exchange.dydx.abacus.state.manager.V4StateManagerAdaptor

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/EnvironmentsMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/EnvironmentsMock.kt
@@ -42,7 +42,8 @@ class EnvironmentsMock {
                     "documentation":"https://v4-teacher.vercel.app/",
                     "community":"https://discord.com/invite/dydx",
                     "feedback":"https://docs.google.com/forms/d/e/1FAIpQLSezLsWCKvAYDEb7L-2O4wOON1T56xxro9A2Azvl6IxXHP_15Q/viewform",
-                    "launchIncentive":"https://dydx.exchange/v4-launch-incentive"
+                    "launchIncentive":"https://dydx.exchange/v4-launch-incentive",
+                    "complianceSupportEmail":"someemail@gmail.com"
                }
            },
            "wallets": {

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.28'
+    spec.version                  = '1.7.29'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
linear: [MOB-514 : add expires at to abacus](https://linear.app/dydx/issue/MOB-514/add-expires-at-to-abacus)

- adds the `expiresAt` value to the `Compliance` object which is 7 days advanced from `updatedAt`
- adds tests for v1 and v2 abacus to test calculation of `expiresAt`
- cleans up some logic for setting compliance object