### PR TITLE
feat: enable testnet OTE flows

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/IRouterProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/IRouterProcessor.kt
@@ -8,6 +8,7 @@ interface IRouterProcessor {
     var tokens: List<Any>?
     var chains: List<Any>?
     var exchangeDestinationChainId: String?
+
     fun receivedChains(
         existing: Map<String, Any>?,
         payload: Map<String, Any>

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -144,7 +144,7 @@ internal class SkipProcessor(
     override fun updateTokensDefaults(modified: MutableMap<String, Any>, selectedChainId: String?) {
         val tokenOptions = tokenOptions(selectedChainId)
         internalState.tokens = tokenOptions
-        modified.safeSet("transfer.token    ", defaultTokenAddress(selectedChainId))
+        modified.safeSet("transfer.token", defaultTokenAddress(selectedChainId))
         modified.safeSet("transfer.depositOptions.tokens", tokenOptions)
         modified.safeSet("transfer.withdrawalOptions.tokens", tokenOptions)
         internalState.tokenResources = tokenResources(selectedChainId)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
@@ -103,16 +103,20 @@ class V4StateManagerConfigs(
         return if (environment.isMainNet) "noble-1" else "grand-1"
     }
 
-    fun osmosisChainId(): String? {
-        return if (environment.isMainNet) "osmosis-1" else "osmosis-5"
+    fun osmosisChainId(): String {
+        return if (environment.isMainNet) "osmosis-1" else "osmo-test-5"
+    }
+
+    fun neutronChainId(): String {
+        return if (environment.isMainNet) "neutron-1" else "pion-1"
     }
 
     fun skipV1Chains(): String {
-        return "$skipHost/v1/info/chains?include_evm=true"
+        return "$skipHost/v1/info/chains?include_evm=true$onlyTestnets"
     }
 
     fun skipV1Assets(): String {
-        return "$skipHost/v1/fungible/assets?include_evm_assets=true"
+        return "$skipHost/v1/fungible/assets?include_evm_assets=true$onlyTestnets"
     }
 
     fun skipV2MsgsDirect(): String {
@@ -120,6 +124,11 @@ class V4StateManagerConfigs(
     }
 
     val nobleDenom = "uusdc"
+
+    private val onlyTestnets: String
+        get() {
+            return if (environment.isMainNet) "" else "&only_testnets=true"
+        }
 
     private val skipHost: String
         get() {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -654,60 +654,53 @@ internal open class AccountSupervisor(
             }
         }
     }
+
     private fun transferNobleBalanceSkip(amount: BigDecimal) {
         val url = helper.configs.skipV2MsgsDirect()
         val fromChain = helper.configs.nobleChainId()
         val fromToken = helper.configs.nobleDenom()
-        val nobleAddress = accountAddress.toNobleAddress()
-        val chainId = helper.environment.dydxChainId
-        val dydxTokenDemon = helper.environment.tokens["usdc"]?.denom
-        if (
-            fromChain != null &&
-            fromToken != null &&
-            nobleAddress != null &&
-            chainId != null &&
-            dydxTokenDemon != null
-        ) {
-            val body: Map<String, Any> = mapOf(
-                "amount_in" to amount.toPlainString(),
+        val nobleAddress = accountAddress.toNobleAddress() ?: return
+        val chainId = helper.environment.dydxChainId ?: return
+        val dydxTokenDemon = helper.environment.tokens["usdc"]?.denom ?: return
+        val body: Map<String, Any> = mapOf(
+            "amount_in" to amount.toPlainString(),
 //              from noble denom and chain
-                "source_asset_denom" to fromToken,
-                "source_asset_chain_id" to fromChain,
+            "source_asset_denom" to fromToken,
+            "source_asset_chain_id" to fromChain,
 //              to dydx denom and chain
-                "dest_asset_denom" to dydxTokenDemon,
-                "dest_asset_chain_id" to chainId,
-                "chain_ids_to_addresses" to mapOf(
-                    fromChain to nobleAddress,
-                    chainId to accountAddress.toString(),
-                ),
-                "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
+            "dest_asset_denom" to dydxTokenDemon,
+            "dest_asset_chain_id" to chainId,
+            "chain_ids_to_addresses" to mapOf(
+                fromChain to nobleAddress,
+                chainId to accountAddress,
+            ),
+            "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
+        )
+        val header =
+            iMapOf(
+                "Content-Type" to "application/json",
             )
-            val header =
-                iMapOf(
-                    "Content-Type" to "application/json",
-                )
-            helper.post(url, header, body.toJsonPrettyPrint()) { _, response, code, _ ->
-                if (response == null) {
-                    val json = helper.parser.decodeJsonObject(response)
-                    if (json != null) {
-                        val skipRoutePayloadProcessor = SkipRoutePayloadProcessor(parser = helper.parser)
-                        val processedPayload = skipRoutePayloadProcessor.received(existing = mapOf(), payload = json)
-                        val ibcPayload =
-                            helper.parser.asString(
-                                processedPayload.get("data"),
-                            )
-                        if (ibcPayload != null) {
-                            helper.transaction(TransactionType.SendNobleIBC, ibcPayload) {
-                                val error = helper.parseTransactionResponse(it)
-                                if (error != null) {
-                                    Logger.e { "transferNobleBalanceSkip error: $error" }
-                                }
+        helper.post(url, header, body.toJsonPrettyPrint()) { _, response, code, _ ->
+            if (response == null) {
+                val json = helper.parser.decodeJsonObject(response)
+                if (json != null) {
+                    val skipRoutePayloadProcessor = SkipRoutePayloadProcessor(parser = helper.parser)
+                    val processedPayload = skipRoutePayloadProcessor.received(existing = mapOf(), payload = json)
+                    val ibcPayload =
+                        helper.parser.asString(
+                            processedPayload.get("data"),
+                        )
+                    if (ibcPayload != null) {
+                        helper.transaction(TransactionType.SendNobleIBC, ibcPayload) {
+                            val error = helper.parseTransactionResponse(it)
+                            if (error != null) {
+                                Logger.e { "transferNobleBalanceSkip error: $error" }
                             }
                         }
                     }
-                } else {
-                    Logger.e { "transferNobleBalanceSkip error, code: $code" }
                 }
+            } else {
+                Logger.e { "transferNobleBalanceSkip error, code: $code" }
             }
         }
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -654,6 +654,63 @@ internal open class AccountSupervisor(
             }
         }
     }
+    private fun transferNobleBalanceSkip(amount: BigDecimal) {
+        val url = helper.configs.skipV2MsgsDirect()
+        val fromChain = helper.configs.nobleChainId()
+        val fromToken = helper.configs.nobleDenom()
+        val nobleAddress = accountAddress.toNobleAddress()
+        val chainId = helper.environment.dydxChainId
+        val dydxTokenDemon = helper.environment.tokens["usdc"]?.denom
+        if (
+            fromChain != null &&
+            fromToken != null &&
+            nobleAddress != null &&
+            chainId != null &&
+            dydxTokenDemon != null
+        ) {
+            val body: Map<String, Any> = mapOf(
+                "amount_in" to amount.toPlainString(),
+//              from noble denom and chain
+                "source_asset_denom" to fromToken,
+                "source_asset_chain_id" to fromChain,
+//              to dydx denom and chain
+                "dest_asset_denom" to dydxTokenDemon,
+                "dest_asset_chain_id" to chainId,
+                "chain_ids_to_addresses" to mapOf(
+                    fromChain to nobleAddress,
+                    chainId to accountAddress.toString(),
+                ),
+                "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
+            )
+            val header =
+                iMapOf(
+                    "Content-Type" to "application/json",
+                )
+            helper.post(url, header, body.toJsonPrettyPrint()) { _, response, code, _ ->
+                if (response == null) {
+                    val json = helper.parser.decodeJsonObject(response)
+                    if (json != null) {
+                        val skipRoutePayloadProcessor = SkipRoutePayloadProcessor(parser = helper.parser)
+                        val processedPayload = skipRoutePayloadProcessor.received(existing = mapOf(), payload = json)
+                        val ibcPayload =
+                            helper.parser.asString(
+                                processedPayload.get("data"),
+                            )
+                        if (ibcPayload != null) {
+                            helper.transaction(TransactionType.SendNobleIBC, ibcPayload) {
+                                val error = helper.parseTransactionResponse(it)
+                                if (error != null) {
+                                    Logger.e { "transferNobleBalanceSkip error: $error" }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    Logger.e { "transferNobleBalanceSkip error, code: $code" }
+                }
+            }
+        }
+    }
 
     private fun transferNobleBalanceSkip(amount: BigDecimal) {
         val url = helper.configs.skipV2MsgsDirect()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -658,7 +658,7 @@ internal open class AccountSupervisor(
     private fun transferNobleBalanceSkip(amount: BigDecimal) {
         val url = helper.configs.skipV2MsgsDirect()
         val fromChain = helper.configs.nobleChainId()
-        val fromToken = helper.configs.nobleDenom()
+        val fromToken = helper.configs.nobleDenom
         val nobleAddress = accountAddress.toNobleAddress() ?: return
         val chainId = helper.environment.dydxChainId ?: return
         val dydxTokenDemon = helper.environment.tokens["usdc"]?.denom ?: return

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -1018,10 +1018,9 @@ internal class OnboardingSupervisor(
             return
         }
         if (fromAmount <= 0) return
-        val osmosisAddress = accountAddress.toOsmosisAddress() ?: return
-        val nobleAddress = accountAddress.toNobleAddress() ?: return
-        val osmosisChainId = helper.configs.osmosisChainId() ?: return
+        val osmosisChainId = helper.configs.osmosisChainId()
         val nobleChainId = helper.configs.nobleChainId()
+        val neutronChainId = helper.configs.neutronChainId()
         val fromChain = helper.environment.dydxChainId ?: return
         val fromToken = helper.environment.tokens["usdc"]?.denom ?: return
         val fromAmountString = helper.parser.asString(fromAmount) ?: return
@@ -1034,9 +1033,9 @@ internal class OnboardingSupervisor(
             "dest_asset_chain_id" to toChain,
             "chain_ids_to_addresses" to mapOf(
                 fromChain to accountAddress,
-                osmosisChainId to osmosisAddress,
-                nobleChainId to nobleAddress,
-                "neutron-1" to accountAddress.toNeutronAddress(),
+                osmosisChainId to accountAddress.toOsmosisAddress(),
+                nobleChainId to accountAddress.toNobleAddress(),
+                neutronChainId to accountAddress.toNeutronAddress(),
                 toChain to toAddress,
             ),
             "allow_multi_tx" to true,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -17,3 +17,6 @@ internal const val MAX_LEVERAGE_BUFFER_PERCENT = 0.98
 // Order flags
 internal const val SHORT_TERM_ORDER_FLAGS = 0
 internal const val CONDITIONAL_ORDER_FLAGS = 32
+
+// Asset Constants
+internal const val NATIVE_TOKEN_DEFAULT_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
@@ -174,6 +174,96 @@ class SkipRouteProcessorTests {
         assertEquals(expected, result)
     }
 
+    /**
+     * Tests a CCTP withdrawal initiated from the cctpToNobleSkip method
+     * This payload is used by the chain transaction method WithdrawToNobleIBC
+     * This processes a Dydx -> Noble CCTP transaction
+     */
+    @Test
+    fun testReceivedCCTPDydxToNoble() {
+        val payload = skipRouteMock.payloadCCTPDydxToNoble
+        val result = skipRouteProcessor.received(existing = mapOf(), payload = templateToJson(payload), decimals = 6.0)
+        val jsonEncoder = JsonEncoder()
+        val expectedMsg = mapOf(
+            "sourcePort" to "transfer",
+            "sourceChannel" to "channel-0",
+            "token" to mapOf(
+                "denom" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+                "amount" to "10996029",
+            ),
+            "sender" to "dydx1nhzuazjhyfu474er6v4ey8zn6wa5fy6g2dgp7s",
+            "receiver" to "noble1nhzuazjhyfu474er6v4ey8zn6wa5fy6gthndxf",
+            "timeoutHeight" to mapOf<String, Any>(),
+            "timeoutTimestamp" to 1718308711061386287,
+        )
+        val expectedData = jsonEncoder.encode(
+            mapOf(
+                "msg" to expectedMsg,
+                "value" to expectedMsg,
+                "msgTypeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
+                "typeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
+            ),
+        )
+        val expected = mapOf(
+            "toAmountUSD" to 11.01,
+            "toAmount" to 10.996029,
+            "slippage" to "1",
+            "requestPayload" to mapOf(
+                "fromChainId" to "dydx-mainnet-1",
+                "fromAddress" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+                "toChainId" to "noble-1",
+                "toAddress" to "uusdc",
+                "data" to expectedData,
+            ),
+        )
+        assertEquals(expected, result)
+    }
+
+    /**
+     * Tests a CCTP autosweep from the transferNobleBalance method
+     * This payload is used by the chain transaction method sendNobleIBC
+     * This processes a Noble -> Dydx CCTP transaction
+     */
+    @Test
+    fun testReceivedCCTPNobleToDydx() {
+        val payload = skipRouteMock.payloadCCTPNobleToDydx
+        val result = skipRouteProcessor.received(existing = mapOf(), payload = templateToJson(payload), decimals = 6.0)
+        val jsonEncoder = JsonEncoder()
+        val expectedMsg = mapOf(
+            "sourcePort" to "transfer",
+            "sourceChannel" to "channel-33",
+            "token" to mapOf(
+                "denom" to "uusdc",
+                "amount" to "5884",
+            ),
+            "sender" to "noble1nhzuazjhyfu474er6v4ey8zn6wa5fy6gthndxf",
+            "receiver" to "dydx1nhzuazjhyfu474er6v4ey8zn6wa5fy6g2dgp7s",
+            "timeoutHeight" to mapOf<String, Any>(),
+            "timeoutTimestamp" to 1718318348813666048,
+        )
+        val expectedData = jsonEncoder.encode(
+            mapOf(
+                "msg" to expectedMsg,
+                "value" to expectedMsg,
+                "msgTypeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
+                "typeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
+            ),
+        )
+        val expected = mapOf(
+            "toAmountUSD" to 0.01,
+            "toAmount" to 0.005884,
+            "slippage" to "1",
+            "requestPayload" to mapOf(
+                "fromChainId" to "noble-1",
+                "fromAddress" to "uusdc",
+                "toChainId" to "dydx-mainnet-1",
+                "toAddress" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+                "data" to expectedData,
+            ),
+        )
+        assertEquals(expected, result)
+    }
+
     @Test
     fun testReceivedError() {
         val payload = skipRouteMock.payloadError


### PR DESCRIPTION
NOTE: This doesn't fully enable testnet. We cannot perform withdrawals and deposits. But this is still past parity with existing squid integration as the route endpoint always fails on testnets. 

Squid integration: fails on `/v1/route`. `Withdraw` / `Deposit` button is never enabled, fees never estimated, just get a route error.
Skip Integration (this PR): succeeds on `/msgs_direct`, button is enabled, fees estimated. Failure upon clicking the button.

