### PR TITLE
v1.7.75: Add buffer and use oraclePrice to determine collateral movement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.74"
+version = "1.7.75"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
@@ -49,14 +49,15 @@ class AccountTransformer() {
             ) ?: mapOf()
 
             val transferAmount = if (MarginModeCalculator.getShouldTransferCollateral(
-                parser,
-                subaccount=childSubaccount,
-                tradeInput = trade,
-            )) {
+                    parser,
+                    subaccount = childSubaccount,
+                    tradeInput = trade,
+                )
+            ) {
                 MarginModeCalculator.calculateIsolatedMarginTransferAmount(
                     parser,
                     trade,
-                    market
+                    market,
                 ) ?: 0.0
             } else {
                 0.0

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
@@ -8,7 +8,7 @@ class AccountTransformer() {
     private val subaccountTransformer = SubaccountTransformer()
     internal fun applyTradeToAccount(
         account: Map<String, Any>?,
-        subaccountNumber: Int?,
+        subaccountNumber: Int,
         trade: Map<String, Any>,
         market: Map<String, Any>?,
         parser: ParserProtocol,
@@ -22,14 +22,14 @@ class AccountTransformer() {
                 subaccountNumber ?: 0,
                 trade,
             )
+        val subaccount = parser.asNativeMap(
+            parser.value(
+                account,
+                "subaccounts.$subaccountNumber",
+            ),
+        ) ?: mapOf()
         if (subaccountNumber == childSubaccountNumber) {
             // CROSS
-            val subaccount = parser.asNativeMap(
-                parser.value(
-                    account,
-                    "subaccounts.$subaccountNumber",
-                ),
-            ) ?: mapOf()
             val modifiedSubaccount =
                 subaccountTransformer.applyTradeToSubaccount(
                     subaccount,
@@ -41,17 +41,26 @@ class AccountTransformer() {
             modified.safeSet("subaccounts.$subaccountNumber", modifiedSubaccount)
             return modified
         } else {
-            val transferAmount = calculateIsolatedMarginTransferAmount(
-                parser,
-                trade,
-            ) ?: 0.0
-
-            val subaccount = parser.asNativeMap(
+            val childSubaccount = parser.asNativeMap(
                 parser.value(
                     account,
-                    "subaccounts.$subaccountNumber",
+                    "subaccounts.$childSubaccountNumber",
                 ),
             ) ?: mapOf()
+
+            val transferAmount = if (MarginModeCalculator.getShouldTransferCollateral(
+                parser,
+                subaccount=childSubaccount,
+                tradeInput = trade,
+            )) {
+                MarginModeCalculator.calculateIsolatedMarginTransferAmount(
+                    parser,
+                    trade,
+                    market
+                ) ?: 0.0
+            } else {
+                0.0
+            }
 
             val modifiedSubaccount =
                 subaccountTransformer.applyTransferToSubaccount(
@@ -61,13 +70,6 @@ class AccountTransformer() {
                     period,
                 )
             modified.safeSet("subaccounts.$subaccountNumber", modifiedSubaccount)
-
-            val childSubaccount = parser.asNativeMap(
-                parser.value(
-                    account,
-                    "subaccounts.$childSubaccountNumber",
-                ),
-            ) ?: mapOf()
 
             val modifiedChildSubaccount =
                 subaccountTransformer.applyTradeToSubaccount(
@@ -80,21 +82,6 @@ class AccountTransformer() {
                 )
             modified.safeSet("subaccounts.$childSubaccountNumber", modifiedChildSubaccount)
             return modified
-        }
-    }
-
-    fun calculateIsolatedMarginTransferAmount(
-        parser: ParserProtocol,
-        trade: Map<String, Any>,
-    ): Double? {
-        val marketOrderUsdcSize = parser.asDouble(parser.value(trade, "marketOrder.usdcSize"))
-        val targetLeverage = parser.asDouble(trade["targetLeverage"]) ?: 1.0
-
-        return if (targetLeverage == 0.0) {
-            null
-        } else {
-            val usdcSize = marketOrderUsdcSize ?: parser.asDouble(parser.value(trade, "size.usdcSize")) ?: return null
-            usdcSize / targetLeverage
         }
     }
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginModeCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginModeCalculator.kt
@@ -1,5 +1,6 @@
 package exchange.dydx.abacus.calculator
 
+import abs
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.utils.MAX_SUBACCOUNT_NUMBER
 import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
@@ -186,5 +187,93 @@ internal object MarginModeCalculator {
 
         // User has reached the maximum number of childSubaccounts for their current parentSubaccount
         error("No available subaccount number")
+    }
+
+    private fun getIsIncreasingPositionSize(
+        parser: ParserProtocol,
+        subaccount: Map<String, Any>?,
+        tradeInput: Map<String, Any>?,
+    ): Boolean {
+        val marketId = parser.asString(tradeInput?.get("marketId")) ?: return true
+        val position = parser.asNativeMap(parser.value(subaccount, "openPositions.$marketId"))
+        val currentSize = parser.asDouble(parser.value(position, "size.current")) ?: 0.0
+        val postOrderSize = parser.asDouble(parser.value(position, "size.postOrder")) ?: 0.0
+        return postOrderSize.abs() > currentSize.abs()
+    }
+
+    /**
+     * @description Determine if collateral should be transferred for an isolated margin trade
+     */
+    fun getShouldTransferCollateral(
+        parser: ParserProtocol,
+        subaccount: Map<String, Any>?,
+        tradeInput: Map<String, Any>?,
+    ): Boolean {
+        val isIncreasingPositionSize = getIsIncreasingPositionSize(parser, subaccount, tradeInput)
+        val isIsolatedMarginOrder = parser.asString(tradeInput?.get("marginMode")) == "ISOLATED"
+        val isReduceOnly = parser.asBool(tradeInput?.get("reduceOnly")) ?: false
+
+        return isIncreasingPositionSize && isIsolatedMarginOrder && !isReduceOnly
+    }
+
+    private fun getTransferAmountFromTargetLeverage(
+        askPrice: Double,
+        oraclePrice: Double,
+        size: Double,
+        targetLeverage: Double,
+    ): Double {
+        if (targetLeverage == 0.0) {
+            return 0.0
+        }
+
+        return (oraclePrice * size) / targetLeverage + (askPrice - oraclePrice) * size
+    }
+
+    /**
+     * @description Calculate the amount of collateral to transfer for an isolated margin trade.
+     * Max leverage is capped at 98% of the the market's max leverage and takes the oraclePrice into account in order to pass collateral checks.
+     */
+    fun calculateIsolatedMarginTransferAmount(
+        parser: ParserProtocol,
+        trade: Map<String, Any>,
+        market: Map<String, Any>?,
+    ): Double? {
+        val targetLeverage = parser.asDouble(trade["targetLeverage"]) ?: 1.0
+        val size = parser.asDouble(parser.value(trade, "size.size"))?.abs() ?: return null
+        val oraclePrice = parser.asDouble(parser.value(market, "oraclePrice")) ?: return null
+        val askPrice = parser.asDouble(parser.value(trade, "summary.price")) ?: return null
+        val initialMarginFraction = parser.asDouble(parser.value(market, "configs.initialMarginFraction"))
+        val effectiveImf = parser.asDouble(parser.value(market, "configs.effectiveInitialMarginFraction"))
+
+        val maxLeverageForMarket = if (effectiveImf != null) {
+            1.0 / effectiveImf
+        } else if (initialMarginFraction != null) {
+            1.0 / initialMarginFraction
+        } else {
+            null
+        }
+
+        // Cap targetLeverage to 98% of max leverage
+        val adjustedTargetLeverage = if (maxLeverageForMarket != null) {
+            val cappedLeverage = maxLeverageForMarket * 0.98
+            if (targetLeverage > cappedLeverage) {
+                cappedLeverage
+            } else {
+                targetLeverage
+            }
+        } else {
+            null
+        }
+
+        return if (adjustedTargetLeverage == 0.0 || adjustedTargetLeverage == null) {
+            null
+        } else {
+            getTransferAmountFromTargetLeverage(
+                askPrice,
+                oraclePrice,
+                size,
+                targetLeverage=adjustedTargetLeverage,
+            )
+        }
     }
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginModeCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginModeCalculator.kt
@@ -2,6 +2,7 @@ package exchange.dydx.abacus.calculator
 
 import abs
 import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.utils.MAX_LEVERAGE_BUFFER_PERCENT
 import exchange.dydx.abacus.utils.MAX_SUBACCOUNT_NUMBER
 import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
 import kollections.iListOf
@@ -255,7 +256,7 @@ internal object MarginModeCalculator {
 
         // Cap targetLeverage to 98% of max leverage
         val adjustedTargetLeverage = if (maxLeverageForMarket != null) {
-            val cappedLeverage = maxLeverageForMarket * 0.98
+            val cappedLeverage = maxLeverageForMarket * MAX_LEVERAGE_BUFFER_PERCENT
             if (targetLeverage > cappedLeverage) {
                 cappedLeverage
             } else {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginModeCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginModeCalculator.kt
@@ -272,7 +272,7 @@ internal object MarginModeCalculator {
                 askPrice,
                 oraclePrice,
                 size,
-                targetLeverage=adjustedTargetLeverage,
+                targetLeverage = adjustedTargetLeverage,
             )
         }
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -11,7 +11,6 @@ import exchange.dydx.abacus.calculator.SlippageConstants.TAKE_PROFIT_MARKET_ORDE
 import exchange.dydx.abacus.output.input.MarginMode
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.state.manager.EnvironmentFeatureFlags
-import exchange.dydx.abacus.utils.MAX_SUBACCOUNT_NUMBER
 import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
 import exchange.dydx.abacus.utils.Numeric
 import exchange.dydx.abacus.utils.QUANTUM_MULTIPLIER
@@ -1780,7 +1779,8 @@ internal class TradeInputCalculator(
                 parser,
                 subaccount,
                 trade,
-            )) {
+            )
+        ) {
             val isolatedMarginTransferAmount = MarginModeCalculator.calculateIsolatedMarginTransferAmount(
                 parser,
                 trade,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -11,6 +11,8 @@ import exchange.dydx.abacus.calculator.SlippageConstants.TAKE_PROFIT_MARKET_ORDE
 import exchange.dydx.abacus.output.input.MarginMode
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.state.manager.EnvironmentFeatureFlags
+import exchange.dydx.abacus.utils.MAX_SUBACCOUNT_NUMBER
+import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
 import exchange.dydx.abacus.utils.Numeric
 import exchange.dydx.abacus.utils.QUANTUM_MULTIPLIER
 import exchange.dydx.abacus.utils.Rounder
@@ -52,7 +54,7 @@ internal class TradeInputCalculator(
 
     internal fun calculate(
         state: Map<String, Any>,
-        subaccountNumber: Int?,
+        subaccountNumber: Int,
         input: String?,
     ): Map<String, Any> {
         val account = parser.asNativeMap(state["account"])
@@ -402,6 +404,7 @@ internal class TradeInputCalculator(
         if (subaccount == null || market == null) {
             return null
         }
+
         val marginMode = parser.asString(parser.value(trade, "marginMode"))
         val marketId = parser.asString(market["id"]) ?: return null
         val position = parser.asNativeMap(
@@ -410,18 +413,17 @@ internal class TradeInputCalculator(
                 "openPositions.$marketId",
             ),
         )
+
         if (position != null) {
             when (marginMode) {
                 "ISOLATED" -> {
-                    // TODO: When the collateral of child subaccounts is implemented, return from here. The below code is the CROSS implementation.
-                    val currentNotionalTotal = parser.asDouble(parser.value(position, "notionalTotal.current"))
-                    val postOrderNotionalTotal = parser.asDouble(parser.value(position, "notionalTotal.postOrder"))
-                    val mmf = parser.asDouble(parser.value(market, "configs.maintenanceMarginFraction"))
-                    if (currentNotionalTotal != null && mmf != null) {
-                        if (postOrderNotionalTotal != null) {
-                            return postOrderNotionalTotal.times(mmf)
+                    val currentEquity = parser.asDouble(parser.value(position, "equity.current"))
+                    val postOrderEquity = parser.asDouble(parser.value(position, "equity.postOrder"))
+                    if (currentEquity != null) {
+                        if (postOrderEquity != null) {
+                            return postOrderEquity
                         }
-                        return currentNotionalTotal.times(mmf)
+                        return currentEquity
                     }
                 }
 
@@ -455,7 +457,14 @@ internal class TradeInputCalculator(
         market: Map<String, Any>?
     ): Double? {
         if (subaccount == null || market == null) return null
-        // TODO: When Child Subaccounts are added to Subaccount data class, return the child subaccount's leverage
+        val subaccountNumber = parser.asInt(subaccount["subaccountNumber"]) ?: return null
+
+        if (subaccountNumber >= NUM_PARENT_SUBACCOUNTS) {
+            val currentLeverage = parser.asDouble(parser.value(subaccount, "leverage.current"))
+            val postOrderLeverage = parser.asDouble(parser.value(subaccount, "leverage.postOrder"))
+            return postOrderLeverage ?: currentLeverage
+        }
+
         val marketId = parser.asString(market["id"])
         val position = parser.asNativeMap(
             parser.value(
@@ -1765,6 +1774,24 @@ internal class TradeInputCalculator(
 
             else -> {}
         }
+
+        // Calculate isolated margin transfer amount
+        if (MarginModeCalculator.getShouldTransferCollateral(
+                parser,
+                subaccount,
+                trade,
+            )) {
+            val isolatedMarginTransferAmount = MarginModeCalculator.calculateIsolatedMarginTransferAmount(
+                parser,
+                trade,
+                market,
+            )
+
+            summary.safeSet("isolatedMarginTransferAmount", isolatedMarginTransferAmount)
+        } else {
+            summary.safeSet("isolatedMarginTransferAmount", null)
+        }
+
         return summary
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
@@ -309,6 +309,7 @@ data class TradeInputSummary(
     val filled: Boolean,
     val positionMargin: Double?,
     val positionLeverage: Double?,
+    val isolatedMarginTransferAmount: Double?,
 ) {
     companion object {
         internal fun create(
@@ -330,6 +331,8 @@ data class TradeInputSummary(
                 val filled = parser.asBool(data["filled"]) ?: false
                 val positionMargin = parser.asDouble(data["positionMargin"])
                 val positionLeverage = parser.asDouble(data["positionLeverage"])
+                val isolatedMarginTransferAmount =
+                    parser.asDouble(data["isolatedMarginTransferAmount"])
 
                 return if (
                     existing?.price != price ||
@@ -341,7 +344,8 @@ data class TradeInputSummary(
                     existing?.total != total ||
                     existing?.positionMargin != positionMargin ||
                     existing?.positionLeverage != positionLeverage ||
-                    existing?.filled != filled
+                    existing?.filled != filled ||
+                    existing.isolatedMarginTransferAmount != isolatedMarginTransferAmount
                 ) {
                     TradeInputSummary(
                         price,
@@ -355,6 +359,7 @@ data class TradeInputSummary(
                         filled,
                         positionMargin,
                         positionLeverage,
+                        isolatedMarginTransferAmount,
                     )
                 } else {
                     existing

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
@@ -601,28 +601,30 @@ open class TradingStateMachine(
                 this.environment,
             )
 
-            when (this.input?.get("current")) {
-                "trade" -> {
-                    calculateTrade(subaccountNumber)
-                }
+            if (subaccountNumber != null) {
+                when (this.input?.get("current")) {
+                    "trade" -> {
+                        calculateTrade(subaccountNumber)
+                    }
 
-                "closePosition" -> {
-                    calculateClosePosition(subaccountNumber)
-                }
+                    "closePosition" -> {
+                        calculateClosePosition(subaccountNumber)
+                    }
 
-                "transfer" -> {
-                    calculateTransfer(subaccountNumber)
-                }
+                    "transfer" -> {
+                        calculateTransfer(subaccountNumber)
+                    }
 
-                "triggerOrders" -> {
-                    calculateTriggerOrders(subaccountNumber)
-                }
+                    "triggerOrders" -> {
+                        calculateTriggerOrders(subaccountNumber)
+                    }
 
-                "adjustIsolatedMargin" -> {
-                    calculateAdjustIsolatedMargin(subaccountNumber)
-                }
+                    "adjustIsolatedMargin" -> {
+                        calculateAdjustIsolatedMargin(subaccountNumber)
+                    }
 
-                else -> {}
+                    else -> {}
+                }
             }
         }
         recalculateStates(changes)
@@ -674,11 +676,11 @@ open class TradingStateMachine(
         return StateChanges(realChanges, changes.markets, changes.subaccountNumbers)
     }
 
-    private fun calculateTrade(subaccountNumber: Int?) {
+    private fun calculateTrade(subaccountNumber: Int) {
         calculateTrade("trade", TradeCalculation.trade, subaccountNumber)
     }
 
-    private fun calculateTrade(tag: String, calculation: TradeCalculation, subaccountNumber: Int?) {
+    private fun calculateTrade(tag: String, calculation: TradeCalculation, subaccountNumber: Int) {
         val input = this.input?.mutable()
         val trade = parser.asNativeMap(input?.get(tag))
         val inputType = parser.asString(parser.value(trade, "size.input"))
@@ -699,7 +701,7 @@ open class TradingStateMachine(
         this.input = input
     }
 
-    private fun calculateClosePosition(subaccountNumber: Int?) {
+    private fun calculateClosePosition(subaccountNumber: Int) {
         calculateTrade("closePosition", TradeCalculation.closePosition, subaccountNumber)
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -6,8 +6,10 @@ internal const val MAX_SUBACCOUNT_NUMBER = 128_000
 
 // Short Term Order Duration (Blocks) to add to GTB
 internal const val SHORT_TERM_ORDER_DURATION = 10
-
 internal const val QUANTUM_MULTIPLIER = 1_000_000
 
 // Route Param Constants
 internal const val SLIPPAGE_PERCENT = "1"
+
+// Isolated Margin Constants
+internal const val MAX_LEVERAGE_BUFFER_PERCENT = 0.98

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -327,6 +327,9 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             "targetLeverage": 2.0,
                             "options": {
                                 "needsMarginMode": true
+                            },
+                            "summary": {
+                                "isolatedMarginTransferAmount": 13.697401030000002
                             }
                         }
                     }
@@ -335,7 +338,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
         )
 
         val postOrderEquity = parser.asDouble(parser.value(perp.data, "wallet.account.groupedSubaccounts.0.openPositions.APE-USD.equity.postOrder")) ?: 0.0
-        assertEquals(postOrderEquity, 10.0)
+        assertEquals(postOrderEquity, 13.697401030000002)
     }
 
     @Test


### PR DESCRIPTION
### Description
* `AccountTransformer`
  * remove `calculateIsolatedMarginTransferAmount`. Moved calculation for transfer amount into `MarginModeCalculator`
  * Utilize new `getShouldTransferCollateral` and `calculateIsolatedMarginTranasferAmount` 

* `MarginModeCalculator`
  *  Add 4 new helper functions
  * `getIsIncreasingPositionSize` which is used in `getShouldTransferCollateral`
  * `calculateIsolatedMarginTransferAmount` which caps the targetLeverage to 98% of Max Leverage and returns `getTransferAmountFromTargetLeverage`

* `TradeInputCalculator`
  * Update `ISOLATED` switch cases to return correct values
  * utilize `getShouldTransferCollateral` to determine whether to `calculateIsolatedMarginTransferAmount`
  * Save value to `summary.isolatedMarginTransferAmount`

* `TradeInput`
  * add `isolatedMarginTransferAmount` to `TradeInputSummary`

* `TradingStateMachine`
  * make `subaccountNumber` required, it should never be null

* `SubaccountSupervisor`
  * Remove naive transfer amount math and read directly from `trade.summary.isolatedMarginTransferAmount`

* `Constants`
  * add `MAX_LEVERAGE_BUFFER_PERCENT`

* `IsolatedMarginModeTests`
  * Update test to include `summary.isolatedMarginTransferAmount` comparison  