### PR TITLE
Apply the same logic to calculate marginMode and targetLeverage for new and existing trade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.89"
+version = "1.7.90"
 
 repositories {
     google()


### PR DESCRIPTION
Otherwise, when the first market to trade is isolated (i.e., initiateTrade() gets called), the targetLeverage of the position is not applied.