### PR TITLE
isolated [1/n]: update position size difference calculation / fix slow receipt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.12"
+version = "1.8.13"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
@@ -1,12 +1,15 @@
 package exchange.dydx.abacus.calculator
 
 import abs
+import exchange.dydx.abacus.output.PerpetualMarket
+import exchange.dydx.abacus.output.Subaccount
+import exchange.dydx.abacus.output.input.MarginMode
+import exchange.dydx.abacus.output.input.TradeInput
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.MAX_LEVERAGE_BUFFER_PERCENT
 import exchange.dydx.abacus.utils.MAX_SUBACCOUNT_NUMBER
 import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
-import exchange.dydx.abacus.utils.Numeric
 import kollections.iListOf
 import kotlin.math.max
 import kotlin.math.min
@@ -56,19 +59,17 @@ internal object MarginCalculator {
         return if (order != null) order.value as Map<String, Any> else null
     }
 
-    fun findExistingOrder(
+    fun hasExistingOrder(
         parser: ParserProtocol,
         subaccount: Map<String, Any>?,
         marketId: String?
-    ): Map<String, Any>? {
+    ): Boolean {
         val orders = parser.asNativeMap(parser.value(subaccount, "orders"))
-        val order = orders?.entries?.firstOrNull {
+        return orders?.entries?.any {
             val orderMarketId = parser.asString(parser.value(it.value, "marketId"))
             val orderStatus = parser.asString(parser.value(it.value, "status"))
             orderMarketId == marketId && listOf("OPEN", "PENDING", "UNTRIGGERED", "PARTIALLY_FILLED").contains(orderStatus)
-        }
-
-        return if (order != null) order.value as Map<String, Any> else null
+        } ?: false
     }
 
     fun findExistingMarginMode(
@@ -215,6 +216,17 @@ internal object MarginCalculator {
         error("No available subaccount number")
     }
 
+    fun getChildSubaccountNumberForIsolatedMarginClosePosition(
+        parser: ParserProtocol,
+        account: Map<String, Any>?,
+        subaccountNumber: Int,
+        tradeInput: Map<String, Any>?
+    ): Int {
+        val marketId = parser.asString(tradeInput?.get("marketId")) ?: return subaccountNumber
+        val position = findExistingPosition(parser, account, marketId, subaccountNumber)
+        return parser.asInt(position?.get("subaccountNumber")) ?: subaccountNumber
+    }
+
     /**
      * @description Calculate and validate the amount of collateral to transfer for an isolated margin trade.
      */
@@ -237,18 +249,29 @@ internal object MarginCalculator {
         return if (isCorrectSign) transferAmount else null
     }
 
-    private fun getIsIncreasingPositionSize(
-        parser: ParserProtocol,
-        subaccount: Map<String, Any>?,
-        tradeInput: Map<String, Any>?,
-    ): Boolean {
-        return getPositionSizeDifference(parser, subaccount, tradeInput)?.let { it > 0 } ?: true
+    /**
+     * @description Calculate the amount of collateral to transfer into child subaccount for an isolated margin trade.
+     */
+    fun getIsolatedMarginTransferInAmountForTrade(
+        trade: TradeInput,
+        subaccount: Subaccount,
+        market: PerpetualMarket
+    ): Double? {
+        return if (getShouldTransferInCollateral(trade, subaccount)) {
+            calculateIsolatedMarginTransferAmount(
+                trade,
+                market,
+                subaccount,
+            )
+        } else {
+            null
+        }
     }
 
     /**
      * @description Determine if collateral should be transferred into child subaccount for an isolated margin trade
      */
-    fun getShouldTransferInCollateral(
+    internal fun getShouldTransferInCollateral(
         parser: ParserProtocol,
         subaccount: Map<String, Any>?,
         tradeInput: Map<String, Any>?,
@@ -261,9 +284,22 @@ internal object MarginCalculator {
     }
 
     /**
-     * @description Determine if collateral should be transferred out from child subaccount for an isolated margin trade
+     * @description Determine if collateral should be transferred into child subaccount for an isolated margin trade
      */
-    fun getShouldTransferOutCollateral(
+    private fun getShouldTransferInCollateral(
+        trade: TradeInput,
+        subaccount: Subaccount,
+    ): Boolean {
+        val isIsolatedMarginOrder = trade.marginMode == MarginMode.Isolated
+        val isIncreasingPositionSize = getIsIncreasingPositionSize(subaccount, trade)
+        val isReduceOnly = trade.reduceOnly
+        return isIncreasingPositionSize && isIsolatedMarginOrder && !isReduceOnly
+    }
+
+    /**
+     * @description Determine if collateral should be transferred out of child subaccount for an isolated margin trade
+     */
+    internal fun getShouldTransferOutCollateral(
         parser: ParserProtocol,
         subaccount: Map<String, Any>?,
         tradeInput: Map<String, Any>?,
@@ -271,7 +307,7 @@ internal object MarginCalculator {
         val isPositionFullyClosed = getIsPositionFullyClosed(parser, subaccount, tradeInput)
         val isIsolatedMarginOrder = parser.asString(tradeInput?.get("marginMode")) == "ISOLATED"
         val hasOpenOrder = parser.asString(tradeInput?.get("marketId"))?.let { marketId ->
-            findExistingOrder(parser, subaccount, marketId) != null
+            hasExistingOrder(parser, subaccount, marketId)
         } ?: false
 
         return isPositionFullyClosed && isIsolatedMarginOrder && !hasOpenOrder
@@ -291,9 +327,21 @@ internal object MarginCalculator {
         } ?: false
     }
 
-    /**
-     * @description Helper to determine how much collateral needs to be transferred in for an isolated margin trade
-     */
+    private fun getIsIncreasingPositionSize(
+        parser: ParserProtocol,
+        subaccount: Map<String, Any>?,
+        tradeInput: Map<String, Any>?,
+    ): Boolean {
+        return getPositionSizeDifference(parser, subaccount, tradeInput)?.let { it > 0 } ?: true
+    }
+
+    private fun getIsIncreasingPositionSize(
+        subaccount: Subaccount,
+        trade: TradeInput,
+    ): Boolean {
+        return getPositionSizeDifference(subaccount, trade)?.let { it > 0 } ?: true
+    }
+
     private fun getPositionSizeDifference(
         parser: ParserProtocol,
         subaccount: Map<String, Any>?,
@@ -328,6 +376,109 @@ internal object MarginCalculator {
         return currentPositionSize + tradeSize
     }
 
+    /**
+     * @description Since position is already typed, we can calculate difference with position size diff directly
+     */
+    private fun getPositionSizeDifference(
+        subaccount: Subaccount,
+        trade: TradeInput,
+    ): Double? {
+        return subaccount.openPositions?.find { it.id == trade.marketId }?.let {
+            (it.size.postOrder ?: 0.0).abs() - (it.size.current ?: 0.0).abs()
+        } ?: return null
+    }
+
+    /**
+     * @description Calculate the amount of collateral to transfer for an isolated margin trade.
+     * Max leverage is capped at 98% of the the market's max leverage and takes the oraclePrice into account in order to pass collateral checks.
+     */
+    private fun calculateIsolatedMarginTransferAmount(
+        parser: ParserProtocol,
+        trade: Map<String, Any>,
+        market: Map<String, Any>?,
+        subaccount: Map<String, Any>?,
+    ): Double? {
+        val targetLeverage = parser.asDouble(trade["targetLeverage"]) ?: 1.0
+        val side = parser.asString(parser.value(trade, "side")) ?: return null
+        val oraclePrice = parser.asDouble(parser.value(market, "oraclePrice")) ?: return null
+        val price = parser.asDouble(parser.value(trade, "summary.price")) ?: return null
+        val initialMarginFraction = parser.asDouble(parser.value(market, "configs.initialMarginFraction")) ?: 0.0
+        val effectiveImf = parser.asDouble(parser.value(market, "configs.effectiveInitialMarginFraction")) ?: 0.0
+        val positionSizeDifference = getPositionSizeDifference(parser, subaccount, trade) ?: return null
+
+        return calculateIsolatedMarginTransferAmountFromValues(
+            targetLeverage,
+            side,
+            oraclePrice,
+            price,
+            initialMarginFraction,
+            effectiveImf,
+            positionSizeDifference,
+        )
+    }
+
+    private fun calculateIsolatedMarginTransferAmount(
+        trade: TradeInput,
+        market: PerpetualMarket,
+        subaccount: Subaccount,
+    ): Double? {
+        val targetLeverage = trade.targetLeverage
+        val side = trade.side?.rawValue ?: return null
+        val oraclePrice = market.oraclePrice ?: return null
+        val price = trade.summary?.price ?: return null
+        val initialMarginFraction = market.configs?.initialMarginFraction ?: 0.0
+        val effectiveImf = market.configs?.effectiveInitialMarginFraction ?: 0.0
+        val positionSizeDifference = getPositionSizeDifference(subaccount, trade) ?: return null
+
+        return calculateIsolatedMarginTransferAmountFromValues(
+            targetLeverage,
+            side,
+            oraclePrice,
+            price,
+            initialMarginFraction,
+            effectiveImf,
+            positionSizeDifference,
+        )
+    }
+
+    private fun calculateIsolatedMarginTransferAmountFromValues(
+        targetLeverage: Double,
+        side: String,
+        oraclePrice: Double,
+        price: Double,
+        initialMarginFraction: Double,
+        effectiveImf: Double,
+        positionSizeDifference: Double,
+    ): Double? {
+        val maxLeverageForMarket = if (effectiveImf != 0.0) {
+            1.0 / effectiveImf
+        } else if (initialMarginFraction != 0.0) {
+            1.0 / initialMarginFraction
+        } else {
+            null
+        }
+
+        // Cap targetLeverage to 98% of max leverage
+        val adjustedTargetLeverage = if (maxLeverageForMarket != null) {
+            val cappedLeverage = maxLeverageForMarket * MAX_LEVERAGE_BUFFER_PERCENT
+            min(targetLeverage, cappedLeverage)
+        } else {
+            null
+        }
+
+        return if (adjustedTargetLeverage == 0.0 || adjustedTargetLeverage == null) {
+            null
+        } else {
+            getTransferAmountFromTargetLeverage(
+                price,
+                oraclePrice,
+                side,
+                positionSizeDifference,
+                targetLeverage = adjustedTargetLeverage,
+            )
+        }
+    }
+
     internal fun getTransferAmountFromTargetLeverage(
         price: Double,
         oraclePrice: Double,
@@ -349,54 +500,5 @@ internal object MarginCalculator {
         }
 
         return max((oraclePrice * size) / targetLeverage + priceDiff * size, naiveTransferAmount)
-    }
-
-    /**
-     * @description Calculate the amount of collateral to transfer for an isolated margin trade.
-     * Max leverage is capped at 98% of the the market's max leverage and takes the oraclePrice into account in order to pass collateral checks.
-     */
-    internal fun calculateIsolatedMarginTransferAmount(
-        parser: ParserProtocol,
-        trade: Map<String, Any>,
-        market: Map<String, Any>?,
-        subaccount: Map<String, Any>?,
-    ): Double? {
-        val targetLeverage = parser.asDouble(trade["targetLeverage"]) ?: 1.0
-        val side = parser.asString(parser.value(trade, "side")) ?: return null
-        val oraclePrice = parser.asDouble(parser.value(market, "oraclePrice")) ?: return null
-        val price = parser.asDouble(parser.value(trade, "summary.price")) ?: return null
-        val initialMarginFraction = parser.asDouble(parser.value(market, "configs.initialMarginFraction")) ?: 0.0
-        val effectiveImf = parser.asDouble(parser.value(market, "configs.effectiveInitialMarginFraction")) ?: 0.0
-
-        val maxLeverageForMarket = if (effectiveImf != 0.0) {
-            1.0 / effectiveImf
-        } else if (initialMarginFraction != 0.0) {
-            1.0 / initialMarginFraction
-        } else {
-            null
-        }
-
-        // Cap targetLeverage to 98% of max leverage
-        val adjustedTargetLeverage = if (maxLeverageForMarket != null) {
-            val cappedLeverage = maxLeverageForMarket * MAX_LEVERAGE_BUFFER_PERCENT
-            min(targetLeverage, cappedLeverage)
-        } else {
-            null
-        }
-
-        // Get the position size difference
-        val positionSizeDifference = getPositionSizeDifference(parser, subaccount, trade) ?: return null
-
-        return if (adjustedTargetLeverage == 0.0 || adjustedTargetLeverage == null) {
-            null
-        } else {
-            getTransferAmountFromTargetLeverage(
-                price,
-                oraclePrice,
-                side,
-                positionSizeDifference,
-                targetLeverage = adjustedTargetLeverage,
-            )
-        }
     }
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
@@ -316,20 +316,15 @@ internal object MarginCalculator {
         trade: Map<String, Any>,
         currentPositionSize: Double,
     ): Double {
-        val marketId = parser.asString(trade["marketId"])
-        val side = parser.asString(trade["side"])
-        val tradeSize = if (marketId != null && side != null) {
-            parser.asNativeMap(trade["summary"])?.let { summary ->
-                if (parser.asBool(summary["filled"]) == true) {
-                    val multiplier = if (side == "BUY") Numeric.double.NEGATIVE else Numeric.double.POSITIVE
-                    (parser.asDouble(summary["size"]) ?: Numeric.double.ZERO) * multiplier * Numeric.double.NEGATIVE
-                } else {
-                    null
-                }
-            } ?: 0.0
-        } else {
-            0.0
-        }
+        val tradeSize = parser.asNativeMap(trade["summary"])?.takeIf {
+            parser.asString(trade["marketId"]) != null &&
+                parser.asString(trade["side"]) != null &&
+                parser.asBool(it["filled"]) == true
+        }?.let { summary ->
+            val multiplier = if (parser.asString(trade["side"]) == "BUY") Numeric.double.POSITIVE else Numeric.double.NEGATIVE
+            (parser.asDouble(summary["size"]) ?: Numeric.double.ZERO) * multiplier
+        } ?: 0.0
+
         return currentPositionSize + tradeSize
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
@@ -10,6 +10,7 @@ import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.MAX_LEVERAGE_BUFFER_PERCENT
 import exchange.dydx.abacus.utils.MAX_SUBACCOUNT_NUMBER
 import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
+import exchange.dydx.abacus.utils.Numeric
 import kollections.iListOf
 import kotlin.math.max
 import kotlin.math.min

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -1774,17 +1774,6 @@ internal class TradeInputCalculator(
             else -> {}
         }
 
-        // Calculate isolated margin transfer amount
-        // TODO(@aforaleka): move this out of summary and into place order so trade is up to date
-        val isolatedMarginTransferAmount = MarginCalculator.getIsolatedMarginTransferAmount(
-            parser,
-            subaccount,
-            trade,
-            market,
-        )
-
-        summary.safeSet("isolatedMarginTransferAmount", isolatedMarginTransferAmount)
-
         return summary
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
@@ -273,8 +273,7 @@ data class TradeInputSummary(
     val reward: Double?,
     val filled: Boolean,
     val positionMargin: Double?,
-    val positionLeverage: Double?,
-    val isolatedMarginTransferAmount: Double?,
+    val positionLeverage: Double?
 ) {
     companion object {
         internal fun create(
@@ -296,8 +295,6 @@ data class TradeInputSummary(
                 val filled = parser.asBool(data["filled"]) ?: false
                 val positionMargin = parser.asDouble(data["positionMargin"])
                 val positionLeverage = parser.asDouble(data["positionLeverage"])
-                val isolatedMarginTransferAmount =
-                    parser.asDouble(data["isolatedMarginTransferAmount"])
 
                 return if (
                     existing?.price != price ||
@@ -309,8 +306,7 @@ data class TradeInputSummary(
                     existing?.total != total ||
                     existing?.positionMargin != positionMargin ||
                     existing?.positionLeverage != positionLeverage ||
-                    existing?.filled != filled ||
-                    existing.isolatedMarginTransferAmount != isolatedMarginTransferAmount
+                    existing?.filled != filled
                 ) {
                     TradeInputSummary(
                         price,
@@ -324,7 +320,6 @@ data class TradeInputSummary(
                         filled,
                         positionMargin,
                         positionLeverage,
-                        isolatedMarginTransferAmount,
                     )
                 } else {
                     existing

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
@@ -45,7 +45,7 @@ fun TradingStateMachine.closePosition(
         )
 
     val childSubaccountNumber =
-        MarginCalculator.getChildSubaccountNumberForIsolatedMarginTrade(
+        MarginCalculator.getChildSubaccountNumberForIsolatedMarginClosePosition(
             parser,
             account,
             subaccountNumber,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -1,6 +1,7 @@
 package exchange.dydx.abacus.state.v2.supervisor
 
 import abs
+import exchange.dydx.abacus.calculator.MarginCalculator
 import exchange.dydx.abacus.calculator.TriggerOrdersConstants.TRIGGER_ORDER_DEFAULT_DURATION_DAYS
 import exchange.dydx.abacus.output.Notification
 import exchange.dydx.abacus.output.PositionSide
@@ -619,9 +620,16 @@ internal class SubaccountSupervisor(
     }
 
     internal fun getTransferPayloadForIsolatedMarginTrade(orderPayload: HumanReadablePlaceOrderPayload): HumanReadableSubaccountTransferPayload? {
-        val trade = stateMachine.state?.input?.trade
-        val isolatedMarginTransferAmount = trade?.summary?.isolatedMarginTransferAmount
+        val trade = stateMachine.state?.input?.trade ?: return null
         val childSubaccountNumber = orderPayload.subaccountNumber
+        val childSubaccount = stateMachine.state?.subaccount(childSubaccountNumber) ?: return null
+        val market = stateMachine.state?.market(orderPayload.marketId) ?: return null
+
+        val isolatedMarginTransferAmount = MarginCalculator.getIsolatedMarginTransferInAmountForTrade(
+            trade,
+            subaccount = childSubaccount,
+            market,
+        )
 
         if (isolatedMarginTransferAmount != null && isolatedMarginTransferAmount > 0.0) {
             val transferAmount = isolatedMarginTransferAmount.abs().toString()

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -394,8 +394,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             "targetLeverage": 2.0,
                             "summary": {
                                 "price": 1.0,
-                                "size": 50.0,
-                                "isolatedMarginTransferAmount": 10.0
+                                "size": 50.0
                             }
                         }
                     }
@@ -586,8 +585,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             "targetLeverage": 2.0,
                             "summary": {
                                 "price": 1.0,
-                                "size": 50.0,
-                                "isolatedMarginTransferAmount": 10.0
+                                "size": 50.0
                             }
                         }
                     }
@@ -720,9 +718,6 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                             "targetLeverage": 2.0,
                             "options": {
                                 "needsMarginMode": true
-                            },
-                            "summary": {
-                                "isolatedMarginTransferAmount": 13.697401030000002
                             }
                         }
                     }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -773,6 +773,11 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                     "marketId" to "ARB-USD",
                     "marginMode" to "ISOLATED",
                     "reduceOnly" to false,
+                    "side" to "BUY",
+                    "summary" to mapOf(
+                        "filled" to true,
+                        "size" to 16.0,
+                    ),
                 ),
             ),
         )
@@ -796,6 +801,11 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                     "marketId" to "ARB-USD",
                     "marginMode" to "ISOLATED",
                     "reduceOnly" to true,
+                    "side" to "BUY",
+                    "summary" to mapOf(
+                        "filled" to true,
+                        "size" to 16.0,
+                    ),
                 ),
             ),
         )
@@ -819,6 +829,11 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                     "marketId" to "ARB-USD",
                     "marginMode" to "ISOLATED",
                     "reduceOnly" to true,
+                    "side" to "SELL",
+                    "summary" to mapOf(
+                        "filled" to true,
+                        "size" to 16.0,
+                    ),
                 ),
             ),
         )
@@ -842,6 +857,11 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                     "marketId" to "ARB-USD",
                     "marginMode" to "ISOLATED",
                     "reduceOnly" to false,
+                    "side" to "SELL",
+                    "summary" to mapOf(
+                        "filled" to true,
+                        "size" to 6.0,
+                    ),
                 ),
             ),
         )
@@ -871,6 +891,11 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                     "marketId" to "ARB-USD",
                     "marginMode" to "ISOLATED",
                     "reduceOnly" to false,
+                    "side" to "SELL",
+                    "summary" to mapOf(
+                        "filled" to true,
+                        "size" to 22.0,
+                    ),
                 ),
             ),
         )

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
                 
                 
                 
-    if false
+    if !Dir.exist?('build/cocoapods/framework/Abacus.framework') || Dir.empty?('build/cocoapods/framework/Abacus.framework')
         raise "
 
         Kotlin framework 'Abacus' doesn't exist yet, so a proper Xcode project can't be generated.

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.12'
+    spec.version = '1.8.13'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
calculate how much to transfer with position size difference inferred from trade input instead of position, since delta has not been applied to position
this should fix receipt being slow / weird state where it was using an outdated position size

alternative route of applying transfer after position delta is duplicating even more code so didn't go down that path

https://github.com/dydxprotocol/v4-abacus/assets/9400120/3d31023b-1ac3-4e48-81e9-6f0393f7ae83

