### PR TITLE
isolated [2/n]: calculate transfer payload for isolated trade on the fly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.12"
+version = "1.8.13"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
@@ -218,6 +218,17 @@ internal object MarginCalculator {
         error("No available subaccount number")
     }
 
+    fun getChildSubaccountNumberForIsolatedMarginClosePosition(
+        parser: ParserProtocol,
+        account: Map<String, Any>?,
+        subaccountNumber: Int,
+        tradeInput: Map<String, Any>?
+    ): Int {
+        val marketId = parser.asString(tradeInput?.get("marketId")) ?: return subaccountNumber
+        val position = findExistingPosition(parser, account, marketId, subaccountNumber)
+        return parser.asInt(position?.get("subaccountNumber")) ?: subaccountNumber
+    }
+
     /**
      * @description Calculate and validate the amount of collateral to transfer for an isolated margin trade.
      */

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
@@ -293,7 +293,7 @@ internal object MarginCalculator {
         subaccount: Subaccount,
     ): Boolean {
         val isIsolatedMarginOrder = trade.marginMode == MarginMode.Isolated
-        val isIncreasingPositionSize = getIsIncreasingPositionSize(subaccount, trade)
+        val isIncreasingPositionSize = getIsIncreasingPositionSizeTyped(subaccount, trade)
         val isReduceOnly = trade.reduceOnly
         return isIncreasingPositionSize && isIsolatedMarginOrder && !isReduceOnly
     }
@@ -337,11 +337,11 @@ internal object MarginCalculator {
         return getPositionSizeDifference(parser, subaccount, tradeInput)?.let { it > 0 } ?: true
     }
 
-    private fun getIsIncreasingPositionSize(
+    private fun getIsIncreasingPositionSizeTyped(
         subaccount: Subaccount,
         trade: TradeInput,
     ): Boolean {
-        return getPositionSizeDifference(subaccount, trade)?.let { it > 0 } ?: true
+        return getPositionSizeDifferenceTyped(subaccount, trade)?.let { it > 0 } ?: true
     }
 
     private fun getPositionSizeDifference(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
@@ -1,12 +1,15 @@
 package exchange.dydx.abacus.calculator
 
 import abs
+import exchange.dydx.abacus.output.PerpetualMarket
+import exchange.dydx.abacus.output.Subaccount
+import exchange.dydx.abacus.output.input.MarginMode
+import exchange.dydx.abacus.output.input.TradeInput
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.MAX_LEVERAGE_BUFFER_PERCENT
 import exchange.dydx.abacus.utils.MAX_SUBACCOUNT_NUMBER
 import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
-import exchange.dydx.abacus.utils.Numeric
 import kollections.iListOf
 import kotlin.math.max
 import kotlin.math.min
@@ -237,18 +240,29 @@ internal object MarginCalculator {
         return if (isCorrectSign) transferAmount else null
     }
 
-    private fun getIsIncreasingPositionSize(
-        parser: ParserProtocol,
-        subaccount: Map<String, Any>?,
-        tradeInput: Map<String, Any>?,
-    ): Boolean {
-        return getPositionSizeDifference(parser, subaccount, tradeInput)?.let { it > 0 } ?: true
+    /**
+     * @description Calculate the amount of collateral to transfer into child subaccount for an isolated margin trade.
+     */
+    fun getIsolatedMarginTransferInAmountForTradeTyped(
+        trade: TradeInput,
+        subaccount: Subaccount,
+        market: PerpetualMarket
+    ): Double? {
+        return if (getShouldTransferInCollateralTyped(trade, subaccount)) {
+            calculateIsolatedMarginTransferAmountTyped(
+                trade,
+                market,
+                subaccount,
+            )
+        } else {
+            null
+        }
     }
 
     /**
      * @description Determine if collateral should be transferred into child subaccount for an isolated margin trade
      */
-    fun getShouldTransferInCollateral(
+    internal fun getShouldTransferInCollateral(
         parser: ParserProtocol,
         subaccount: Map<String, Any>?,
         tradeInput: Map<String, Any>?,
@@ -261,9 +275,22 @@ internal object MarginCalculator {
     }
 
     /**
-     * @description Determine if collateral should be transferred out from child subaccount for an isolated margin trade
+     * @description Determine if collateral should be transferred into child subaccount for an isolated margin trade
      */
-    fun getShouldTransferOutCollateral(
+    private fun getShouldTransferInCollateralTyped(
+        trade: TradeInput,
+        subaccount: Subaccount,
+    ): Boolean {
+        val isIsolatedMarginOrder = trade.marginMode == MarginMode.Isolated
+        val isIncreasingPositionSize = getIsIncreasingPositionSize(subaccount, trade)
+        val isReduceOnly = trade.reduceOnly
+        return isIncreasingPositionSize && isIsolatedMarginOrder && !isReduceOnly
+    }
+
+    /**
+     * @description Determine if collateral should be transferred out of child subaccount for an isolated margin trade
+     */
+    internal fun getShouldTransferOutCollateral(
         parser: ParserProtocol,
         subaccount: Map<String, Any>?,
         tradeInput: Map<String, Any>?,
@@ -291,9 +318,21 @@ internal object MarginCalculator {
         } ?: false
     }
 
-    /**
-     * @description Helper to determine how much collateral needs to be transferred in for an isolated margin trade
-     */
+    private fun getIsIncreasingPositionSize(
+        parser: ParserProtocol,
+        subaccount: Map<String, Any>?,
+        tradeInput: Map<String, Any>?,
+    ): Boolean {
+        return getPositionSizeDifference(parser, subaccount, tradeInput)?.let { it > 0 } ?: true
+    }
+
+    private fun getIsIncreasingPositionSize(
+        subaccount: Subaccount,
+        trade: TradeInput,
+    ): Boolean {
+        return getPositionSizeDifference(subaccount, trade)?.let { it > 0 } ?: true
+    }
+
     private fun getPositionSizeDifference(
         parser: ParserProtocol,
         subaccount: Map<String, Any>?,
@@ -328,6 +367,109 @@ internal object MarginCalculator {
         return currentPositionSize + tradeSize
     }
 
+    /**
+     * @description Since position is already typed, we can calculate difference with position size diff directly
+     */
+    private fun getPositionSizeDifferenceTyped(
+        subaccount: Subaccount,
+        trade: TradeInput,
+    ): Double? {
+        return subaccount.openPositions?.find { it.id == trade.marketId }?.let {
+            (it.size.postOrder ?: 0.0).abs() - (it.size.current ?: 0.0).abs()
+        } ?: return null
+    }
+
+    /**
+     * @description Calculate the amount of collateral to transfer for an isolated margin trade.
+     * Max leverage is capped at 98% of the the market's max leverage and takes the oraclePrice into account in order to pass collateral checks.
+     */
+    private fun calculateIsolatedMarginTransferAmount(
+        parser: ParserProtocol,
+        trade: Map<String, Any>,
+        market: Map<String, Any>?,
+        subaccount: Map<String, Any>?,
+    ): Double? {
+        val targetLeverage = parser.asDouble(trade["targetLeverage"]) ?: 1.0
+        val side = parser.asString(parser.value(trade, "side")) ?: return null
+        val oraclePrice = parser.asDouble(parser.value(market, "oraclePrice")) ?: return null
+        val price = parser.asDouble(parser.value(trade, "summary.price")) ?: return null
+        val initialMarginFraction = parser.asDouble(parser.value(market, "configs.initialMarginFraction")) ?: 0.0
+        val effectiveImf = parser.asDouble(parser.value(market, "configs.effectiveInitialMarginFraction")) ?: 0.0
+        val positionSizeDifference = getPositionSizeDifference(parser, subaccount, trade) ?: return null
+
+        return calculateIsolatedMarginTransferAmountFromValues(
+            targetLeverage,
+            side,
+            oraclePrice,
+            price,
+            initialMarginFraction,
+            effectiveImf,
+            positionSizeDifference,
+        )
+    }
+
+    private fun calculateIsolatedMarginTransferAmountTyped(
+        trade: TradeInput,
+        market: PerpetualMarket,
+        subaccount: Subaccount,
+    ): Double? {
+        val targetLeverage = trade.targetLeverage
+        val side = trade.side?.rawValue ?: return null
+        val oraclePrice = market.oraclePrice ?: return null
+        val price = trade.summary?.price ?: return null
+        val initialMarginFraction = market.configs?.initialMarginFraction ?: 0.0
+        val effectiveImf = market.configs?.effectiveInitialMarginFraction ?: 0.0
+        val positionSizeDifference = getPositionSizeDifferenceTyped(subaccount, trade) ?: return null
+
+        return calculateIsolatedMarginTransferAmountFromValues(
+            targetLeverage,
+            side,
+            oraclePrice,
+            price,
+            initialMarginFraction,
+            effectiveImf,
+            positionSizeDifference,
+        )
+    }
+
+    private fun calculateIsolatedMarginTransferAmountFromValues(
+        targetLeverage: Double,
+        side: String,
+        oraclePrice: Double,
+        price: Double,
+        initialMarginFraction: Double,
+        effectiveImf: Double,
+        positionSizeDifference: Double,
+    ): Double? {
+        val maxLeverageForMarket = if (effectiveImf != 0.0) {
+            1.0 / effectiveImf
+        } else if (initialMarginFraction != 0.0) {
+            1.0 / initialMarginFraction
+        } else {
+            null
+        }
+
+        // Cap targetLeverage to 98% of max leverage
+        val adjustedTargetLeverage = if (maxLeverageForMarket != null) {
+            val cappedLeverage = maxLeverageForMarket * MAX_LEVERAGE_BUFFER_PERCENT
+            min(targetLeverage, cappedLeverage)
+        } else {
+            null
+        }
+
+        return if (adjustedTargetLeverage == 0.0 || adjustedTargetLeverage == null) {
+            null
+        } else {
+            getTransferAmountFromTargetLeverage(
+                price,
+                oraclePrice,
+                side,
+                positionSizeDifference,
+                targetLeverage = adjustedTargetLeverage,
+            )
+        }
+    }
+
     internal fun getTransferAmountFromTargetLeverage(
         price: Double,
         oraclePrice: Double,
@@ -349,54 +491,5 @@ internal object MarginCalculator {
         }
 
         return max((oraclePrice * size) / targetLeverage + priceDiff * size, naiveTransferAmount)
-    }
-
-    /**
-     * @description Calculate the amount of collateral to transfer for an isolated margin trade.
-     * Max leverage is capped at 98% of the the market's max leverage and takes the oraclePrice into account in order to pass collateral checks.
-     */
-    internal fun calculateIsolatedMarginTransferAmount(
-        parser: ParserProtocol,
-        trade: Map<String, Any>,
-        market: Map<String, Any>?,
-        subaccount: Map<String, Any>?,
-    ): Double? {
-        val targetLeverage = parser.asDouble(trade["targetLeverage"]) ?: 1.0
-        val side = parser.asString(parser.value(trade, "side")) ?: return null
-        val oraclePrice = parser.asDouble(parser.value(market, "oraclePrice")) ?: return null
-        val price = parser.asDouble(parser.value(trade, "summary.price")) ?: return null
-        val initialMarginFraction = parser.asDouble(parser.value(market, "configs.initialMarginFraction")) ?: 0.0
-        val effectiveImf = parser.asDouble(parser.value(market, "configs.effectiveInitialMarginFraction")) ?: 0.0
-
-        val maxLeverageForMarket = if (effectiveImf != 0.0) {
-            1.0 / effectiveImf
-        } else if (initialMarginFraction != 0.0) {
-            1.0 / initialMarginFraction
-        } else {
-            null
-        }
-
-        // Cap targetLeverage to 98% of max leverage
-        val adjustedTargetLeverage = if (maxLeverageForMarket != null) {
-            val cappedLeverage = maxLeverageForMarket * MAX_LEVERAGE_BUFFER_PERCENT
-            min(targetLeverage, cappedLeverage)
-        } else {
-            null
-        }
-
-        // Get the position size difference
-        val positionSizeDifference = getPositionSizeDifference(parser, subaccount, trade) ?: return null
-
-        return if (adjustedTargetLeverage == 0.0 || adjustedTargetLeverage == null) {
-            null
-        } else {
-            getTransferAmountFromTargetLeverage(
-                price,
-                oraclePrice,
-                side,
-                positionSizeDifference,
-                targetLeverage = adjustedTargetLeverage,
-            )
-        }
     }
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -1774,17 +1774,6 @@ internal class TradeInputCalculator(
             else -> {}
         }
 
-        // Calculate isolated margin transfer amount
-        // TODO(@aforaleka): move this out of summary and into place order so trade is up to date
-        val isolatedMarginTransferAmount = MarginCalculator.getIsolatedMarginTransferAmount(
-            parser,
-            subaccount,
-            trade,
-            market,
-        )
-
-        summary.safeSet("isolatedMarginTransferAmount", isolatedMarginTransferAmount)
-
         return summary
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
@@ -273,8 +273,7 @@ data class TradeInputSummary(
     val reward: Double?,
     val filled: Boolean,
     val positionMargin: Double?,
-    val positionLeverage: Double?,
-    val isolatedMarginTransferAmount: Double?,
+    val positionLeverage: Double?
 ) {
     companion object {
         internal fun create(
@@ -296,8 +295,6 @@ data class TradeInputSummary(
                 val filled = parser.asBool(data["filled"]) ?: false
                 val positionMargin = parser.asDouble(data["positionMargin"])
                 val positionLeverage = parser.asDouble(data["positionLeverage"])
-                val isolatedMarginTransferAmount =
-                    parser.asDouble(data["isolatedMarginTransferAmount"])
 
                 return if (
                     existing?.price != price ||
@@ -309,8 +306,7 @@ data class TradeInputSummary(
                     existing?.total != total ||
                     existing?.positionMargin != positionMargin ||
                     existing?.positionLeverage != positionLeverage ||
-                    existing?.filled != filled ||
-                    existing.isolatedMarginTransferAmount != isolatedMarginTransferAmount
+                    existing?.filled != filled
                 ) {
                     TradeInputSummary(
                         price,
@@ -324,7 +320,6 @@ data class TradeInputSummary(
                         filled,
                         positionMargin,
                         positionLeverage,
-                        isolatedMarginTransferAmount,
                     )
                 } else {
                     existing

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
@@ -45,7 +45,7 @@ fun TradingStateMachine.closePosition(
         )
 
     val childSubaccountNumber =
-        MarginCalculator.getChildSubaccountNumberForIsolatedMarginTrade(
+        MarginCalculator.getChildSubaccountNumberForIsolatedMarginClosePosition(
             parser,
             account,
             subaccountNumber,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -625,7 +625,7 @@ internal class SubaccountSupervisor(
         val childSubaccount = stateMachine.state?.subaccount(childSubaccountNumber) ?: return null
         val market = stateMachine.state?.market(orderPayload.marketId) ?: return null
 
-        val isolatedMarginTransferAmount = MarginCalculator.getIsolatedMarginTransferInAmountForTradeTyped(
+        val isolatedMarginTransferAmount = MarginCalculator.getIsolatedMarginTransferInAmountForTrade(
             trade,
             subaccount = childSubaccount,
             market,

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -394,8 +394,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             "targetLeverage": 2.0,
                             "summary": {
                                 "price": 1.0,
-                                "size": 50.0,
-                                "isolatedMarginTransferAmount": 10.0
+                                "size": 50.0
                             }
                         }
                     }
@@ -503,7 +502,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
         perp.trade("10", TradeInputField.size, 0)
         test(
             {
-                perp.trade("1", TradeInputField.targetLeverage, 0)
+                perp.closePosition("10", ClosePositionInputField.size, 0)
             },
             """
                 {
@@ -512,7 +511,8 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             "groupedSubaccounts": {
                                 "0": {
                                     "freeCollateral": {
-                                        "current": 137.13
+                                        "current": 137.13,
+                                        "postOrder": 157.12
                                     },
                                     "openPositions": {
                                         "APE-USD": {
@@ -522,7 +522,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                             },
                                             "equity": {
                                                 "current": 25.20,
-                                                "postOrder": 25.20
+                                                "postOrder": 5.20
                                             }
                                         }
                                     }
@@ -531,8 +531,8 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         }
                     },
                     "input": {
-                        "current": "trade",
-                        "trade": {
+                        "current": "closePosition",
+                        "closePosition": {
                             "marketId": "APE-USD",
                             "marginMode": "ISOLATED",
                             "targetLeverage": 1.0,
@@ -566,7 +566,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                         "APE-USD": {
                                             "size": {
                                                 "current": 20,
-                                                "postOrder": -30
+                                                "postOrder": 10
                                             },
                                             "equity": {
                                                 "current": 25.20,
@@ -586,8 +586,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             "targetLeverage": 2.0,
                             "summary": {
                                 "price": 1.0,
-                                "size": 50.0,
-                                "isolatedMarginTransferAmount": 10.0
+                                "size": 50.0
                             }
                         }
                     }
@@ -720,9 +719,6 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             "targetLeverage": 2.0,
                             "options": {
                                 "needsMarginMode": true
-                            },
-                            "summary": {
-                                "isolatedMarginTransferAmount": 13.697401030000002
                             }
                         }
                     }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -502,7 +502,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
         perp.trade("10", TradeInputField.size, 0)
         test(
             {
-                perp.closePosition("10", ClosePositionInputField.size, 0)
+                perp.trade("1", TradeInputField.targetLeverage, 0)
             },
             """
                 {
@@ -511,8 +511,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             "groupedSubaccounts": {
                                 "0": {
                                     "freeCollateral": {
-                                        "current": 137.13,
-                                        "postOrder": 157.12
+                                        "current": 137.13
                                     },
                                     "openPositions": {
                                         "APE-USD": {
@@ -522,7 +521,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                             },
                                             "equity": {
                                                 "current": 25.20,
-                                                "postOrder": 5.20
+                                                "postOrder": 25.20
                                             }
                                         }
                                     }
@@ -531,8 +530,8 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                         }
                     },
                     "input": {
-                        "current": "closePosition",
-                        "closePosition": {
+                        "current": "trade",
+                        "trade": {
                             "marketId": "APE-USD",
                             "marginMode": "ISOLATED",
                             "targetLeverage": 1.0,
@@ -566,7 +565,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                         "APE-USD": {
                                             "size": {
                                                 "current": 20,
-                                                "postOrder": 10
+                                                "postOrder": -30
                                             },
                                             "equity": {
                                                 "current": 25.20,

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.12'
+    spec.version = '1.8.13'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
+ refactoring
+ calculate transfer payload for isolated trade on placing order
+ close position should get a more efficient way to find the child subaccount number (can assume it's the first subaccount with that open market position)
