### PR TITLE
Refactor v4_markets subscribed utilizing data classes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.26"
+version = "1.8.27"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.27"
+version = "1.8.29"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/PerpetualState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/PerpetualState.kt
@@ -2,6 +2,7 @@ package exchange.dydx.abacus.output
 
 import exchange.dydx.abacus.output.input.Input
 import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.state.internalstate.InternalState
 import exchange.dydx.abacus.utils.IList
 import exchange.dydx.abacus.utils.IMap
 import exchange.dydx.abacus.utils.Logger
@@ -17,6 +18,7 @@ data class PerpetualState(
     /*
      * We are handling this explicitly for js
      */
+    val internalState: InternalState?,
     val assets: IMap<String, Asset>?,
     val marketsSummary: PerpetualMarketSummary?,
     val orderbooks: IMap<String, MarketOrderbook>?,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketsSummaryProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketsSummaryProcessor.kt
@@ -2,8 +2,12 @@ package exchange.dydx.abacus.processor.markets
 
 import exchange.dydx.abacus.processor.base.BaseProcessor
 import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.state.internalstate.InternalStatePerpetualMarket
+import exchange.dydx.abacus.state.internalstate.InternalStatePerpetualMarkets
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
+import indexer.codegen.IndexerPerpetualMarketStatus
+import indexer.codegen.IndexerPerpetualMarketType
 
 @Suppress("UNCHECKED_CAST")
 internal class MarketsSummaryProcessor(parser: ParserProtocol, calculateSparklines: Boolean = false) :
@@ -23,6 +27,70 @@ internal class MarketsSummaryProcessor(parser: ParserProtocol, calculateSparklin
         val markets = marketsProcessor.subscribed(parser.asNativeMap(existing?.get("markets")), content)
         return modify(existing, markets)
     }
+
+    internal fun testSubscribed(content: Map<String, Any>): InternalStatePerpetualMarkets {
+        val payload = parser.asNativeMap(content["markets"])
+        return if (payload != null) {
+            val markets = mutableMapOf<String, InternalStatePerpetualMarket>()
+            for ((market, data) in payload) {
+                val marketPayload = parser.asNativeMap(data)
+                if (marketPayload != null) {
+                    val clobPairId = parser.asInt(marketPayload["clobPairId"]) ?: error("clobPairId is null")
+                    val ticker = parser.asString(marketPayload["ticker"]) ?: error("ticker is null")
+                    val status = IndexerPerpetualMarketStatus.valueOf(parser.asString(marketPayload["status"]) ?: error("status is null"))
+                    val oraclePrice = parser.asDouble(marketPayload["oraclePrice"]) ?: error("oraclePrice is null")
+                    val priceChange24H = parser.asDouble(marketPayload["priceChange24H"]) ?: error("priceChange24H is null")
+                    val volume24H = parser.asDouble(marketPayload["volume24H"]) ?: error("volume24H is null")
+                    val trades24H = parser.asInt(marketPayload["trades24H"]) ?: error("trades24H is null")
+                    val nextFundingRate = parser.asDouble(marketPayload["nextFundingRate"]) ?: error("nextFundingRate is null")
+                    val initialMarginFraction = parser.asDouble(marketPayload["initialMarginFraction"]) ?: error("initialMarginFraction is null")
+                    val maintenanceMarginFraction = parser.asDouble(marketPayload["maintenanceMarginFraction"]) ?: error("maintenanceMarginFraction is null")
+                    val openInterest = parser.asDouble(marketPayload["openInterest"]) ?: error("openInterest is null")
+                    val atomicResolution = parser.asInt(marketPayload["atomicResolution"]) ?: error("atomicResolution is null")
+                    val quantumConversionExponent = parser.asInt(marketPayload["quantumConversionExponent"]) ?: error("quantumConversionExponent is null")
+                    val tickSize = parser.asDouble(marketPayload["tickSize"]) ?: error("tickSize is null")
+                    val stepSize = parser.asDouble(marketPayload["stepSize"]) ?: error("stepSize is null")
+                    val stepBaseQuantums = parser.asInt(marketPayload["stepBaseQuantums"]) ?: error("stepBaseQuantums is null")
+                    val subticksPerTick = parser.asInt(marketPayload["subticksPerTick"]) ?: error("subticksPerTick is null")
+                    val marketType = IndexerPerpetualMarketType.valueOf(parser.asString(marketPayload["marketType"]) ?: error("marketType is null"))
+                    val openInterestLowerCap = parser.asDouble(marketPayload["openInterestLowerCap"]) ?: error("openInterestLowerCap is null")
+                    val openInterestUpperCap = parser.asDouble(marketPayload["openInterestUpperCap"]) ?: error("openInterestUpperCap is null")
+                    val baseOpenInterest = parser.asDouble(marketPayload["baseOpenInterest"]) ?: error("baseOpenInterest is null")
+
+                    val receivedMarket = InternalStatePerpetualMarket(
+                        clobPairId = clobPairId,
+                        ticker = ticker,
+                        status = status,
+                        oraclePrice = oraclePrice,
+                        priceChange24H = priceChange24H,
+                        volume24H = volume24H,
+                        trades24H = trades24H,
+                        nextFundingRate = nextFundingRate,
+                        initialMarginFraction = initialMarginFraction,
+                        maintenanceMarginFraction = maintenanceMarginFraction,
+                        openInterest = openInterest,
+                        atomicResolution = atomicResolution,
+                        quantumConversionExponent = quantumConversionExponent,
+                        tickSize = tickSize,
+                        stepSize = stepSize,
+                        stepBaseQuantums = stepBaseQuantums,
+                        subticksPerTick = subticksPerTick,
+                        marketType = marketType,
+                        openInterestLowerCap = openInterestLowerCap,
+                        openInterestUpperCap = openInterestUpperCap,
+                        baseOpenInterest = baseOpenInterest,
+                    )
+                    markets[market] = receivedMarket
+                }
+            }
+            InternalStatePerpetualMarkets(
+                markets = markets
+            )
+        } else {
+            InternalStatePerpetualMarkets()
+        }
+    }
+
 
     @Suppress("FunctionName")
     internal fun channel_data(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
@@ -2,4 +2,5 @@ package exchange.dydx.abacus.state.internalstate
 
 internal data class InternalState(
     val transfer: InternalTransferInputState = InternalTransferInputState(),
+    val perpetualMarkets: InternalStatePerpetualMarkets = InternalStatePerpetualMarkets(),
 )

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
@@ -1,6 +1,12 @@
 package exchange.dydx.abacus.state.internalstate
 
-internal data class InternalState(
+import kollections.JsExport
+import kotlinx.serialization.Serializable
+
+@Suppress("UNCHECKED_CAST")
+@JsExport
+@Serializable
+data class InternalState(
     val transfer: InternalTransferInputState = InternalTransferInputState(),
     val perpetualMarkets: InternalStatePerpetualMarkets = InternalStatePerpetualMarkets(),
 )

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalStatePerpetualMarkets.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalStatePerpetualMarkets.kt
@@ -1,13 +1,22 @@
 package exchange.dydx.abacus.state.internalstate
 
+import exchange.dydx.abacus.utils.iMapOf
 import indexer.codegen.IndexerPerpetualMarketStatus
 import indexer.codegen.IndexerPerpetualMarketType
+import kollections.JsExport
+import kotlinx.serialization.Serializable
 
-internal data class InternalStatePerpetualMarkets (
-    val markets: Map<String, InternalStatePerpetualMarket>? = null,
+@Suppress("UNCHECKED_CAST")
+@JsExport
+@Serializable
+data class InternalStatePerpetualMarkets (
+    var markets: Map<String, InternalStatePerpetualMarket> = iMapOf(),
 )
 
-internal data class InternalStatePerpetualMarket (
+@Suppress("UNCHECKED_CAST")
+@JsExport
+@Serializable
+data class InternalStatePerpetualMarket (
     val clobPairId: Int, // "6",
     val ticker: String, // "ADA-USD",
     val status: IndexerPerpetualMarketStatus,//  "ACTIVE",

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalStatePerpetualMarkets.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalStatePerpetualMarkets.kt
@@ -1,0 +1,32 @@
+package exchange.dydx.abacus.state.internalstate
+
+import indexer.codegen.IndexerPerpetualMarketStatus
+import indexer.codegen.IndexerPerpetualMarketType
+
+internal data class InternalStatePerpetualMarkets (
+    val markets: Map<String, InternalStatePerpetualMarket>? = null,
+)
+
+internal data class InternalStatePerpetualMarket (
+    val clobPairId: Int, // "6",
+    val ticker: String, // "ADA-USD",
+    val status: IndexerPerpetualMarketStatus,//  "ACTIVE",
+    val oraclePrice: Double, // "0.408213647",
+    val priceChange24H: Double, // "-0.0034423657",
+    val volume24H: Double, // "12831.688",
+    val trades24H: Int, // 388,
+    val nextFundingRate: Double, // "0",
+    val initialMarginFraction: Double, // "0.1",
+    val maintenanceMarginFraction: Double, // "0.05",
+    val openInterest: Double, // "247890",
+    val atomicResolution: Int, // -5,
+    val quantumConversionExponent: Int, // -9,
+    val tickSize: Double, //  "0.0001",
+    val stepSize: Double, // "10",
+    val stepBaseQuantums: Int, // 1000000,
+    val subticksPerTick: Int, // 1000000,
+    val marketType: IndexerPerpetualMarketType?,
+    val openInterestLowerCap: Double, // "20000000",
+    val openInterestUpperCap: Double, // "50000000",
+    val baseOpenInterest: Double, // "247890"
+)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalTransferInputState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalTransferInputState.kt
@@ -3,8 +3,13 @@ package exchange.dydx.abacus.state.internalstate
 import exchange.dydx.abacus.output.input.SelectionOption
 import exchange.dydx.abacus.output.input.TransferInputChainResource
 import exchange.dydx.abacus.output.input.TransferInputTokenResource
+import kollections.JsExport
+import kotlinx.serialization.Serializable
 
-internal data class InternalTransferInputState(
+@Suppress("UNCHECKED_CAST")
+@JsExport
+@Serializable
+data class InternalTransferInputState(
     var chains: List<SelectionOption>? = null,
     var tokens: List<SelectionOption>? = null,
     var chainResources: Map<String, TransferInputChainResource>? = null,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Markets.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Markets.kt
@@ -10,6 +10,10 @@ internal fun TradingStateMachine.receivedMarkets(
     payload: Map<String, Any>,
     subaccountNumber: Int,
 ): StateChanges {
+    internalState = internalState.copy(
+        transfer = internalState.transfer,
+        perpetualMarkets = marketsProcessor.testSubscribed(payload)
+    )
     marketsSummary = marketsProcessor.subscribed(marketsSummary, payload)
     marketsSummary = marketsCalculator.calculate(parser.asMap(marketsSummary), assets, null)
     val subaccountNumbers = MarginCalculator.getChangedSubaccountNumbers(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Markets.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Markets.kt
@@ -77,6 +77,17 @@ internal fun TradingStateMachine.receivedBatchedMarketsChanges(
     subaccountNumber: Int,
 ): StateChanges {
     val blankAssets = assets == null
+    val perpetualMarkets = marketsProcessor.channelBatchData(
+        internalStatePerpetualMarkets = internalState.perpetualMarkets,
+        contents = payload as List<Map<String, Map<String, Map<String, Any>>>>
+    )
+
+    if (perpetualMarkets != null) {
+        internalState = internalState.copy(
+            perpetualMarkets = perpetualMarkets
+        )
+    }
+
     marketsSummary = marketsProcessor.channel_batch_data(marketsSummary, payload)
     val keys = mutableSetOf<String>()
     for (partialPayload in payload) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
@@ -87,7 +87,7 @@ open class TradingStateMachine(
     private val maxSubaccountNumber: Int,
     private val useParentSubaccount: Boolean,
 ) {
-    internal val internalState: InternalState = InternalState()
+    internal var internalState: InternalState = InternalState()
 
     internal val parser: ParserProtocol = Parser()
     internal val marketsProcessor = MarketsSummaryProcessor(parser)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
@@ -1304,6 +1304,7 @@ open class TradingStateMachine(
             }
         }
         return PerpetualState(
+            internalState = internalState,
             assets,
             marketsSummary,
             orderbooks,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
@@ -655,6 +655,7 @@ internal class StateManagerAdaptorV2(
     private fun didSetRestriction(restriction: UsageRestriction?) {
         val state = stateMachine.state
         stateMachine.state = PerpetualState(
+            state?.internalState,
             state?.assets,
             state?.marketsSummary,
             state?.orderbooks,
@@ -688,6 +689,7 @@ internal class StateManagerAdaptorV2(
     private fun didSetGeo(geo: String?) {
         val state = stateMachine.state
         stateMachine.state = PerpetualState(
+            state?.internalState,
             state?.assets,
             state?.marketsSummary,
             state?.orderbooks,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -1017,6 +1017,7 @@ internal open class AccountSupervisor(
         val state = stateMachine.state
         stateMachine.state =
             PerpetualState(
+                state?.internalState,
                 state?.assets,
                 state?.marketsSummary,
                 state?.orderbooks,
@@ -1051,6 +1052,7 @@ internal open class AccountSupervisor(
         val state = stateMachine.state
         stateMachine.state =
             PerpetualState(
+                state?.internalState,
                 state?.assets,
                 state?.marketsSummary,
                 state?.orderbooks,

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.26'
+    spec.version = '1.8.27'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.27'
+    spec.version = '1.8.29'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Add a different format to the internal data that we are working with.
- It just consumed Indexer v4_markets subscribed message outright and saves into a data-class
- Next steps would be to add the derived data, fix tests, and support channel_batch_data updates