### PR TITLE
Isolated markets: reduce position delta

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.6"
+version = "1.8.7"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
@@ -1,7 +1,6 @@
 package exchange.dydx.abacus.calculator
 
 import exchange.dydx.abacus.protocols.ParserProtocol
-import exchange.dydx.abacus.utils.Numeric
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
 
@@ -59,7 +58,7 @@ class AccountTransformer() {
                 parser,
                 account,
                 subaccountNumber,
-                tradeInput = trade
+                tradeInput = trade,
             )
 
             val transferAmount = if (shouldTransferIn || shouldTransferOut) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
@@ -48,21 +48,12 @@ class AccountTransformer() {
                 ),
             ) ?: mapOf()
 
-            val transferAmount = if (MarginCalculator.getShouldTransferCollateral(
-                    parser,
-                    subaccount = childSubaccount,
-                    tradeInput = trade,
-                )
-            ) {
-                MarginCalculator.calculateIsolatedMarginTransferAmount(
-                    parser,
-                    trade,
-                    market,
-                    subaccount = childSubaccount,
-                ) ?: 0.0
-            } else {
-                0.0
-            }
+            val transferAmount = MarginCalculator.getIsolatedMarginTransferAmount(
+                parser,
+                subaccount = childSubaccount,
+                trade = trade,
+                market,
+            ) ?: 0.0
 
             val modifiedSubaccount =
                 subaccountTransformer.applyTransferToSubaccount(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
@@ -1,6 +1,7 @@
 package exchange.dydx.abacus.calculator
 
 import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.utils.Numeric
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
 
@@ -48,12 +49,20 @@ class AccountTransformer() {
                 ),
             ) ?: mapOf()
 
-            val transferAmount = if (MarginCalculator.getShouldTransferCollateral(
-                    parser,
-                    subaccount = childSubaccount,
-                    tradeInput = trade,
-                )
-            ) {
+            val shouldTransferIn = MarginCalculator.getShouldTransferCollateral(
+                parser,
+                subaccount = childSubaccount,
+                tradeInput = trade,
+            )
+
+            val shouldTransferOut = MarginCalculator.getShouldTransferOutCollateral(
+                parser,
+                account,
+                subaccountNumber,
+                tradeInput = trade
+            )
+
+            val transferAmount = if (shouldTransferIn || shouldTransferOut) {
                 MarginCalculator.calculateIsolatedMarginTransferAmount(
                     parser,
                     trade,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
@@ -48,20 +48,12 @@ class AccountTransformer() {
                 ),
             ) ?: mapOf()
 
-            val shouldTransferIn = MarginCalculator.getShouldTransferCollateral(
-                parser,
-                subaccount = childSubaccount,
-                tradeInput = trade,
-            )
-
-            val shouldTransferOut = MarginCalculator.getShouldTransferOutCollateral(
-                parser,
-                account,
-                subaccountNumber,
-                tradeInput = trade,
-            )
-
-            val transferAmount = if (shouldTransferIn || shouldTransferOut) {
+            val transferAmount = if (MarginCalculator.getShouldTransferCollateral(
+                    parser,
+                    subaccount = childSubaccount,
+                    tradeInput = trade,
+                )
+            ) {
                 MarginCalculator.calculateIsolatedMarginTransferAmount(
                     parser,
                     trade,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/SubaccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/SubaccountTransformer.kt
@@ -224,7 +224,7 @@ internal class SubaccountTransformer {
                 market,
                 transfer,
             )
-            return applyDeltaToSubaccount(subaccount, delta, parser, period)
+            return applyDeltaToSubaccount(subaccount, delta, parser, period, hasTransfer = transfer != null)
         }
         return subaccount
     }
@@ -350,7 +350,8 @@ internal class SubaccountTransformer {
         subaccount: Map<String, Any>,
         delta: Map<String, Any>?,
         parser: ParserProtocol,
-        period: String
+        period: String,
+        hasTransfer: Boolean = false,
     ): Map<String, Any> {
         val modified = subaccount.mutable()
 
@@ -363,6 +364,7 @@ internal class SubaccountTransformer {
                 delta,
                 parser.asDouble(parser.value(marketPosition, "size.current")) ?: Numeric.double.ZERO,
                 parser,
+                hasTransfer,
             )
         } else {
             null
@@ -394,10 +396,11 @@ internal class SubaccountTransformer {
     private fun transformDelta(
         delta: Map<String, Any>,
         positionSize: Double,
-        parser: ParserProtocol
+        parser: ParserProtocol,
+        hasTransfer: Boolean = false,
     ): Map<String, Any> {
         val marketId = parser.asString(delta["marketId"])
-        if (parser.asBool(delta["reduceOnly"]) == true && marketId != null) {
+        if (parser.asBool(delta["reduceOnly"]) == true && marketId != null && !hasTransfer) {
             val size = parser.asDouble(delta["size"]) ?: Numeric.double.ZERO
             val price = parser.asDouble(delta["price"]) ?: Numeric.double.ZERO
             val modifiedSize =

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -1775,6 +1775,7 @@ internal class TradeInputCalculator(
         }
 
         // Calculate isolated margin transfer amount
+        // TODO(@aforaleka): move this out of summary and into place order so trade is up to date
         if (MarginCalculator.getShouldTransferCollateral(
                 parser,
                 subaccount,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -1776,23 +1776,14 @@ internal class TradeInputCalculator(
 
         // Calculate isolated margin transfer amount
         // TODO(@aforaleka): move this out of summary and into place order so trade is up to date
-        if (MarginCalculator.getShouldTransferCollateral(
-                parser,
-                subaccount,
-                trade,
-            )
-        ) {
-            val isolatedMarginTransferAmount = MarginCalculator.calculateIsolatedMarginTransferAmount(
-                parser,
-                trade,
-                market,
-                subaccount,
-            )
+        val isolatedMarginTransferAmount = MarginCalculator.getIsolatedMarginTransferAmount(
+            parser,
+            subaccount,
+            trade,
+            market,
+        )
 
-            summary.safeSet("isolatedMarginTransferAmount", isolatedMarginTransferAmount)
-        } else {
-            summary.safeSet("isolatedMarginTransferAmount", null)
-        }
+        summary.safeSet("isolatedMarginTransferAmount", isolatedMarginTransferAmount)
 
         return summary
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
@@ -2,7 +2,6 @@ package exchange.dydx.abacus.state.model
 
 import abs
 import exchange.dydx.abacus.calculator.MarginCalculator
-import exchange.dydx.abacus.output.input.MarginMode
 import exchange.dydx.abacus.responses.ParsingError
 import exchange.dydx.abacus.responses.StateResponse
 import exchange.dydx.abacus.state.changes.Changes
@@ -77,8 +76,6 @@ fun TradingStateMachine.closePosition(
 
                 trade["timeInForce"] = "IOC"
                 trade["reduceOnly"] = true
-
-                trade["marginMode"] = if (position["equity"] != null) MarginMode.Isolated.rawValue else MarginMode.Cross.rawValue
 
                 val currentPositionLeverage = parser.asDouble(parser.value(position, "leverage.current"))?.abs()
                 trade["targetLeverage"] = if (currentPositionLeverage != null && currentPositionLeverage > 0) currentPositionLeverage else 1.0

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -146,8 +146,8 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
 
     @Test
     fun testMarginModeWithExistingPosition() {
-        testMarginAmountForSubaccountTransferWithExistingIsolatedPosition()
-        testMarginAmountForSubaccountTransferWithExistingIsolatedPositionAndOpenOrders()
+        testMarginAmountForSubaccountTransferWithExistingPosition()
+        testMarginAmountForSubaccountTransferWithExistingPositionAndOpenOrders()
     }
 
     // MarginMode should automatically to match the current market based on a variety of factors
@@ -220,7 +220,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
         )
     }
 
-    private fun testMarginAmountForSubaccountTransferWithExistingIsolatedPosition() {
+    private fun testMarginAmountForSubaccountTransferWithExistingPosition() {
         test(
             {
                 perp.socket(
@@ -236,13 +236,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         "account": {
                             "groupedSubaccounts": {
                                 "0": {
-                                    "equity": {
-                                        "current": 162.33
-                                    },
                                     "freeCollateral": {
-                                        "current": 137.13
-                                    },
-                                    "quoteBalance": {
                                         "current": 137.13
                                     },
                                     "openPositions": {
@@ -252,9 +246,6 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                             },
                                             "equity": {
                                                 "current": 25.20
-                                            },
-                                            "freeCollateral": {
-                                                "current": 20.16
                                             }
                                         }
                                     }
@@ -305,7 +296,8 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             "marketId": "APE-USD",
                             "marginMode": "ISOLATED",
                             "targetLeverage": 1.0,
-                            "size": {
+                            "summary": {
+                                "price": 1.0,
                                 "size": 10.0
                             }
                         }
@@ -354,10 +346,6 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         "trade": {
                             "marketId": "APE-USD",
                             "marginMode": "ISOLATED",
-                            "side": "SELL",
-                            "size": {
-                                "size": 10.0
-                            },
                             "targetLeverage": 1.0,
                             "summary": {
                                 "price": 1.0,
@@ -407,15 +395,10 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         "trade": {
                             "marketId": "APE-USD",
                             "marginMode": "ISOLATED",
-                            "side": "SELL",
-                            "size": {
-                                "size": 50.0
-                            },
-                            "price": {
-                                "limitPrice": 1.0
-                            },
                             "targetLeverage": 2.0,
                             "summary": {
+                                "price": 1.0,
+                                "size": 50.0,
                                 "isolatedMarginTransferAmount": 10.0
                             }
                         }
@@ -425,7 +408,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
         )
     }
 
-    private fun testMarginAmountForSubaccountTransferWithExistingIsolatedPositionAndOpenOrders() {
+    private fun testMarginAmountForSubaccountTransferWithExistingPositionAndOpenOrders() {
         test(
             {
                 perp.socket(
@@ -450,13 +433,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                             "marketId": "APE-USD" 
                                         }
                                     },
-                                    "equity": {
-                                        "current": 162.33
-                                    },
                                     "freeCollateral": {
-                                        "current": 137.13
-                                    },
-                                    "quoteBalance": {
                                         "current": 137.13
                                     },
                                     "openPositions": {
@@ -466,9 +443,6 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                             },
                                             "equity": {
                                                 "current": 25.20
-                                            },
-                                            "freeCollateral": {
-                                                "current": 20.16
                                             }
                                         }
                                     }
@@ -566,10 +540,6 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         "trade": {
                             "marketId": "APE-USD",
                             "marginMode": "ISOLATED",
-                            "side": "SELL",
-                            "size": {
-                                "size": 10.0
-                            },
                             "targetLeverage": 1.0,
                             "summary": {
                                 "price": 1.0,
@@ -618,15 +588,10 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         "trade": {
                             "marketId": "APE-USD",
                             "marginMode": "ISOLATED",
-                            "side": "SELL",
-                            "size": {
-                                "size": 50.0
-                            },
-                            "price": {
-                                "limitPrice": 1.0
-                            },
                             "targetLeverage": 2.0,
                             "summary": {
+                                "price": 1.0,
+                                "size": 50.0,
                                 "isolatedMarginTransferAmount": 10.0
                             }
                         }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -303,7 +303,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         }
                     }
                 }
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         // input a trade that will flip position absolute net size +10
@@ -356,7 +356,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         }
                     }
                 }
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -268,7 +268,8 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             "groupedSubaccounts": {
                                 "0": {
                                     "freeCollateral": {
-                                        "current": 137.13
+                                        "current": 137.13,
+                                        "postOrder": 157.13
                                     },
                                     "openPositions": {
                                         "APE-USD": {
@@ -278,7 +279,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                             },
                                             "equity": {
                                                 "current": 25.20,
-                                                "postOrder": 25.20
+                                                "postOrder": 5.2
                                             }
                                         }
                                     }
@@ -299,6 +300,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             },
                             "targetLeverage": 1.0,
                             "summary": {
+                                "isolatedMarginTransferAmount": -20.0
                             }
                         }
                     }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -903,9 +903,9 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                     "orders" to mapOf(
                         "order-id" to mapOf(
                             "marketId" to "ARB-USD",
-                            "status" to "OPEN"
-                        )
-                    )
+                            "status" to "OPEN",
+                        ),
+                    ),
                 ),
                 tradeInput = mapOf(
                     "marketId" to "ARB-USD",

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -303,7 +303,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         }
                     }
                 }
-            """.trimIndent(),
+            """.trimIndent()
         )
 
         // input a trade that will flip position absolute net size +10
@@ -356,7 +356,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         }
                     }
                 }
-            """.trimIndent(),
+            """.trimIndent()
         )
     }
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -797,7 +797,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
     fun testGetShouldTransferCollateral() {
         assertTrue(
             "Should result in a transfer",
-            MarginCalculator.getShouldTransferCollateral(
+            MarginCalculator.getShouldTransferInCollateral(
                 parser,
                 subaccount = mapOf(
                     "openPositions" to mapOf(
@@ -817,10 +817,10 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
             ),
         )
 
-        // If reduce only is true, should not transfer
+        // If reduce only is true, should not transfer in
         assertEquals(
             false,
-            MarginCalculator.getShouldTransferCollateral(
+            MarginCalculator.getShouldTransferInCollateral(
                 parser,
                 subaccount = mapOf(
                     "openPositions" to mapOf(
@@ -840,10 +840,33 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
             ),
         )
 
-        // If postOrder is less than current, should not transfer
+        // If reduce only is true + no open orders, should transfer out
+        assertEquals(
+            true,
+            MarginCalculator.getShouldTransferOutCollateral(
+                parser,
+                subaccount = mapOf(
+                    "openPositions" to mapOf(
+                        "ARB-USD" to mapOf(
+                            "size" to mapOf(
+                                "current" to 0.0,
+                                "postOrder" to 16.0,
+                            ),
+                        ),
+                    ),
+                ),
+                tradeInput = mapOf(
+                    "marketId" to "ARB-USD",
+                    "marginMode" to "ISOLATED",
+                    "reduceOnly" to true,
+                ),
+            ),
+        )
+
+        // If postOrder is less than current, should not transfer in
         assertEquals(
             false,
-            MarginCalculator.getShouldTransferCollateral(
+            MarginCalculator.getShouldTransferInCollateral(
                 parser,
                 subaccount = mapOf(
                     "openPositions" to mapOf(
@@ -854,6 +877,35 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             ),
                         ),
                     ),
+                ),
+                tradeInput = mapOf(
+                    "marketId" to "ARB-USD",
+                    "marginMode" to "ISOLATED",
+                    "reduceOnly" to false,
+                ),
+            ),
+        )
+
+        // If reducing position but has open orders, should not transfer out
+        assertEquals(
+            false,
+            MarginCalculator.getShouldTransferOutCollateral(
+                parser,
+                subaccount = mapOf(
+                    "openPositions" to mapOf(
+                        "ARB-USD" to mapOf(
+                            "size" to mapOf(
+                                "current" to 22.0,
+                                "postOrder" to 16.0,
+                            ),
+                        ),
+                    ),
+                    "orders" to mapOf(
+                        "order-id" to mapOf(
+                            "marketId" to "ARB-USD",
+                            "status" to "OPEN"
+                        )
+                    )
                 ),
                 tradeInput = mapOf(
                     "marketId" to "ARB-USD",

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -3,6 +3,7 @@ package exchange.dydx.abacus.payload.v4
 import exchange.dydx.abacus.calculator.MarginCalculator
 import exchange.dydx.abacus.responses.StateResponse
 import exchange.dydx.abacus.state.model.TradeInputField
+import exchange.dydx.abacus.state.model.closePosition
 import exchange.dydx.abacus.state.model.trade
 import exchange.dydx.abacus.state.model.tradeInMarket
 import kotlin.test.BeforeTest

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/OrderbookChannelMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/OrderbookChannelMock.kt
@@ -323,6 +323,38 @@ internal class OrderbookChannelMock {
           }
         }
     """.trimIndent()
+
+    internal val subscribed_ape = """
+        {
+          "type": "subscribed",
+          "connection_id": "e3b086f3-c360-40e2-bb74-c36ff8a69d2e",
+          "message_id": 5,
+          "channel": "v4_orderbook",
+          "id": "APE-USD",
+          "contents": {
+            "bids": [
+              {
+                "price": "2",
+                "size": "50"
+              },
+              {
+                "price": "1",
+                "size": "2710"
+              }
+            ],
+            "asks": [
+              {
+                "price": "1",
+                "size": "70"
+              },
+              {
+                "price": "2",
+                "size": "29100"
+              }
+            ]
+          }
+        }
+    """.trimIndent()
     internal val channel_batch_data = """
         {
           "type": "channel_batch_data",

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/ParentSubaccountsChannelMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/ParentSubaccountsChannelMock.kt
@@ -976,7 +976,7 @@ internal class ParentSubaccountsChannelMock {
         }
     """.trimIndent()
 
-    internal val read_subscribe_with_isolated_position = """
+    internal val real_subscribe_with_isolated_position = """
         {
           "type": "subscribed",
           "connection_id": "54dfe8a3-db43-4d07-b37f-66b37d00296c",
@@ -1046,6 +1046,105 @@ internal class ParentSubaccountsChannelMock {
               ]
             },
             "orders": [],
+            "blockHeight": "18642087"
+          }
+        }
+    """.trimIndent()
+
+    internal val real_subscribe_with_isolated_position_and_open_orders = """
+        {
+          "type": "subscribed",
+          "connection_id": "54dfe8a3-db43-4d07-b37f-66b37d00296c",
+          "message_id": 2,
+          "channel": "v4_parent_subaccounts",
+          "id": "dydx1jd8uuuwcfr2xg6ek0g3mes2kppzm54qd65npwe/0",
+          "contents": {
+            "subaccount": {
+              "address": "dydx1jd8uuuwcfr2xg6ek0g3mes2kppzm54qd65npwe",
+              "parentSubaccountNumber": 0,
+              "equity": "155.66683808",
+              "freeCollateral": "151.957356664",
+              "childSubaccounts": [
+                {
+                  "address": "dydx1jd8uuuwcfr2xg6ek0g3mes2kppzm54qd65npwe",
+                  "subaccountNumber": 0,
+                  "equity": "137.128721",
+                  "freeCollateral": "137.128721",
+                  "openPerpetualPositions": {},
+                  "assetPositions": {
+                    "USDC": {
+                      "size": "137.128721",
+                      "symbol": "USDC",
+                      "side": "LONG",
+                      "assetId": "0",
+                      "subaccountNumber": 0
+                    }
+                  },
+                  "marginEnabled": true
+                },
+                {
+                  "address": "dydx1jd8uuuwcfr2xg6ek0g3mes2kppzm54qd65npwe",
+                  "subaccountNumber": 128,
+                  "equity": "18.53811708",
+                  "freeCollateral": "14.828635664",
+                  "openPerpetualPositions": {
+                    "APE-USD": {
+                      "market": "APE-USD",
+                      "status": "OPEN",
+                      "side": "LONG",
+                      "size": "20",
+                      "maxSize": "20",
+                      "entryPrice": "0.929",
+                      "exitPrice": null,
+                      "realizedPnl": "0",
+                      "unrealizedPnl": "-0.03259292",
+                      "createdAt": "2024-06-21T19:30:50.890Z",
+                      "createdAtHeight": "18641960",
+                      "closedAt": null,
+                      "sumOpen": "20",
+                      "sumClose": "0",
+                      "netFunding": "0",
+                      "subaccountNumber": 128
+                    }
+                  },
+                  "assetPositions": {
+                    "USDC": {
+                      "size": "0.00929",
+                      "symbol": "USDC",
+                      "side": "SHORT",
+                      "assetId": "0",
+                      "subaccountNumber": 128
+                    }
+                  },
+                  "marginEnabled": true
+                }
+              ]
+            },
+            "orders": [
+              {
+                "id": "bbc7cfe6-8837-5c46-94c4-36a4319231ac",
+                "subaccountId": "04121c50-eb1e-5b44-bc82-bdf830c115c8",
+                "clientId": "1458418463",
+                "clobPairId": "22",
+                "side": "BUY",
+                "size": "10",
+                "totalFilled": "0",
+                "price": "0.4",
+                "type": "LIMIT",
+                "status": "OPEN",
+                "timeInForce": "GTT",
+                "reduceOnly": false,
+                "orderFlags": "64",
+                "goodTilBlockTime": "2024-07-23T20:19:56.000Z",
+                "createdAtHeight": "18937469",
+                "clientMetadata": "0",
+                "updatedAt": "2024-06-25T20:19:57.419Z",
+                "updatedAtHeight": "18937469",
+                "postOnly": false,
+                "ticker": "APE-USD",
+                "subaccountNumber": 128
+              }
+            ],
             "blockHeight": "18642087"
           }
         }


### PR DESCRIPTION
when inputting a trade (or close position) that reduces an isolated position, and there is no other open orders, postorder cross free collateral should increase, and position margin for the existing isolated position should decrease

main changes:
- introduces the concept of how much collateral can be transferred out (which we'll later incorporate to transfer out collateral on subaccount/ positions change); this will allow cross free collateral to reflect post transfer amount
- fixes usdcSize (which can be the transfer amount) being overwritten in `transformDelta` by passing in extra param `hasTransfer` that skips that