### PR TITLE
Fix negative input to margin input amount

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.0"
+version = "1.8.1"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.3"
+version = "1.8.4"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.2"
+version = "1.8.4"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.1"
+version = "1.8.2"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+AdjustIsolatedMarginInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+AdjustIsolatedMarginInput.kt
@@ -14,6 +14,7 @@ import exchange.dydx.abacus.utils.safeSet
 import kollections.JsExport
 import kollections.iListOf
 import kotlinx.serialization.Serializable
+import kotlin.math.absoluteValue
 
 @JsExport
 @Serializable
@@ -88,7 +89,7 @@ fun TradingStateMachine.adjustIsolatedMargin(
                     } else {
                         equity
                     }
-                    val amountValue = parser.asDouble(data)
+                    val amountValue = parser.asDouble(data)?.absoluteValue
 
                     if (amountValue == null) {
                         adjustIsolatedMargin.safeSet("Amount", null)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/AdjustIsolatedMarginInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/AdjustIsolatedMarginInputTests.kt
@@ -135,6 +135,22 @@ class AdjustIsolatedMarginInputTests : V4BaseTests(useParentSubaccount = true) {
             }
             """.trimIndent(),
         )
+
+        test(
+            {
+                perp.adjustIsolatedMargin("-92.49", AdjustIsolatedMarginInputField.Amount, 0)
+            },
+            """
+            {
+                "input": {
+                    "current": "adjustIsolatedMargin",
+                    "adjustIsolatedMargin": {
+                        "Amount": "92.49"
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
     }
 
     private fun testMarginRemoval() {


### PR DESCRIPTION
Mobile app sends the input field as-is, so there can be negative numbers.  For margin, we will just ignore the sign.