### PR TITLE
feat: skip route + msgs endpoints [OTE-348]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.52"
+version = "1.7.53"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRoutePayloadProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRoutePayloadProcessor.kt
@@ -1,0 +1,41 @@
+package exchange.dydx.abacus.processor.router.skip
+
+import exchange.dydx.abacus.processor.base.BaseProcessor
+import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.utils.safeSet
+
+internal class SkipRoutePayloadProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
+    private val keyMap = mapOf(
+        "string" to mapOf(
+            // Transaction request payload
+            "txs.0.evm_tx.to" to "targetAddress",
+            "txs.0.evm_tx.data" to "data",
+            "txs.0.evm_tx.value" to "value",
+            "route.source_asset_chain_id" to "fromChainId",
+            "route.source_asset_denom" to "fromAddress",
+            "route.dest_asset_chain_id" to "toChainId",
+            "route.dest_asset_denom" to "toAddress",
+
+//            SQUID PARAMS THAT ARE NOW DEPRECATED:
+//            "route.transactionRequest.routeType" to "routeType",
+//            "route.transactionRequest.gasPrice" to "gasPrice",
+//            "route.transactionRequest.gasLimit" to "gasLimit",
+//            "route.transactionRequest.maxFeePerGas" to "maxFeePerGas",
+//            "route.transactionRequest.maxPriorityFeePerGas" to "maxPriorityFeePerGas",
+        ),
+    )
+
+    override fun received(
+        existing: Map<String, Any>?,
+        payload: Map<String, Any>
+    ): Map<String, Any> {
+        val modified = transform(existing, payload, keyMap)
+        val data = modified.get("data")
+        if (data != null) {
+//            skip does not provide the 0x prefix. it's not required but is good for clarity
+//            and keeps our typing honest (we typecast this value to evmAddress in web)
+            modified.safeSet("data", "0x$data")
+        }
+        return modified
+    }
+}

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessor.kt
@@ -1,0 +1,82 @@
+package exchange.dydx.abacus.processor.router.skip
+
+import exchange.dydx.abacus.processor.base.BaseProcessor
+import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.utils.SLIPPAGE_PERCENT
+import exchange.dydx.abacus.utils.safeSet
+import kotlin.math.pow
+
+@Suppress("ForbiddenComment")
+internal class SkipRouteProcessor(internal val parser: ParserProtocol) {
+    private val keyMap = mapOf(
+        "string" to mapOf(
+            "route.usd_amount_out" to "toAmountUSD",
+            "route.estimated_amount_out" to "toAmount",
+            "swap_price_impact_percent" to "aggregatePriceImpact",
+
+//            SQUID PARAMS THAT ARE NOW DEPRECATED:
+//            "route.estimate.gasCosts.0.amountUSD" to "gasFee",
+//            "route.estimate.exchangeRate" to "exchangeRate",
+//            "route.estimate.estimatedRouteDuration" to "estimatedRouteDuration",
+//            "route.estimate.toAmountMin" to "toAmountMin",
+
+        ),
+    )
+
+    private fun findFee(payload: Map<String, Any>, key: String): Double? {
+        val estimatedFees = parser.asList(parser.value(payload, "route.estimated_fees"))
+        val foundFeeObj = estimatedFees?.find {
+            parser.asString(parser.asNativeMap(it)?.get("fee_type")) == key
+        }
+        val feeInUSD = parser.asDouble(parser.asNativeMap(foundFeeObj)?.get("usd_amount"))
+        return feeInUSD
+    }
+
+    fun received(
+        existing: Map<String, Any>?,
+        payload: Map<String, Any>,
+        decimals: Double?
+    ): Map<String, Any> {
+        val modified = BaseProcessor(parser).transform(existing, payload, keyMap)
+
+        var bridgeFees = findFee(payload, "BRIDGE")
+//        TODO: update web UI to show smart relay fees
+//        For now we're just bundling it with the bridge fees
+        val smartRelayFees = findFee(payload, "SMART_RELAY")
+        if (bridgeFees == null) {
+            bridgeFees = smartRelayFees
+        } else if (smartRelayFees != null) {
+            bridgeFees += smartRelayFees
+        }
+        val gasFees = findFee(payload, "GAS")
+
+        modified.safeSet("gasFees", gasFees)
+        modified.safeSet("bridgeFees", bridgeFees)
+
+        val toAmount = parser.asLong(parser.value(payload, "route.estimated_amount_out"))
+        if (toAmount != null && decimals != null) {
+            modified.safeSet("toAmount", toAmount / 10.0.pow(decimals))
+        }
+        val toAmountUSD = parser.asDouble(parser.value(payload, "route.usd_amount_out"))
+        if (toAmountUSD != null) {
+            modified.safeSet("toAmountUSD", toAmountUSD)
+        }
+
+        val payloadProcessor = SkipRoutePayloadProcessor(parser)
+//        TODO: Remove slippage.
+//        This is just hard coded in our params so we're keeping it to be at parity for now
+//        Fast follow squid -> skip migration project to removing max slippage
+//        because we already show the actual price impact.
+        modified.safeSet("slippage", SLIPPAGE_PERCENT)
+        modified.safeSet("requestPayload", payloadProcessor.received(null, payload))
+
+        val errorCode = parser.value(payload, "code")
+//        if we have an error code, add the payload as a list of errors
+//        this allows to match the current errors format.
+//        TODO: replace errors with errorMessage once we finish migration
+        if (errorCode != null) {
+            modified.safeSet("errors", parser.asString(listOf(payload)))
+        }
+        return modified
+    }
+}

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
@@ -123,6 +123,10 @@ class V4StateManagerConfigs(
         return "$skipHost/v1/fungible/assets?include_evm_assets=true"
     }
 
+    fun skipV2MsgsDirect(): String {
+        return "$skipHost/v2/fungible/msgs_direct"
+    }
+
     fun nobleDenom(): String? {
         return "uusdc"
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -8,3 +8,6 @@ internal const val MAX_SUBACCOUNT_NUMBER = 128_000
 internal const val SHORT_TERM_ORDER_DURATION = 10
 
 internal const val QUANTUM_MULTIPLIER = 1_000_000
+
+// Route Param Constants
+internal const val SLIPPAGE_PERCENT = "1"

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
@@ -4,6 +4,7 @@ import exchange.dydx.abacus.output.input.TransferInputChainResource
 import exchange.dydx.abacus.output.input.TransferInputTokenResource
 import exchange.dydx.abacus.state.internalstate.InternalTransferInputState
 import exchange.dydx.abacus.tests.payloads.SkipChainsMock
+import exchange.dydx.abacus.tests.payloads.SkipRouteMock
 import exchange.dydx.abacus.tests.payloads.SkipTokensMock
 import exchange.dydx.abacus.utils.Parser
 import kotlinx.serialization.json.Json
@@ -11,6 +12,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal fun templateToJson(template: String): Map<String, Any> {
     return Json.parseToJsonElement(template.trimIndent()).jsonObject.toMap()
@@ -23,6 +25,7 @@ class SkipProcessorTests {
     internal val skipProcessor = SkipProcessor(parser = parser, internalState = internalState)
     internal val skipChainsMock = SkipChainsMock()
     internal val skipTokensMock = SkipTokensMock()
+    internal val skipRouteMock = SkipRouteMock()
     internal val selectedChainId = "osmosis-1"
     internal val selectedTokenAddress = "selectedTokenDenom"
     internal val selectedTokenSymbol = "selectedTokenSymbol"
@@ -301,5 +304,36 @@ class SkipProcessorTests {
         assertEquals(payload["chain_to_assets_map"], skipProcessor.skipTokens)
         assertEquals(expectedTokens, internalState.tokens)
         assertEquals(expectedTokenResources, internalState.tokenResources)
+    }
+
+    @Test
+    fun testReceivedRoute() {
+        val payload = templateToJson(skipRouteMock.payload)
+        val result = skipProcessor.receivedRoute(
+            existing = mapOf(),
+            payload = payload,
+            requestId = null,
+        )
+        val expected = mapOf(
+            "transfer" to mapOf(
+                "route" to mapOf(
+//                    TODO: set up text properly so we get a decimals value
+                    "toAmount" to "11640000",
+                    "toAmountUSD" to 11.64,
+                    "bridgeFees" to 0.36,
+                    "slippage" to "1",
+                    "requestPayload" to mapOf(
+                        "targetAddress" to "0xBC8552339dA68EB65C8b88B414B5854E0E366cFc",
+                        "data" to "0xd77d6ec00000000000000000000000000000000000000000000000000000000000b19cc000000000000000000000000000000000000000000000000000000000000000040000000000000000000000009dc5ce8a5722795f5723d32b921c53d3bb449348000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000057e40000000000000000000000000691cf4641d5608f085b2c1921172120bb603d074",
+                        "value" to "0",
+                        "fromChainId" to "1",
+                        "fromAddress" to "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                        "toChainId" to "noble-1",
+                        "toAddress" to "uusdc",
+                    ),
+                ),
+            ),
+        )
+        assertTrue(expected == result)
     }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
@@ -1,0 +1,50 @@
+package exchange.dydx.abacus.processor.router.skip
+
+import exchange.dydx.abacus.tests.payloads.SkipRouteMock
+import exchange.dydx.abacus.utils.Parser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SkipRouteProcessorTests {
+    val parser = Parser()
+    internal val skipRouteMock = SkipRouteMock()
+    internal val skipRouteProcessor = SkipRouteProcessor(parser = parser)
+
+    /**
+     * Tests a CCTP deposit.
+     */
+    @Test
+    fun testReceivedCCTPDeposit() {
+        val payload = skipRouteMock.payload
+        val result = skipRouteProcessor.received(existing = mapOf(), payload = templateToJson(payload), decimals = 6.0)
+        val expected = mapOf(
+            "toAmountUSD" to 11.64,
+            "toAmount" to 11.64,
+            "bridgeFees" to .36,
+            "slippage" to "1",
+            "requestPayload" to mapOf(
+                "targetAddress" to "0xBC8552339dA68EB65C8b88B414B5854E0E366cFc",
+                "data" to "0xd77d6ec00000000000000000000000000000000000000000000000000000000000b19cc000000000000000000000000000000000000000000000000000000000000000040000000000000000000000009dc5ce8a5722795f5723d32b921c53d3bb449348000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000057e40000000000000000000000000691cf4641d5608f085b2c1921172120bb603d074",
+                "value" to "0",
+                "fromChainId" to "1",
+                "fromAddress" to "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                "toChainId" to "noble-1",
+                "toAddress" to "uusdc",
+            ),
+        )
+        assertTrue(expected == result)
+    }
+
+    @Test
+    fun testReceivedError() {
+        val payload = skipRouteMock.payloadError
+        val result = skipRouteProcessor.received(existing = mapOf(), payload = templateToJson(payload), decimals = 6.0)
+        val expected = mapOf(
+            "slippage" to "1",
+            "requestPayload" to emptyMap<String, Any>(),
+            "errors" to "[{code=3, message=\"difference in usd value of route input and output is too large. input usd value: 100000.00 output usd value: 98811.81\", details=[{\"@type\":\"type.googleapis.com/google.rpc.ErrorInfo\",\"reason\":\"BAD_PRICE_ERROR\",\"domain\":\"skip.money\",\"metadata\":{}}]}]",
+        )
+        assertEquals(expected.toString(), result.toString())
+    }
+}

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipRouteMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipRouteMock.kt
@@ -1,0 +1,123 @@
+package exchange.dydx.abacus.tests.payloads
+
+internal class SkipRouteMock {
+    internal val payload = """{
+    "msgs": [
+        {
+            "evm_tx": {
+                "chain_id": "1",
+                "to": "0xBC8552339dA68EB65C8b88B414B5854E0E366cFc",
+                "value": "0",
+                "data": "d77d6ec00000000000000000000000000000000000000000000000000000000000b19cc000000000000000000000000000000000000000000000000000000000000000040000000000000000000000009dc5ce8a5722795f5723d32b921c53d3bb449348000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000057e40000000000000000000000000691cf4641d5608f085b2c1921172120bb603d074",
+                "required_erc20_approvals": [
+                    {
+                        "token_contract": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                        "spender": "0xBC8552339dA68EB65C8b88B414B5854E0E366cFc",
+                        "amount": "12000000"
+                    }
+                ],
+                "signer_address": "0x0f7833777bfC9ef72D8B76AE954D3849DD71F829"
+            }
+        }
+    ],
+    "txs": [
+        {
+            "evm_tx": {
+                "chain_id": "1",
+                "to": "0xBC8552339dA68EB65C8b88B414B5854E0E366cFc",
+                "value": "0",
+                "data": "d77d6ec00000000000000000000000000000000000000000000000000000000000b19cc000000000000000000000000000000000000000000000000000000000000000040000000000000000000000009dc5ce8a5722795f5723d32b921c53d3bb449348000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000057e40000000000000000000000000691cf4641d5608f085b2c1921172120bb603d074",
+                "required_erc20_approvals": [
+                    {
+                        "token_contract": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                        "spender": "0xBC8552339dA68EB65C8b88B414B5854E0E366cFc",
+                        "amount": "12000000"
+                    }
+                ],
+                "signer_address": "0x0f7833777bfC9ef72D8B76AE954D3849DD71F829"
+            },
+            "operations_indices": [
+                0
+            ]
+        }
+    ],
+    "route": {
+        "source_asset_denom": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "source_asset_chain_id": "1",
+        "dest_asset_denom": "uusdc",
+        "dest_asset_chain_id": "noble-1",
+        "amount_in": "12000000",
+        "amount_out": "11640000",
+        "operations": [
+            {
+                "cctp_transfer": {
+                    "from_chain_id": "1",
+                    "to_chain_id": "noble-1",
+                    "burn_token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "denom_in": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "denom_out": "uusdc",
+                    "bridge_id": "CCTP",
+                    "smart_relay": true
+                },
+                "tx_index": 0,
+                "amount_in": "12000000",
+                "amount_out": "11640000"
+            }
+        ],
+        "chain_ids": [
+            "1",
+            "noble-1"
+        ],
+        "does_swap": false,
+        "estimated_amount_out": "11640000",
+        "swap_venues": [],
+        "txs_required": 1,
+        "usd_amount_in": "12.00",
+        "usd_amount_out": "11.64",
+        "estimated_fees": [
+            {
+                "fee_type": "SMART_RELAY",
+                "bridge_id": "CCTP",
+                "amount": "360000",
+                "usd_amount": "0.36",
+                "origin_asset": {
+                    "denom": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "chain_id": "1",
+                    "origin_denom": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "origin_chain_id": "1",
+                    "trace": "",
+                    "is_cw20": false,
+                    "is_evm": false,
+                    "is_svm": false,
+                    "symbol": "USDC",
+                    "name": "USD Coin",
+                    "logo_uri": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/usdc.svg",
+                    "decimals": 6,
+                    "token_contract": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "coingecko_id": "usd-coin",
+                    "recommended_symbol": "USDC"
+                },
+                "chain_id": "1",
+                "tx_index": 0
+            }
+        ],
+        "required_chain_addresses": [
+            "1",
+            "noble-1"
+        ]
+    }
+}"""
+    internal val payloadError = """
+    {
+  "code": 3,
+  "message": "difference in usd value of route input and output is too large. input usd value: 100000.00 output usd value: 98811.81",
+  "details": [
+    {
+      "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+      "reason": "BAD_PRICE_ERROR",
+      "domain": "skip.money",
+      "metadata": {}
+    }
+  ]
+}"""
+}


### PR DESCRIPTION
implements skip replacement for squid /route endpoint

This PR implements the skip analog of squid's /route endpoint by utilizing Skip's msgs_direct endpoint.

In order to do this we:

- Implemented the receivedRoute method on the SkipProcessor
- Implemented the receivedRouteV2 method on the SkipProcessor
- Created and implemented the `SkipRouteProcesor
- Created and implemented the SkipRoutePayloadProcessor
- Skip does not provide all the same data that Squid does, so we did our best to keep the data format as similar as possible. We'll have to make some updates on the web side to handle these changes though. Most notably:
  - gasLimit should no longer be required

Some things to cleanup after this PR:
- errors property is set in a pretty hacky way to coerce the skip payload to mimic squid's. this is intentional to reduce the # of breaking internal API changes. We can migrate that after we confirm core functionality works.
- slippage is just hard coded. we made sure that the input param for the skip payload is synced with the processor but we 
should be updating this value all across the codebase. this will be a separate PR as it's not directly related to this functionality
- there's still some shared logic we may want to deduplicate from squid and skip (TBD. since we're removing squid it may not be worth it)

Future architectural things:
- i don't think we should be imputing the to and from addresses. we'd be able to easily dedupe a lot more code if we depended on the users dispatching the toAddress toTokenDenom toChainId transferType etc. in the transfer request.
