### PR TITLE
isolated margin: use correct payload + codespace broadcast errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.56"
+version = "1.7.57"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/responses/ParsingError.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/responses/ParsingError.kt
@@ -32,7 +32,8 @@ data class ParsingError(
     val type: ParsingErrorType,
     val message: String,
     val stringKey: String? = null,
-    val stackTrace: String? = null
+    val stackTrace: String? = null,
+    val codespace: String? = null
 )
 
 class ParsingException(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
@@ -11,7 +11,7 @@ class V4TransactionErrors {
                     ParsingError(
                         ParsingErrorType.BackendError,
                         message ?: "Unknown error",
-                        "ERRORS.BROADCAST_ERROR_${codespace.uppercase()}_${code}",
+                        "ERRORS.BROADCAST_ERROR_${codespace.uppercase()}_$code",
                     )
                 } else {
                     null

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
@@ -5,13 +5,13 @@ import exchange.dydx.abacus.responses.ParsingErrorType
 
 class V4TransactionErrors {
     companion object {
-        fun error(code: Int?, message: String?): ParsingError? {
+        fun error(code: Int?, message: String?, codespace: String? = null): ParsingError? {
             return if (code != null) {
-                if (code != 0) {
+                if (code != 0 && codespace != null) {
                     ParsingError(
                         ParsingErrorType.BackendError,
                         message ?: "Unknown error",
-                        "ERRORS.BROADCAST_ERROR_$code",
+                        "ERRORS.BROADCAST_ERROR_${codespace.uppercase()}_${code}",
                     )
                 } else {
                     null

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/NetworkHelper.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/NetworkHelper.kt
@@ -522,7 +522,8 @@ class NetworkHelper(
                 if (error != null) {
                     val message = parser.asString(error["message"])
                     val code = parser.asInt(error["code"])
-                    return V4TransactionErrors.error(code, message)
+                    val codespace = parser.asString(error["codespace"])
+                    return V4TransactionErrors.error(code, message, codespace)
                 } else {
                     null
                 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -685,7 +685,9 @@ internal class SubaccountSupervisor(
                     useTransactionQueue,
                 )
             } else {
-                helper.send(error, callback, transferPayload)
+                // callback with order payload instead of transfer payload since
+                // client shows it as a place order error and needs order client id
+                helper.send(error, callback, payload)
             }
         }
 
@@ -698,7 +700,7 @@ internal class SubaccountSupervisor(
                 transferPayloadString,
                 null,
                 isolatedMarginTransactionCallback,
-                useTransactionQueue,
+                true,
             )
         } else {
             submitTransaction(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -700,7 +700,7 @@ internal class SubaccountSupervisor(
                 transferPayloadString,
                 null,
                 isolatedMarginTransactionCallback,
-                true,
+                useTransactionQueue = true,
             )
         } else {
             submitTransaction(

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.52'
+    spec.version                  = '1.7.57'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
                 
                 
                 
-    if !Dir.exist?('build/cocoapods/framework/Abacus.framework') || Dir.empty?('build/cocoapods/framework/Abacus.framework')
+    if false
         raise "
 
         Kotlin framework 'Abacus' doesn't exist yet, so a proper Xcode project can't be generated.


### PR DESCRIPTION
- broadcast errors from different module/codespace have different meanings; adding codespace to localized stringkey to differentiate
- use order payload instead of transfer in the place order / isolated margin flow, so that client has access to order client Id when there's an error