### PR TITLE
isolated: fix margin diff for closing position / transfer out

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.16"
+version = "1.8.17"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
@@ -71,6 +71,7 @@ class AccountTransformer() {
             )
             modified.safeSet("subaccounts.$subaccountNumber", modifiedParentSubaccount)
 
+            // when transfer out is true, post order position margin should be null
             val modifiedChildSubaccount = subaccountTransformer.applyTradeToSubaccount(
                 childSubaccount,
                 trade,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
@@ -57,12 +57,19 @@ class AccountTransformer() {
             ) ?: 0.0
 
             val shouldTransferOut = MarginCalculator.getShouldTransferOutCollateral(
-                parser, subaccount = childSubaccount, trade
+                parser,
+                subaccount = childSubaccount,
+                trade,
             )
 
-                val transferToReceiveByParent = if (shouldTransferOut) MarginCalculator.getSubaccountFreeCollateralToTransferOut(
-                    parser, subaccount = childSubaccount
-                ) else null
+            val transferToReceiveByParent = if (shouldTransferOut) {
+                MarginCalculator.getSubaccountFreeCollateralToTransferOut(
+                    parser,
+                    subaccount = childSubaccount,
+                )
+            } else {
+                null
+            }
 
             Logger.e { "$transferToReceiveByParent" }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AccountTransformer.kt
@@ -1,6 +1,7 @@
 package exchange.dydx.abacus.calculator
 
 import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
 
@@ -55,10 +56,20 @@ class AccountTransformer() {
                 market,
             ) ?: 0.0
 
+            val shouldTransferOut = MarginCalculator.getShouldTransferOutCollateral(
+                parser, subaccount = childSubaccount, trade
+            )
+
+                val transferToReceiveByParent = if (shouldTransferOut) MarginCalculator.getSubaccountFreeCollateralToTransferOut(
+                    parser, subaccount = childSubaccount
+                ) else null
+
+            Logger.e { "$transferToReceiveByParent" }
+
             val modifiedSubaccount =
                 subaccountTransformer.applyTransferToSubaccount(
                     subaccount,
-                    transferAmount * -1.0,
+                    ((if (transferAmount > 0.0) transferAmount else transferToReceiveByParent) ?: 0.0) * -1.0,
                     parser,
                     period,
                 )

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/SubaccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/SubaccountTransformer.kt
@@ -220,6 +220,7 @@ internal class SubaccountTransformer {
         isTransferOut: Boolean? = false,
     ): Map<String, Any>? {
         if (subaccount != null) {
+            // when isTransferOut is true, usdcSize is overwritten to 0
             val delta = deltaFromTrade(
                 parser,
                 trade,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/SubaccountTransformer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/SubaccountTransformer.kt
@@ -48,6 +48,7 @@ internal class SubaccountTransformer {
         trade: Map<String, Any>,
         market: Map<String, Any>?,
         transfer: Double? = null,
+        shouldTransferOut: Boolean? = false,
     ): Map<String, Any>? {
         val marketId = parser.asString(trade["marketId"])
         val side = parser.asString(trade["side"])
@@ -82,7 +83,7 @@ internal class SubaccountTransformer {
                             "marketId" to marketId,
                             "size" to size,
                             "price" to price,
-                            "usdcSize" to usdcSize,
+                            "usdcSize" to if (shouldTransferOut == true) 0.0 else usdcSize,
                             "fee" to fee,
                             "feeRate" to feeRate,
                             "reduceOnly" to (parser.asBool(trade["reduceOnly"]) ?: false),
@@ -215,7 +216,8 @@ internal class SubaccountTransformer {
         market: Map<String, Any>?,
         parser: ParserProtocol,
         period: String,
-        transfer: Double? = null
+        transfer: Double? = null,
+        isTransferOut: Boolean? = false,
     ): Map<String, Any>? {
         if (subaccount != null) {
             val delta = deltaFromTrade(
@@ -223,6 +225,7 @@ internal class SubaccountTransformer {
                 trade,
                 market,
                 transfer,
+                isTransferOut,
             )
             return applyDeltaToSubaccount(subaccount, delta, parser, period, hasTransfer = transfer != null)
         }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -270,7 +270,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                 "0": {
                                     "freeCollateral": {
                                         "current": 137.13,
-                                        "postOrder": 157.29
+                                        "postOrder": 157.12
                                     },
                                     "openPositions": {
                                         "APE-USD": {
@@ -279,8 +279,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                                 "postOrder": 0
                                             },
                                             "equity": {
-                                                "current": 25.20,
-                                                "postOrder": 0.0
+                                                "current": 25.20
                                             }
                                         }
                                     }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/IsolatedMarginModeTests.kt
@@ -270,7 +270,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                 "0": {
                                     "freeCollateral": {
                                         "current": 137.13,
-                                        "postOrder": 157.12
+                                        "postOrder": 157.29
                                     },
                                     "openPositions": {
                                         "APE-USD": {
@@ -280,7 +280,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
                                             },
                                             "equity": {
                                                 "current": 25.20,
-                                                "postOrder": 5.20
+                                                "postOrder": 0.0
                                             }
                                         }
                                     }
@@ -808,7 +808,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
         // If full close + no open orders, should transfer out
         assertEquals(
             true,
-            MarginCalculator.getShouldTransferOutCollateral(
+            MarginCalculator.getShouldTransferOutRemainingCollateral(
                 parser,
                 subaccount = mapOf(
                     "openPositions" to mapOf(
@@ -864,7 +864,7 @@ class IsolatedMarginModeTests : V4BaseTests(true) {
         // If reducing position to full close but has open orders, should not transfer out
         assertEquals(
             false,
-            MarginCalculator.getShouldTransferOutCollateral(
+            MarginCalculator.getShouldTransferOutRemainingCollateral(
                 parser,
                 subaccount = mapOf(
                     "openPositions" to mapOf(

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.16'
+    spec.version = '1.8.17'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
<img width="461" alt="image" src="https://github.com/dydxprotocol/v4-abacus/assets/9400120/5524a3dd-1f5a-4535-baf7-4f2ee9440a86">

1. fix logic to determine when to transfer out margin (previously flipped position + reduce only logic was wrong)
2. when transferring out, estimate collateral that will be transferred out as quote balance + size*price
3. position margin receipt: overwrite usdcSize as 0 in trade delta so that post order position margin is null