### PR TITLE
change retrieveSparklines to true for web

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.86"
+version = "1.7.87"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.85"
+version = "1.7.86"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/Configs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/Configs.kt
@@ -55,7 +55,7 @@ data class MarketsConfigs(
             subscribeToCandles = true,
         )
         val forWeb = MarketsConfigs(
-            retrieveSparklines = false,
+            retrieveSparklines = true,
             retrieveCandles = false,
             retrieveHistoricalFundings = true,
             subscribeToMarkets = true,


### PR DESCRIPTION
Web utilizes the 24h sparklines, re-enable for AbacusV2 configs for web.