### PR TITLE
update trading rewards to fetch all rewards since rewards_history_start_date defined in env.json

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.28"
+version = "1.7.29"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.29"
+version = "1.7.30"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
@@ -1827,8 +1827,12 @@ data class TradingRewards(
                             }
 
                             else -> {
+                                val modified = item.mutable()
+                                modified.safeSet("cumulativeAmount", obj.cumulativeAmount)
+                                val synced =
+                                    HistoricalTradingReward.create(obj, parser, modified, period)
                                 addHistoricalTradingRewards(result, obj, period, lastStart)
-                                result.add(obj)
+                                result.add(synced!!)
                                 objIndex++
                                 dataIndex++
                                 lastStart = obj.startedAtInMilliseconds

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
@@ -1940,7 +1940,7 @@ data class TradingRewards(
                 Instant.fromEpochMilliseconds(lastStart.toLong())
             }
             while (obj.startedAtInMilliseconds < lastStartTime.toEpochMilliseconds().toDouble()) {
-                val previous = previousPlaceHolder(period, lastStartTime, obj.cumulativeAmount)
+                val previous = previousPlaceHolder(period, lastStartTime, obj.cumulativeAmount + obj.amount)
                 if (obj.startedAtInMilliseconds < previous.startedAtInMilliseconds) {
                     result.add(previous)
                     lastStartTime =

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Enviroment.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Enviroment.kt
@@ -4,9 +4,11 @@ import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.utils.IList
 import exchange.dydx.abacus.utils.IMap
+import exchange.dydx.abacus.utils.ServerTime
 import kollections.JsExport
 import kollections.iMutableMapOf
 import kollections.toIList
+import kotlin.time.Duration.Companion.days
 
 @JsExport
 data class IndexerURIs(
@@ -458,7 +460,7 @@ class V4Environment(
             val squidIntegratorId = parser.asString(data["squidIntegratorId"])
             val chainName = parser.asString(data["chainName"])
             val chainLogo = parser.asString(data["chainLogo"])
-            val rewardsHistoryStartDateMs = parser.asString(data["rewardsHistoryStartDateMs"]) ?: return null
+            val rewardsHistoryStartDateMs = parser.asString(data["rewardsHistoryStartDateMs"]) ?: ServerTime.now().minus(180.days).toEpochMilliseconds().toString()
             val isMainNet = parser.asBool(data["isMainNet"]) ?: return null
             val endpoints =
                 EnvironmentEndpoints.parse(parser.asNativeMap(data["endpoints"]) ?: return null, parser)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Enviroment.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Enviroment.kt
@@ -397,6 +397,7 @@ open class Environment(
     val ethereumChainId: String,
     val dydxChainId: String?,
     val squidIntegratorId: String?,
+    val rewardsHistoryStartDateMs: String,
     val isMainNet: Boolean,
     val endpoints: EnvironmentEndpoints,
     val links: EnvironmentLinks?,
@@ -415,6 +416,7 @@ class V4Environment(
     squidIntegratorId: String?,
     val chainName: String?,
     val chainLogo: String?,
+    rewardsHistoryStartDateMs: String,
     isMainNet: Boolean,
     endpoints: EnvironmentEndpoints,
     links: EnvironmentLinks?,
@@ -429,6 +431,7 @@ class V4Environment(
     ethereumChainId,
     dydxChainId,
     squidIntegratorId,
+    rewardsHistoryStartDateMs,
     isMainNet,
     endpoints,
     links,
@@ -455,6 +458,7 @@ class V4Environment(
             val squidIntegratorId = parser.asString(data["squidIntegratorId"])
             val chainName = parser.asString(data["chainName"])
             val chainLogo = parser.asString(data["chainLogo"])
+            val rewardsHistoryStartDateMs = parser.asString(data["rewardsHistoryStartDateMs"]) ?: return null
             val isMainNet = parser.asBool(data["isMainNet"]) ?: return null
             val endpoints =
                 EnvironmentEndpoints.parse(parser.asNativeMap(data["endpoints"]) ?: return null, parser)
@@ -481,6 +485,7 @@ class V4Environment(
                 squidIntegratorId,
                 chainName,
                 "$deploymentUri$chainLogo",
+                rewardsHistoryStartDateMs,
                 isMainNet,
                 endpoints,
                 links,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
@@ -1394,7 +1394,7 @@ open class StateManagerAdaptor(
 
     open fun retrieveAccountHistoricalTradingRewards(
         period: String = "DAILY",
-        previousUrl: String? = null
+        previousUrl: String? = null,
     ) {
         val oldState = stateMachine.state
         var url = historicalTradingRewardAggregationsUrl() ?: return
@@ -1406,12 +1406,15 @@ open class StateManagerAdaptor(
             ),
         )?.mutable()
 
+        val tradingRewardsStartDate = Instant.fromEpochMilliseconds(environment.rewardsHistoryStartDateMs.toLong())
+        val maxDuration = Clock.System.now() - tradingRewardsStartDate
+
         retrieveTimed(
             url,
             historicalTradingRewardsInPeriod,
             "startedAt",
             1.days,
-            180.days, // OTE-337: update this to read in the trading rewards start date from env.json
+            maxDuration,
             "startingBeforeOrAt",
             null,
             params,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/StateManagerAdaptor.kt
@@ -1407,7 +1407,7 @@ open class StateManagerAdaptor(
         )?.mutable()
 
         val tradingRewardsStartDate = Instant.fromEpochMilliseconds(environment.rewardsHistoryStartDateMs.toLong())
-        val maxDuration = Clock.System.now() - tradingRewardsStartDate
+        val maxDuration = Clock.System.now() - tradingRewardsStartDate + 2.days
 
         retrieveTimed(
             url,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -54,6 +54,8 @@ import exchange.dydx.abacus.utils.toNobleAddress
 import kollections.iListOf
 import kollections.iSetOf
 import kollections.toIMap
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.collections.mutableMapOf
 import kotlin.time.Duration.Companion.days
 
@@ -481,12 +483,15 @@ internal open class AccountSupervisor(
             ),
         )?.mutable()
 
+        val tradingRewardsStartDate = Instant.fromEpochMilliseconds(helper.environment.rewardsHistoryStartDateMs.toLong())
+        val maxDuration = Clock.System.now() - tradingRewardsStartDate
+
         helper.retrieveTimed(
             url,
             historicalTradingRewardsInPeriod,
             "startedAt",
             1.days,
-            180.days, // OTE-337: update this to read in the trading rewards start date from env.json
+            maxDuration,
             "startingBeforeOrAt",
             null,
             params,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -484,7 +484,7 @@ internal open class AccountSupervisor(
         )?.mutable()
 
         val tradingRewardsStartDate = Instant.fromEpochMilliseconds(helper.environment.rewardsHistoryStartDateMs.toLong())
-        val maxDuration = Clock.System.now() - tradingRewardsStartDate
+        val maxDuration = Clock.System.now() - tradingRewardsStartDate + 2.days
 
         helper.retrieveTimed(
             url,

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AbacusMockData.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AbacusMockData.kt
@@ -58,6 +58,7 @@ class AbacusMockData {
         "dYdX-api",
         "dYdX Chain",
         "dYdX-logo.png",
+        "1704844800000",
         false,
         EnvironmentEndpoints(
             null,

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/EnvironmentsMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/EnvironmentsMock.kt
@@ -72,6 +72,7 @@ class EnvironmentsMock {
                  "ethereumChainId":"5",
                  "dydxChainId":"dydxprotocol-testnet",
                  "squidIntegratorId": "dYdX-api",
+                 "rewardsHistoryStartDateMs": "1704844800000",
                  "isMainNet":false,
                  "endpoints":{
                     "indexers":[
@@ -105,6 +106,7 @@ class EnvironmentsMock {
                  "ethereumChainId":"5",
                  "dydxChainId":"dydxprotocol-testnet",
                  "squidIntegratorId": "dYdX-api",
+                 "rewardsHistoryStartDateMs": "1704844800000",
                  "isMainNet":false,
                  "endpoints":{
                     "indexers":[

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.29'
+    spec.version                  = '1.7.30'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.28'
+    spec.version                  = '1.7.29'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
- Update the `Environment` type in abacus with `rewardsHistoryStartDateMs` from [here](https://github.com/dydxprotocol/v4-web/pull/578/files#diff-8817bf86fd45bfdf9c54b3c3c52f6e944fb4a05bc7d9f3b9cfd448fc8932130eR299)
- Remove hardcoded `180 days` from query for trading rewards, and instead calculate based on `now - startDateMs + 2.days` (for buffer). Default to 180 days from start if for some reason env.json isn't configured to have this
- Fix previous placeholder

## Testing
- Built locally, verified that data is fetched all the way to start date, tested with a non-null and null env.json variable

<img width="662" alt="Screenshot 2024-05-22 at 4 34 29 PM" src="https://github.com/dydxprotocol/v4-abacus/assets/70078372/f3379e0b-9dce-43d2-b499-f749f8196782">

