### PR TITLE
fix: empty bump to get new release out

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.8"
+version = "1.8.9"
 
 repositories {
     google()


### PR DESCRIPTION
the last release is stuck https://dydx-team.slack.com/archives/C06S9ND5T40/p1719503578454899

just gonna push an empty release to get new stuff out