### PR TITLE
fix: retrieve user fees on subaccount set

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.70"
+version = "1.7.71"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.69"
+version = "1.7.70"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -230,7 +230,7 @@ internal open class AccountSupervisor(
             }
 
         // if this is the first realized subaccount, retrieve user fee tier and user stats
-        if (isSubaccountRealized && !subaccounts.values.any { it.realized }) {
+        if (validatorConnected && isSubaccountRealized && !subaccounts.values.any { it.realized }) {
             if (configs.retrieveUserFeeTier) {
                 retrieveUserFeeTier()
             }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -228,6 +228,17 @@ internal open class AccountSupervisor(
                 newSubaccountSupervisor.validatorConnected = validatorConnected
                 subaccounts[subaccountNumber] = newSubaccountSupervisor
             }
+
+        // if this is the first realized subaccount, retrieve user fee tier and user stats
+        if (isSubaccountRealized && !subaccounts.values.any { it.realized }) {
+            if (configs.retrieveUserFeeTier) {
+                retrieveUserFeeTier()
+            }
+            if (configs.retrieveUserStats) {
+                retrieveUserStats()
+            }
+        }
+
         subaccounts[subaccountNumber]?.realized = isSubaccountRealized
     }
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
                 
                 
                 
-    if false
+    if !Dir.exist?('build/cocoapods/framework/Abacus.framework') || Dir.empty?('build/cocoapods/framework/Abacus.framework')
         raise "
 
         Kotlin framework 'Abacus' doesn't exist yet, so a proper Xcode project can't be generated.

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.63'
+    spec.version                  = '1.7.70'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
testing on web, there's a bug where if dydx wallet isn't immediately connected (i.e. either need to recover keys / reconnect wallet), user fees won't be fetched and no trading rewards/fees will show up in place order CTA

this is because we fetch user fee tiers and stats on account's `didSetValidatorConnected`, and only when a subaccount is already fetched. however in most cases, `subaccounts.values.any { it.realized }` will be false when validator is first set to connected

fix is we will also try to fetch those things on `subscribeToSubaccount`, and checking that it's the first subaccount that gets "realized", keeping similar logic