### PR TITLE
Add Github Action to automatically bump version at PR merge

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - main
-      - develop
     types: closed
 
 permissions:

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Amend the last commit
         run: |
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git config --global user.name "git bot"
+          git config --global user.name "${GITHUB_ACTOR}"
           git commit -a --amend --no-edit
           git push --force-with-lease
           echo "Complete"

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -19,9 +19,9 @@ jobs:
           # Fetch full depth, otherwise the last step overwrites the last commit's parent, essentially removing the graph.
           fetch-depth: 0
 
-      - name: Run bump_version.sh
+      - name: Run bump_version_gh_action.sh
         run: |
-          bash ./bump_version.sh
+          bash ./bump_version_gh_action.sh
       - name: Amend the last commit
         run: |
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,32 @@
+name: Bump version on PR merge
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    types: closed
+
+permissions:
+  contents: write
+  
+jobs:
+  update_version:
+    if: github.event.pull_request.merged == true
+    runs-on: macos-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          # Fetch full depth, otherwise the last step overwrites the last commit's parent, essentially removing the graph.
+          fetch-depth: 0
+
+      - name: Run bump_version.sh
+        run: |
+          bash ./bump_version.sh
+      - name: Amend the last commit
+        run: |
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.name "git bot"
+          git commit -a --amend --no-edit
+          git push --force-with-lease
+          echo "Complete"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up JDK 17
       uses: actions/setup-java@v3
@@ -25,7 +25,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/bump_version_gh_action.sh
+++ b/bump_version_gh_action.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# search for the first line that starts with "version" in build.gradle.kts
+# get the value in the quotes
+VERSION=$(grep "^version = " build.gradle.kts | sed -n 's/version = "\(.*\)"/\1/p')
+
+# increment the version number
+NEW_VERSION=$(echo $VERSION | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
+
+#if NEW_VERSION is not empty, replace the version in build.gradle.kts
+if [ -n "$NEW_VERSION" ]; then
+  sed -i '' "s/version = \"$VERSION\"/version = \"$NEW_VERSION\"/" build.gradle.kts
+  echo "Version bumped to $NEW_VERSION"
+fi


### PR DESCRIPTION
The last part of the version number will be automatically incremented after your PR lands.  After this lands, no more manual bump_version.sh will be needed unless you want to update the major/minor version.

Tested on my private repo.