### PR TITLE
fix: correct decimal calcs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 
 group = "exchange.dydx.abacus"
 
-version = "1.8.21"
+version = "1.8.22"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -91,8 +91,8 @@ internal class SkipProcessor(
         existing?.let {
             modified = it.mutable()
         }
-        val tokenAddress = parser.asString(parser.value(modified, "transfer.token"))
-        val selectedChainId = parser.asString(parser.value(modified, "transfer.chain"))
+        val tokenAddress = parser.asString(parser.value(payload, "route.dest_asset_denom"))
+        val selectedChainId = parser.asString(parser.value(payload, "route.dest_asset_chain_id"))
         val decimals = parser.asDouble(selectedTokenDecimals(tokenAddress = tokenAddress, selectedChainId = selectedChainId))
         val processor = SkipRouteProcessor(parser)
 
@@ -103,11 +103,7 @@ internal class SkipProcessor(
         if (requestId != null) {
             modified.safeSet("transfer.route.requestPayload.requestId", requestId)
         }
-        if (parser.asNativeMap(existing?.get("transfer"))?.get("type") == "DEPOSIT") {
-            val value = usdcAmount(modified)
-            modified.safeSet("transfer.size.usdcSize", value)
-        }
-
+        modified.safeSet("transfer.size.usdcSize", parser.value(modified, "transfer.route.toAmountUSD"))
         return modified
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -172,7 +172,7 @@ internal class SkipProcessor(
     override fun selectedTokenDecimals(tokenAddress: String?, selectedChainId: String?): String? {
         val tokensList = filteredTokens(selectedChainId)
         tokensList?.find {
-            parser.asString(parser.asNativeMap(it)?.get("denom")) == tokenAddress
+            (parser.asString(parser.asNativeMap(it)?.get("denom")) == tokenAddress || parser.asString(parser.asNativeMap(it)?.get("skipDenom")) == tokenAddress)
         }?.let {
             return parser.asString(parser.asNativeMap(it)?.get("decimals"))
         }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -103,7 +103,10 @@ internal class SkipProcessor(
         if (requestId != null) {
             modified.safeSet("transfer.route.requestPayload.requestId", requestId)
         }
-        modified.safeSet("transfer.size.usdcSize", parser.value(modified, "transfer.route.toAmountUSD"))
+        if (parser.asNativeMap(existing?.get("transfer"))?.get("type") == "DEPOSIT") {
+            val value = usdcAmount(modified)
+            modified.safeSet("transfer.size.usdcSize", value)
+        }
         return modified
     }
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
@@ -353,7 +353,6 @@ class SkipProcessorTests {
                         "toAddress" to "uusdc",
                     ),
                 ),
-                "size" to mapOf("usdcSize" to 11.64),
             ),
         )
         assertEquals(expected, result)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
@@ -28,6 +28,7 @@ class SkipProcessorTests {
     internal val skipRouteMock = SkipRouteMock()
     internal val selectedChainId = "osmosis-1"
     internal val selectedTokenAddress = "selectedTokenDenom"
+    internal val selectedTokenSkipDenom = "selected-token-denom-native"
     internal val selectedTokenSymbol = "selectedTokenSymbol"
     internal val selectedTokenDecimals = "15"
     internal val selectedChainAssets = listOf(
@@ -35,6 +36,7 @@ class SkipProcessorTests {
             "denom" to selectedTokenAddress,
             "symbol" to selectedTokenSymbol,
             "decimals" to selectedTokenDecimals,
+            "skipDenom" to selectedTokenSkipDenom,
             "name" to "some-name",
             "logo_uri" to "some-logo-uri",
         ),
@@ -126,6 +128,13 @@ class SkipProcessorTests {
 
     @Test
     fun testSelectedTokenDecimals() {
+        val result = skipProcessor.selectedTokenDecimals(tokenAddress = selectedTokenSkipDenom, selectedChainId = selectedChainId)
+        val expected = selectedTokenDecimals
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun testSelectedTokenDecimalsUsingSkipDenom() {
         val result = skipProcessor.selectedTokenDecimals(tokenAddress = selectedTokenAddress, selectedChainId = selectedChainId)
         val expected = selectedTokenDecimals
         assertEquals(expected, result)
@@ -344,6 +353,7 @@ class SkipProcessorTests {
                         "toAddress" to "uusdc",
                     ),
                 ),
+                "size" to mapOf("usdcSize" to 11.64),
             ),
         )
         assertEquals(expected, result)

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
 
-    spec.version = '1.8.21'
+    spec.version = '1.8.22'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
wooof. 

we were originally assuming that the transfer.token/chain values were the correct values to calculate decimals.
this isn't true because for deposits that represents the 'from' values instead of the 'to' values, which provides an incorrect amount out value.

<img width="529" alt="Screenshot 2024-07-02 at 5 33 47 PM" src="https://github.com/dydxprotocol/v4-abacus/assets/37092291/4904dd19-a8f8-483c-b112-d6e4d3a67142">


after solving that we then needed to account for the fact that we save the SDK approved denom for native tokens (Ex00EE0E whatever that's not right but you know what i mean), but skip gives us {chain-name}-native. so when finding a token by id when retrieving a route, we need to make sure we're searching for both the denom and skip denom.