### PR TITLE
fix(tradingRewardHistory): fix cumulative rewards calculation

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
@@ -1808,6 +1808,7 @@ data class TradingRewards(
                                 // item is newer than obj
                                 val modified = item.mutable()
                                 modified.safeSet("cumulativeAmount", cumulativeAmount)
+
                                 val synced =
                                     HistoricalTradingReward.create(null, parser, modified, period)
                                 addHistoricalTradingRewards(result, synced!!, period, lastStart)
@@ -1819,24 +1820,33 @@ data class TradingRewards(
 
                             (comparison == ComparisonOrder.descending) -> {
                                 // item is older than obj
-                                addHistoricalTradingRewards(result, obj, period, lastStart)
-                                result.add(obj)
+                                val modified = mapOf(
+                                    "amount" to obj.amount,
+                                    "cumulativeAmount" to cumulativeAmount,
+                                    "startedAt" to obj.startedAt,
+                                    "endedAt" to obj.endedAt,
+                                )
+
+                                val synced = HistoricalTradingReward.create(obj, parser, modified, period)
+                                addHistoricalTradingRewards(result, synced!!, period, lastStart)
+                                result.add(synced)
                                 objIndex++
-                                lastStart = obj.startedAtInMilliseconds
-                                cumulativeAmount = obj.cumulativeAmount - obj.amount
+                                lastStart = synced.startedAtInMilliseconds
+                                cumulativeAmount = cumulativeAmount - obj.amount
                             }
 
                             else -> {
                                 val modified = item.mutable()
-                                modified.safeSet("cumulativeAmount", obj.cumulativeAmount)
+                                modified.safeSet("cumulativeAmount", cumulativeAmount)
+
                                 val synced =
                                     HistoricalTradingReward.create(obj, parser, modified, period)
                                 addHistoricalTradingRewards(result, obj, period, lastStart)
                                 result.add(synced!!)
                                 objIndex++
                                 dataIndex++
-                                lastStart = obj.startedAtInMilliseconds
-                                cumulativeAmount = obj.cumulativeAmount - obj.amount
+                                lastStart = synced.startedAtInMilliseconds
+                                cumulativeAmount = cumulativeAmount - obj.amount
                             }
                         }
                     } else {
@@ -1846,11 +1856,19 @@ data class TradingRewards(
                 if (objs != null) {
                     while (objIndex < objs.size) {
                         val obj = objs[objIndex]
-                        addHistoricalTradingRewards(result, obj, period, lastStart)
-                        result.add(obj)
+                        val modified = mapOf(
+                            "amount" to obj.amount,
+                            "cumulativeAmount" to cumulativeAmount,
+                            "startedAt" to obj.startedAt,
+                            "endedAt" to obj.endedAt,
+                        )
+
+                        val synced = HistoricalTradingReward.create(obj, parser, modified, period)
+                        addHistoricalTradingRewards(result, synced!!, period, lastStart)
+                        result.add(synced)
                         objIndex++
                         lastStart = obj.startedAtInMilliseconds
-                        cumulativeAmount = obj.cumulativeAmount - obj.amount
+                        cumulativeAmount = cumulativeAmount - obj.amount
                     }
                 }
                 while (dataIndex < data.size) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
@@ -1841,8 +1841,8 @@ data class TradingRewards(
 
                                 val synced =
                                     HistoricalTradingReward.create(obj, parser, modified, period)
-                                addHistoricalTradingRewards(result, obj, period, lastStart)
-                                result.add(synced!!)
+                                addHistoricalTradingRewards(result, synced!!, period, lastStart)
+                                result.add(synced)
                                 objIndex++
                                 dataIndex++
                                 lastStart = synced.startedAtInMilliseconds

--- a/src/commonTest/kotlin/exchange.dydx.abacus/TradingRewardsTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/TradingRewardsTests.kt
@@ -87,9 +87,10 @@ class TradingRewardsTests {
 
     @Test
     fun testHistoricalDailyTradingRewardsWithExisting() {
+        val total = 200.0
         val tradingRewards = TradingRewards.create(
             TradingRewards(
-                200.0,
+                total,
                 iListOf(
                     BlockReward(1.0, yesterday.toEpochMilliseconds().toDouble(), 1),
                 ),
@@ -97,7 +98,7 @@ class TradingRewardsTests {
                     "DAILY" to iListOf(
                         HistoricalTradingReward(
                             2.0,
-                            197.0,
+                            total,
                             yesterday.toEpochMilliseconds().toDouble(),
                             today.toEpochMilliseconds().toDouble(),
                         ),
@@ -106,7 +107,7 @@ class TradingRewardsTests {
             ),
             parser,
             mapOf(
-                "total" to 200.0,
+                "total" to total,
                 "historical" to mapOf(
                     "DAILY" to iListOf(
                         mapOf(
@@ -127,7 +128,7 @@ class TradingRewardsTests {
             ).toIMap(),
         )
 
-        assertEquals(200.0, tradingRewards?.total)
+        assertEquals(total, tradingRewards?.total)
 
         // DAILY
         // day before yesterday -> yesterday, yesterday -> today, today -> tomorrow
@@ -137,7 +138,7 @@ class TradingRewardsTests {
             iListOf(
                 HistoricalTradingReward(
                     3.0,
-                    200.0,
+                    total,
                     today.toEpochMilliseconds().toDouble(),
                     tomorrow.toEpochMilliseconds().toDouble(),
                 ),


### PR DESCRIPTION
found a bug while building locally where it seemed like cumulative chart was not strictly increasing; realized it's because we were not updating `cumulativeTotal` when merging existing historical rewards with new data correctly. Updated test to account for that