### PR TITLE
chore: relax indexer trailing threshold

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 
 group = "exchange.dydx.abacus"
 
-version = "1.8.21"
+version = "1.8.22"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionStats.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionStats.kt
@@ -35,7 +35,7 @@ internal class ConnectionStats(
     private var lastValidatorCallTime: Instant? = null
 
     @Suppress("PropertyName")
-    private val MAX_NUM_BLOCK_DELAY = 15
+    private val MAX_NUM_BLOCK_DELAY = 25
 
     internal var indexerState = NetworkState()
     internal var validatorState = NetworkState()

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
 
-    spec.version = '1.8.21'
+    spec.version = '1.8.22'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
part of an attempt to reduce indexer trailing statuses triggering

other things that will be added
- make toast go away on the FE when status goes back to normal
- listen to visibility change (i.e. background vs foreground) and reconnect statemanager