### PR TITLE
Use appropriate subaccount for SL/TP triggers.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.66"
+version = "1.7.67"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
@@ -26,12 +26,13 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
     ): Map<String, Any> {
         val account = parser.asNativeMap(state["account"])
         val subaccount = if (subaccountNumber != null) {
-            parser.asNativeMap(
-                parser.value(
-                    account,
-                    "subaccounts.$subaccountNumber",
-                ),
-            )
+            parser.asMap(parser.value(account, "groupedSubaccounts.$subaccountNumber"))
+                ?: parser.asNativeMap(
+                    parser.value(
+                        account,
+                        "subaccounts.$subaccountNumber",
+                    ),
+                )
         } else {
             null
         }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.62'
+    spec.version                  = '1.7.63'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Two fixes:
- Reference groupedSubaccounts for TriggerOrdersInputCalculator.
- Use child subaccount number when constructing payload.