### PR TITLE
feat: expose get chain by id method

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.5"
+version = "1.8.6"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/IRouterProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/IRouterProcessor.kt
@@ -43,6 +43,10 @@ interface IRouterProcessor {
         transactionId: String?,
     ): Map<String, Any>?
 
+    fun getChainById(
+        chainId: String
+    ): Map<String, Any>?
+
     fun getTokenByDenomAndChainId(tokenDenom: String?, chainId: String?): Map<String, Any>?
     fun updateTokensDefaults(modified: MutableMap<String, Any>, selectedChainId: String?)
     fun defaultChainId(): String?

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -145,7 +145,7 @@ internal class SkipProcessor(
         internalState.tokenResources = tokenResources(selectedChainId)
     }
 
-    private fun getChainById(chainId: String): Map<String, Any>? {
+    override fun getChainById(chainId: String): Map<String, Any>? {
         return parser.asNativeMap(this.chains?.find { parser.asString(parser.asNativeMap(it)?.get("chain_id")) == chainId })
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -145,6 +145,8 @@ internal class SkipProcessor(
         internalState.tokenResources = tokenResources(selectedChainId)
     }
 
+//    Update this when we move chains to state
+//    https://linear.app/dydx/issue/OTE-470/migrate-chains-and-tokens-to-abacus-state
     override fun getChainById(chainId: String): Map<String, Any>? {
         return parser.asNativeMap(this.chains?.find { parser.asString(parser.asNativeMap(it)?.get("chain_id")) == chainId })
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/squid/SquidProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/squid/SquidProcessor.kt
@@ -170,6 +170,10 @@ internal class SquidProcessor(
         return processor.received(existing, payload)
     }
 
+    override fun getChainById(chainId: String): Map<String, Any>? {
+        return parser.asNativeMap(this.chains?.find { parser.asString(parser.asNativeMap(it)?.get("chainId")) == chainId })
+    }
+
     override fun updateTokensDefaults(modified: MutableMap<String, Any>, selectedChainId: String?) {
         val tokenOptions = tokenOptions(selectedChainId)
         internalState.tokens = tokenOptions

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
@@ -93,7 +93,7 @@ interface AsyncAbacusStateManagerProtocol {
     fun triggerCompliance(action: ComplianceAction, callback: TransactionCallback)
 
     // Get chain data from id. Necessary to know chain name based on chain id
-    fun getChainById(chainId: String): HumanReadableChainPayload?
+    fun getChainById(chainId: String): TransferChainInfo?
 }
 
 @JsExport

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
@@ -91,6 +91,9 @@ interface AsyncAbacusStateManagerProtocol {
 
     // Trigger update for compliance
     fun triggerCompliance(action: ComplianceAction, callback: TransactionCallback)
+
+    // Get chain data from id. Necessary to know chain name based on chain id
+    fun getChainById(chainId: String): Map<String, Any>?
 }
 
 @JsExport

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
@@ -93,7 +93,7 @@ interface AsyncAbacusStateManagerProtocol {
     fun triggerCompliance(action: ComplianceAction, callback: TransactionCallback)
 
     // Get chain data from id. Necessary to know chain name based on chain id
-    fun getChainById(chainId: String): Map<String, Any>?
+    fun getChainById(chainId: String): HumanReadableChainPayload?
 }
 
 @JsExport

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
@@ -130,3 +130,13 @@ data class HumanReadableTransferPayload(
     val amount: String,
     val recipient: String,
 )
+
+@JsExport
+@Serializable
+data class HumanReadableChainPayload(
+    val chainName: String,
+    val chainId: String,
+    val logoUri: String,
+    val chainType: String,
+    val isTestnet: Boolean,
+)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
@@ -133,7 +133,7 @@ data class HumanReadableTransferPayload(
 
 @JsExport
 @Serializable
-data class HumanReadableChainPayload(
+data class TransferChainInfo(
     val chainName: String,
     val chainId: String,
     val logoUri: String,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
@@ -23,6 +23,7 @@ import exchange.dydx.abacus.state.manager.GasToken
 import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
+import exchange.dydx.abacus.state.manager.HumanReadableChainPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableSubaccountTransferPayload
@@ -42,7 +43,6 @@ import exchange.dydx.abacus.utils.CoroutineTimer
 import exchange.dydx.abacus.utils.DummyFormatter
 import exchange.dydx.abacus.utils.DummyLocalizer
 import exchange.dydx.abacus.utils.IList
-import exchange.dydx.abacus.utils.IMap
 import exchange.dydx.abacus.utils.IOImplementations
 import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.Parser
@@ -622,8 +622,21 @@ class AsyncAbacusStateManagerV2(
         adaptor?.screen(address, callback)
     }
 
-    override fun getChainById(chainId: String): IMap<String, Any>? {
-        val parser = Parser()
-        return parser.asMap(adaptor?.stateMachine?.routerProcessor?.getChainById(chainId = chainId))
+    override fun getChainById(chainId: String): HumanReadableChainPayload? {
+        val chainMap = adaptor?.stateMachine?.routerProcessor?.getChainById(chainId = chainId)
+        val chainName = chainMap?.get("chain_name")
+        val logoUri = chainMap?.get("logo_uri")
+        val chainType = chainMap?.get("chain_type")
+        val isTestnet = chainMap?.get("is_testnet")
+        if (chainName is String && logoUri is String && chainType is String && isTestnet is Boolean) {
+            return HumanReadableChainPayload(
+                chainName = chainName,
+                chainId = chainType,
+                logoUri = logoUri,
+                chainType = chainType,
+                isTestnet = isTestnet,
+            )
+        }
+        return null
     }
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
@@ -23,7 +23,6 @@ import exchange.dydx.abacus.state.manager.GasToken
 import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
-import exchange.dydx.abacus.state.manager.HumanReadableChainPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableSubaccountTransferPayload
@@ -31,6 +30,7 @@ import exchange.dydx.abacus.state.manager.HumanReadableTriggerOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableWithdrawPayload
 import exchange.dydx.abacus.state.manager.OrderbookGrouping
 import exchange.dydx.abacus.state.manager.SingletonAsyncAbacusStateManagerProtocol
+import exchange.dydx.abacus.state.manager.TransferChainInfo
 import exchange.dydx.abacus.state.manager.V4Environment
 import exchange.dydx.abacus.state.manager.configs.V4StateManagerConfigs
 import exchange.dydx.abacus.state.model.AdjustIsolatedMarginInputField
@@ -622,14 +622,15 @@ class AsyncAbacusStateManagerV2(
         adaptor?.screen(address, callback)
     }
 
-    override fun getChainById(chainId: String): HumanReadableChainPayload? {
+    override fun getChainById(chainId: String): TransferChainInfo? {
+        val parser = Parser()
         val chainMap = adaptor?.stateMachine?.routerProcessor?.getChainById(chainId = chainId)
-        val chainName = chainMap?.get("chain_name")
-        val logoUri = chainMap?.get("logo_uri")
-        val chainType = chainMap?.get("chain_type")
-        val isTestnet = chainMap?.get("is_testnet")
+        val chainName = parser.asString(chainMap?.get("chain_name"))
+        val logoUri = parser.asString(chainMap?.get("logo_uri"))
+        val chainType = parser.asString(chainMap?.get("chain_type"))
+        val isTestnet = parser.asBool(chainMap?.get("is_testnet"))
         if (chainName is String && logoUri is String && chainType is String && isTestnet is Boolean) {
-            return HumanReadableChainPayload(
+            return TransferChainInfo(
                 chainName = chainName,
                 chainId = chainType,
                 logoUri = logoUri,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
@@ -42,6 +42,7 @@ import exchange.dydx.abacus.utils.CoroutineTimer
 import exchange.dydx.abacus.utils.DummyFormatter
 import exchange.dydx.abacus.utils.DummyLocalizer
 import exchange.dydx.abacus.utils.IList
+import exchange.dydx.abacus.utils.IMap
 import exchange.dydx.abacus.utils.IOImplementations
 import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.Parser
@@ -619,5 +620,10 @@ class AsyncAbacusStateManagerV2(
 
     override fun screen(address: String, callback: (restriction: Restriction) -> Unit) {
         adaptor?.screen(address, callback)
+    }
+
+    override fun getChainById(chainId: String): IMap<String, Any>? {
+        val parser = Parser()
+        return parser.asMap(adaptor?.stateMachine?.routerProcessor?.getChainById(chainId = chainId))
     }
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
@@ -708,7 +708,12 @@ internal class StateManagerAdaptorV2(
             state?.transferStatuses,
             state?.restriction,
             state?.launchIncentive,
-            Compliance(geo, state?.compliance?.status ?: ComplianceStatus.COMPLIANT, state?.compliance?.updatedAt, state?.compliance?.expiresAt),
+            Compliance(
+                geo,
+                state?.compliance?.status ?: ComplianceStatus.COMPLIANT,
+                state?.compliance?.updatedAt,
+                state?.compliance?.expiresAt,
+            ),
         )
         ioImplementations.threading?.async(ThreadingType.main) {
             stateNotification?.stateChanged(

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
@@ -7,6 +7,7 @@ import exchange.dydx.abacus.tests.payloads.SkipChainsMock
 import exchange.dydx.abacus.tests.payloads.SkipRouteMock
 import exchange.dydx.abacus.tests.payloads.SkipTokensMock
 import exchange.dydx.abacus.utils.Parser
+import exchange.dydx.abacus.utils.toJsonObject
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlin.test.BeforeTest
@@ -345,6 +346,43 @@ class SkipProcessorTests {
                 ),
             ),
         )
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun testGetChainById() {
+        skipProcessor.chains = parser.asNativeList(parser.asNativeMap(templateToMap(skipChainsMock.payload))?.get("chains"))
+        val result = skipProcessor.getChainById("kaiyo-1")
+        val expected = mapOf(
+            "chain_name" to "kujira",
+            "chain_id" to "kaiyo-1",
+            "pfm_enabled" to false,
+            "cosmos_module_support" to mapOf(
+                "authz" to true,
+                "feegrant" to true,
+            ),
+            "supports_memo" to true,
+            "logo_uri" to "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/kaiyo/chain.png",
+            "bech32_prefix" to "kujira",
+            "fee_assets" to listOf(
+                mapOf(
+                    "denom" to "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23",
+                    "gas_price" to null,
+                ),
+                mapOf(
+                    "denom" to "ibc/EFF323CC632EC4F747C61BCE238A758EFDB7699C3226565F7C20DA06509D59A5",
+                    "gas_price" to null,
+                ),
+            ),
+            "chain_type" to "cosmos",
+            "ibc_capabilities" to mapOf(
+                "cosmos_pfm" to false,
+                "cosmos_ibc_hooks" to false,
+                "cosmos_memo" to true,
+                "cosmos_autopilot" to false,
+            ),
+            "is_testnet" to false,
+        ).toJsonObject()
         assertEquals(expected, result)
     }
 }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.7.91'
+    spec.version                  = '1.8.2'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
                 
                 
                 
-    if false
+    if !Dir.exist?('build/cocoapods/framework/Abacus.framework') || Dir.empty?('build/cocoapods/framework/Abacus.framework')
         raise "
 
         Kotlin framework 'Abacus' doesn't exist yet, so a proper Xcode project can't be generated.

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.8.3'
+    spec.version                  = '1.7.91'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
                 
                 
                 
-    if !Dir.exist?('build/cocoapods/framework/Abacus.framework') || Dir.empty?('build/cocoapods/framework/Abacus.framework')
+    if false
         raise "
 
         Kotlin framework 'Abacus' doesn't exist yet, so a proper Xcode project can't be generated.

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.8.2'
+    spec.version                  = '1.8.3'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Exposes get chain by id helper method. This allows us to get the `chainName` that the frontend wants to display. This is also probably just useful in general. 

This poses the question - should we continue being 'react'y and storing all react related data into the state? Or do we want to expose data that react can't update directly via abacus.