### PR TITLE
update margin transfer calculation with absolute net size (flipped isolated position)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.7.91"
+version = "1.7.92"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
@@ -58,6 +58,7 @@ class AccountTransformer() {
                     parser,
                     trade,
                     market,
+                    subaccount = childSubaccount,
                 ) ?: 0.0
             } else {
                 0.0

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
@@ -204,7 +204,7 @@ internal object MarginCalculator {
         tradeInput: Map<String, Any>?,
     ): Boolean {
         return getPositionSizeDifference(parser, subaccount, tradeInput)?.let {
-            it.compareTo(Numeric.double.ZERO) > 0 // whether it's is positive
+            it.compareTo(Numeric.double.ZERO) > 0 // whether it's positive
         } ?: true
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
@@ -204,7 +204,7 @@ internal object MarginCalculator {
         tradeInput: Map<String, Any>?,
     ): Boolean {
         return getPositionSizeDifference(parser, subaccount, tradeInput)?.let {
-            it.compareTo(Numeric.double.ZERO) == 1
+            it.compareTo(Numeric.double.ZERO) > 0 // whether it's is positive
         } ?: true
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -1785,6 +1785,7 @@ internal class TradeInputCalculator(
                 parser,
                 trade,
                 market,
+                subaccount,
             )
 
             summary.safeSet("isolatedMarginTransferAmount", isolatedMarginTransferAmount)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -303,7 +303,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         }
                     }
                 }
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         // input a trade that will flip position absolute net size +10
@@ -356,7 +356,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         }
                     }
                 }
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -134,6 +134,11 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
         testMarginAmountForSubaccountTransfer()
     }
 
+    @Test
+    fun testMarginModeWithExistingPosition() {
+        testMarginAmountForSubaccountTransferWithExistingIsolatedPosition()
+    }
+
     // MarginMode should automatically to match the current market based on a variety of factors
     private fun testMarginModeOnMarketChange() {
         testParentSubaccountSubscribedWithPendingPositions()
@@ -201,6 +206,157 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                     }
                 }
             """.trimIndent(),
+        )
+    }
+
+    private fun testMarginAmountForSubaccountTransferWithExistingIsolatedPosition() {
+        test(
+            {
+                perp.socket(
+                    testWsUrl,
+                    mock.parentSubaccountsChannel.read_subscribe_with_isolated_position,
+                    0,
+                    null,
+                )
+            },
+            """
+                {
+                    "wallet": {
+                        "account": {
+                            "groupedSubaccounts": {
+                                "0": {
+                                    "equity": {
+                                        "current": 162.33
+                                    },
+                                    "freeCollateral": {
+                                        "current": 137.13
+                                    },
+                                    "quoteBalance": {
+                                        "current": 137.13
+                                    },
+                                    "openPositions": {
+                                        "APE-USD": {
+                                            "size": {
+                                                "current": 20
+                                            },
+                                            "equity": {
+                                                "current": 25.20
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            """.trimIndent(),
+        )
+
+        // input a trade that will reduce existing position
+        perp.tradeInMarket("APE-USD", 0)
+        perp.trade("ISOLATED", TradeInputField.marginMode, 0)
+        perp.trade("-10", TradeInputField.size, 0)
+        perp.trade("2", TradeInputField.limitPrice, 0)
+        test(
+            {
+                perp.trade("1", TradeInputField.targetLeverage, 0)
+            },
+            """
+                {
+                    "wallet": {
+                        "account": {
+                            "groupedSubaccounts": {
+                                "0": {
+                                    "freeCollateral": {
+                                        "current": 137.13
+                                    },
+                                    "openPositions": {
+                                        "APE-USD": {
+                                            "size": {
+                                                "current": 20,
+                                                "postOrder": 10
+                                            },
+                                            "equity": {
+                                                "current": 25.20,
+                                                "postOrder": 25.20
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "input": {
+                        "current": "trade",
+                        "trade": {
+                            "marketId": "APE-USD",
+                            "marginMode": "ISOLATED",
+                            "size": {
+                                "size": -10.0
+                            },
+                            "price": {
+                                "limitPrice": 2.0
+                            },
+                            "targetLeverage": 1.0,
+                            "summary": {
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+        )
+
+        // input a trade that will flip position absolute net size +10
+        perp.trade("-50", TradeInputField.size, 0)
+        test(
+            {
+                perp.trade("1", TradeInputField.targetLeverage, 0)
+            },
+            """
+                {
+                    "wallet": {
+                        "account": {
+                            "groupedSubaccounts": {
+                                "0": {
+                                    "freeCollateral": {
+                                        "current": 137.13,
+                                        "postOrder": 117.13
+                                    },
+                                    "openPositions": {
+                                        "APE-USD": {
+                                            "size": {
+                                                "current": 20,
+                                                "postOrder": -30
+                                            },
+                                            "equity": {
+                                                "current": 25.20,
+                                                "postOrder": 45.20
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "input": {
+                        "current": "trade",
+                        "trade": {
+                            "marketId": "APE-USD",
+                            "marginMode": "ISOLATED",
+                            "size": {
+                                "size": -50.0
+                            },
+                            "price": {
+                                "limitPrice": 2.0
+                            },
+                            "targetLeverage": 1.0,
+                            "summary": {
+                                "isolatedMarginTransferAmount": 20.0
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
         )
     }
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/ParentSubaccountsChannelMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/ParentSubaccountsChannelMock.kt
@@ -976,6 +976,81 @@ internal class ParentSubaccountsChannelMock {
         }
     """.trimIndent()
 
+    internal val read_subscribe_with_isolated_position = """
+        {
+          "type": "subscribed",
+          "connection_id": "54dfe8a3-db43-4d07-b37f-66b37d00296c",
+          "message_id": 2,
+          "channel": "v4_parent_subaccounts",
+          "id": "dydx1jd8uuuwcfr2xg6ek0g3mes2kppzm54qd65npwe/0",
+          "contents": {
+            "subaccount": {
+              "address": "dydx1jd8uuuwcfr2xg6ek0g3mes2kppzm54qd65npwe",
+              "parentSubaccountNumber": 0,
+              "equity": "155.66683808",
+              "freeCollateral": "151.957356664",
+              "childSubaccounts": [
+                {
+                  "address": "dydx1jd8uuuwcfr2xg6ek0g3mes2kppzm54qd65npwe",
+                  "subaccountNumber": 0,
+                  "equity": "137.128721",
+                  "freeCollateral": "137.128721",
+                  "openPerpetualPositions": {},
+                  "assetPositions": {
+                    "USDC": {
+                      "size": "137.128721",
+                      "symbol": "USDC",
+                      "side": "LONG",
+                      "assetId": "0",
+                      "subaccountNumber": 0
+                    }
+                  },
+                  "marginEnabled": true
+                },
+                {
+                  "address": "dydx1jd8uuuwcfr2xg6ek0g3mes2kppzm54qd65npwe",
+                  "subaccountNumber": 128,
+                  "equity": "18.53811708",
+                  "freeCollateral": "14.828635664",
+                  "openPerpetualPositions": {
+                    "APE-USD": {
+                      "market": "APE-USD",
+                      "status": "OPEN",
+                      "side": "LONG",
+                      "size": "20",
+                      "maxSize": "20",
+                      "entryPrice": "0.929",
+                      "exitPrice": null,
+                      "realizedPnl": "0",
+                      "unrealizedPnl": "-0.03259292",
+                      "createdAt": "2024-06-21T19:30:50.890Z",
+                      "createdAtHeight": "18641960",
+                      "closedAt": null,
+                      "sumOpen": "20",
+                      "sumClose": "0",
+                      "netFunding": "0",
+                      "subaccountNumber": 128
+                    }
+                  },
+                  "assetPositions": {
+                    "USDC": {
+                      "size": "0.00929",
+                      "symbol": "USDC",
+                      "side": "SHORT",
+                      "assetId": "0",
+                      "subaccountNumber": 128
+                    }
+                  },
+                  "marginEnabled": true
+                }
+              ]
+            },
+            "orders": [],
+            "blockHeight": "18642087"
+          }
+        }
+    """.trimIndent()
+
     internal val real_channel_batch_data = """
         {
             "type": "channel_batch_data",


### PR DESCRIPTION
in calculating how much margin to transfer, should take absolute net size change instead of using the full order amount, so when the position is flipped, it doesn't transfer too much margin

<img width="1248" alt="image" src="https://github.com/dydxprotocol/v4-abacus/assets/9400120/b47ca731-0e3c-42c3-bfe6-27d3cc83c6fd">

