### PR TITLE
create memo field for transferInput

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.41"
+version = "1.7.42"
 
 repositories {
     google()

--- a/docs/Input/TransferInput.md
+++ b/docs/Input/TransferInput.md
@@ -7,7 +7,10 @@ data class TransferInput(
 &emsp;val fee: Double?,
 &emsp;val chain: String?,
 &emsp;val address: String?,
+&emsp;val memo: String?,
 &emsp;val depositOptions: DepositInputOptions?,  
+&emsp;val withdrawalOptions: WithdrawalInputOptions?,  
+&emsp;val transferOutOptions: TransferOutInputOptions?,
 &emsp;val summary: TransferInputSummary?,
 &emsp;val resources: TransferInputResources?,
 &emsp;val requestPayload: TransferInputRequestPayload?
@@ -39,9 +42,21 @@ Selected chain to perform the transfer
 
 Selected token address of the chain to perform the transfer
 
+## memo
+
+Memo for transfer
+
 ## depositOptions
 
 structure of [DepositInputOptions](#DepositInputOptions)
+
+## withdrawalOptions
+
+structure of [WithdrawalInputOptions](#WithdrawalInputOptions)
+
+## transferOutOptions
+
+structure of [TransferOutInputOptions](#TransferOutInputOptions)
 
 ## summary
 
@@ -80,6 +95,66 @@ UX should let the user choose whether to use fast speed
 
 Option of assets to choose from
 
+# WithdrawalInputOptions
+
+data class DepositInputOptions(  
+&emsp;val needsSize: Boolean?,  
+&emsp;val needsAddress: Boolean?,  
+&emsp;val needsFastSpeed: Boolean?,  
+&emsp;val exchanges: Array<SelectionOption>?  
+&emsp;val chains: Array<SelectionOption>?  
+&emsp;val assets: Array<SelectionOption>?  
+)
+
+## needsSize
+
+UX should let user enter the size
+
+## needsAddress
+
+UX should let user enter a wallet address
+
+## needsFastSpeed
+
+UX should let the user choose whether to use fast speed
+
+## exchanges
+
+Option of exchanges to choose from
+
+## chains
+
+Option of chains to choose from
+
+## assets
+
+Option of assets to choose from
+
+# TransferOutInputOptions
+
+data class TransferOutInputOptions(  
+&emsp;val needsSize: Boolean?,  
+&emsp;val needsAddress: Boolean?,  
+&emsp;val chains: Array<SelectionOption>?,
+&emsp;val assets: Array<SelectionOption>?  
+)
+
+## needsSize
+
+UX should let user enter the size
+
+## needsAddress
+
+UX should let user enter a wallet address
+
+## chains
+
+Option of chains to choose from
+
+## assets
+
+Option of assets to choose from
+
 # TransferInputSummary
 
 data class TransferInputSummary(  
@@ -102,7 +177,7 @@ Whether the transfer transaction can be filled
 
 # TransferInputResources
 
-The chain and token resources of the selected chain and its associated tokens.  Use the chainId
+The chain and token resources of the selected chain and its associated tokens. Use the chainId
 and token address of the key to the maps, respectively, to get the resource.
 
 data class TransferInputResources(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
@@ -149,7 +149,7 @@ data class TransferOutInputOptions(
     val needsSize: Boolean?,
     val needsAddress: Boolean?,
     val chains: IList<SelectionOption>?,
-    val assets: IList<SelectionOption>?
+    val assets: IList<SelectionOption>?,
 ) {
     companion object {
         internal fun create(
@@ -474,6 +474,7 @@ data class TransferInput(
     val chain: String?,
     val token: String?,
     val address: String?,
+    val memo: String?,
     val depositOptions: DepositInputOptions?,
     val withdrawalOptions: WithdrawalInputOptions?,
     val transferOutOptions: TransferOutInputOptions?,
@@ -509,6 +510,7 @@ data class TransferInput(
                 val chain = parser.asString(data["chain"])
                 val token = parser.asString(data["token"])
                 val address = parser.asString(data["address"])
+                val memo = parser.asString(data["memo"])
 
                 var depositOptions: DepositInputOptions? = null
                 if (type == TransferType.deposit) {
@@ -577,6 +579,7 @@ data class TransferInput(
                     existing.chain != chain ||
                     existing.token != token ||
                     existing.address != address ||
+                    existing.memo != memo ||
                     existing.depositOptions != depositOptions ||
                     existing.withdrawalOptions != withdrawalOptions ||
                     existing.transferOutOptions != transferOutOptions ||
@@ -595,6 +598,7 @@ data class TransferInput(
                         chain,
                         token,
                         address,
+                        memo,
                         depositOptions,
                         withdrawalOptions,
                         transferOutOptions,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TransferInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TransferInput.kt
@@ -25,6 +25,7 @@ enum class TransferInputField(val rawValue: String) {
     chain("chain"),
     token("token"),
     address("address"),
+    MEMO("memo"),
     fastSpeed("fastSpeed");
 
     companion object {
@@ -69,6 +70,7 @@ fun TradingStateMachine.transfer(
                         transfer.safeSet("size.usdcSize", null)
                         transfer.safeSet("route", null)
                         transfer.safeSet("requestPayload", null)
+                        transfer.safeSet("memo", null)
                         if (parser.asString(data) == "TRANSFER_OUT") {
                             transfer.safeSet("chain", "chain")
                             transfer.safeSet("token", "usdc")
@@ -135,7 +137,6 @@ fun TradingStateMachine.transfer(
                         iListOf(subaccountNumber),
                     )
                 }
-
                 TransferInputField.fastSpeed.rawValue -> {
                     transfer.safeSet(typeText, parser.asBool(data))
                     changes = StateChanges(
@@ -162,6 +163,14 @@ fun TradingStateMachine.transfer(
                     }
                     changes = StateChanges(
                         iListOf(Changes.wallet, Changes.subaccount, Changes.input),
+                        null,
+                        iListOf(subaccountNumber),
+                    )
+                }
+                TransferInputField.MEMO.rawValue -> {
+                    transfer.safeSet(typeText, parser.asString(data))
+                    changes = StateChanges(
+                        iListOf(Changes.input),
                         null,
                         iListOf(subaccountNumber),
                     )

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/TransferInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/TransferInputTests.kt
@@ -28,6 +28,8 @@ class TransferInputTests : V3BaseTests() {
 
         testTransferOutTransferInput()
         perp.log("Transfer Out", time)
+
+        testTransferInputTypeChange()
     }
 
     private fun testDepositTransferInput() {
@@ -414,6 +416,10 @@ class TransferInputTests : V3BaseTests() {
             perp.transfer("5000.0", TransferInputField.usdcSize)
         }, null)
 
+        test({
+            perp.transfer("test memo", TransferInputField.MEMO)
+        }, null)
+
         test(
             {
                 perp.transfer("1000.0", TransferInputField.usdcSize)
@@ -423,6 +429,7 @@ class TransferInputTests : V3BaseTests() {
                     "input": {
                         "transfer": {
                             "type": "TRANSFER_OUT",
+                            "memo": "test memo",
                             "size": {
                                 "usdcSize": 1000.0
                             },
@@ -467,6 +474,72 @@ class TransferInputTests : V3BaseTests() {
                 assertTrue { response.state?.input?.transfer?.transferOutOptions?.assets?.count() == 2 }
                 assertTrue { response.state?.input?.transfer?.transferOutOptions?.chains?.count() == 1 }
             },
+        )
+    }
+
+    private fun testTransferInputTypeChange() {
+        test(
+            {
+                perp.transfer("DEPOSIT", TransferInputField.type)
+            },
+            """
+        {
+            "input": {
+                "transfer": {
+                    "type": "DEPOSIT",
+                    "memo": null
+                }
+            }
+        }
+            """.trimIndent(),
+        )
+
+        test(
+            {
+                perp.transfer("TRANSFER_OUT", TransferInputField.type)
+            },
+            """
+    {
+        "input": {
+            "transfer": {
+                "type": "TRANSFER_OUT",
+                "memo": null
+            }
+        }
+    }
+            """.trimIndent(),
+        )
+
+        test(
+            {
+                perp.transfer("test memo", TransferInputField.MEMO)
+            },
+            """
+        {
+            "input": {
+                "transfer": {
+                    "type": "TRANSFER_OUT",
+                    "memo": "test memo"
+                }
+            }
+        }
+            """.trimIndent(),
+        )
+
+        test(
+            {
+                perp.transfer("WITHDRAWAL", TransferInputField.type)
+            },
+            """
+    {
+        "input": {
+            "transfer": {
+                "type": "WITHDRAWAL",
+                "memo": null
+            }
+        }
+    }
+            """.trimIndent(),
         )
     }
 }


### PR DESCRIPTION
- filled out `TransferInput.md` a bit more (it's outdated)
- add `memo` to `TransferInput`; clear it when transfer type switches (but maintain it between token type switches)

- I considered adding a `needsMemo` field to the different transfer type options (`WithdrawalInputOptions`, etc) but that seemed like overkill when the caller can just conditionally render the memo field depending on type - and maybe we'd want to allow users to fill in a memo in other cases in the future?

Tested with tests; built locally


https://github.com/dydxprotocol/v4-abacus/assets/70078372/73acda34-c595-46ef-8e9e-db4702d20b7a

