### PR TITLE
Add equity tiers in configs output

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.33"
+version = "1.7.34"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Configs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Configs.kt
@@ -252,8 +252,8 @@ data class FeeTier(
 @JsExport
 @Serializable
 data class EquityTiers(
-    val shortTermOrderEquityTiers: List<EquityTier>,
-    val statefulOrderEquityTiers: List<EquityTier>,
+    val shortTermOrderEquityTiers: IList<EquityTier>,
+    val statefulOrderEquityTiers: IList<EquityTier>,
 ) {
     companion object {
         internal fun create(
@@ -297,6 +297,7 @@ data class EquityTiers(
                 }
                 return equityTiers
             }
+            Logger.d { "Equity Tiers values not valid" }
             return null
         }
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Configs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Configs.kt
@@ -8,7 +8,6 @@ import exchange.dydx.abacus.utils.Logger
 import kollections.JsExport
 import kollections.iListOf
 import kollections.iMutableListOf
-import kollections.toIList
 import kotlinx.serialization.Serializable
 
 @JsExport
@@ -263,11 +262,11 @@ data class EquityTiers(
         ): EquityTiers? {
             data?.let {
                 val shortTermOrderEquityTiers = parser.asNativeList(data["shortTermOrderEquityTiers"])?.let { tiers ->
-                    create(existing?.shortTermOrderEquityTiers?.toIList(), parser, tiers)
+                    create(existing?.shortTermOrderEquityTiers, parser, tiers)
                 } ?: iListOf()
 
                 val statefulOrderEquityTiers = parser.asNativeList(data["statefulOrderEquityTiers"])?.let { tiers ->
-                    create(existing?.statefulOrderEquityTiers?.toIList(), parser, tiers)
+                    create(existing?.statefulOrderEquityTiers, parser, tiers)
                 } ?: iListOf()
 
                 return EquityTiers(shortTermOrderEquityTiers, statefulOrderEquityTiers)
@@ -290,14 +289,14 @@ data class EquityTiers(
                     parser.asMap(item)?.let {
                         val tier = existing?.getOrNull(i)
                         val nextTierData = parser.asMap(nextItem)
-                        EquityTier.create(tier, parser, it, i + 1, nextTierData)?.let { equityTier ->
+                        EquityTier.create(tier, parser, it, nextTierData)?.let { equityTier ->
                             equityTiers.add(equityTier)
                         }
                     }
                 }
                 return equityTiers
             }
-            Logger.d { "Equity Tiers values not valid" }
+            Logger.d { "Equity Tiers not valid" }
             return null
         }
     }
@@ -306,7 +305,6 @@ data class EquityTiers(
 @JsExport
 @Serializable
 data class EquityTier(
-    val tierId: Int,
     val requiredTotalNetCollateralUSD: Double,
     val nextLevelRequiredTotalNetCollateralUSD: Double?,
     val maxOrders: Int,
@@ -316,7 +314,6 @@ data class EquityTier(
             existing: EquityTier?,
             parser: ParserProtocol,
             data: Map<*, *>?,
-            tierId: Int,
             nextTierData: Map<*, *>?
         ): EquityTier? {
             data?.let {
@@ -327,13 +324,12 @@ data class EquityTier(
                 val maxOrders = parser.asInt(data["maxOrders"])
 
                 if (requiredTotalNetCollateralUSD != null && maxOrders != null) {
-                    return if (existing?.tierId != tierId ||
+                    return if (
                         existing?.requiredTotalNetCollateralUSD != requiredTotalNetCollateralUSD ||
                         existing?.nextLevelRequiredTotalNetCollateralUSD != nextLevelRequiredTotalNetCollateralUSD ||
                         existing?.maxOrders != maxOrders
                     ) {
                         EquityTier(
-                            tierId,
                             requiredTotalNetCollateralUSD,
                             nextLevelRequiredTotalNetCollateralUSD,
                             maxOrders,

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.33'
+    spec.version                  = '1.7.34'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
need to render an equity tier table in FE similar to this, with tier 1..6
<img width="717" alt="Screenshot 2024-05-28 at 11 48 58 AM" src="https://github.com/dydxprotocol/v4-abacus/assets/9400120/8608f93b-a424-465c-b962-84173e89a229">

we're also removing equity tier limit validation on the FE, which will be done in another PR. therefore ignoring any duplicated processing logic here