### PR TITLE
 Static typing for subaccount fills

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.26"
+version = "1.8.28"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.30"
+version = "1.8.31"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.32"
+version = "1.8.33"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.28"
+version = "1.8.29"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.27"
+version = "1.8.26"
 
 repositories {
     google()

--- a/detekt.yml
+++ b/detekt.yml
@@ -37,6 +37,8 @@ style:
     active: false
   UnusedParameter:
     active: false
+  ForbiddenComment:
+    active: false
 
 empty-blocks:
   EmptyDefaultConstructor:

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Account.kt
@@ -896,7 +896,7 @@ data class SubaccountFill(
     val resources: SubaccountFillResources,
 ) {
     companion object {
-        internal fun create(
+        private fun create(
             existing: SubaccountFill?,
             parser: ParserProtocol,
             data: Map<*, *>?,
@@ -966,27 +966,52 @@ data class SubaccountFill(
             return null
         }
 
-        fun create(
+        internal fun create(
             existing: IList<SubaccountFill>?,
             parser: ParserProtocol,
             data: List<Map<String, Any>>?,
             localizer: LocalizerProtocol?,
         ): IList<SubaccountFill>? {
-            return ParsingHelper.merge(parser, existing, data, { obj, itemData ->
-                val time1 = (obj as SubaccountFill).createdAtMilliseconds
-                val time2 =
-                    parser.asDatetime(itemData["createdAt"])?.toEpochMilliseconds()
-                        ?.toDouble()
-                val id1 = obj.id
-                val id2 = parser.asString(itemData["id"])
-                if (id1 == id2) {
-                    ParsingHelper.compare(time1, time2 ?: 0.0, true)
-                } else {
-                    ParsingHelper.compare(id1, id2, true)
-                }
-            }, { _, obj, itemData ->
-                obj ?: SubaccountFill.create(null, parser, parser.asMap(itemData), localizer)
-            }, true)?.toIList()
+            return ParsingHelper.merge(
+                parser = parser,
+                existing = existing,
+                data = data,
+                comparison = { obj, itemData ->
+                    val time1 = (obj as SubaccountFill).createdAtMilliseconds
+                    val time2 =
+                        parser.asDatetime(itemData["createdAt"])?.toEpochMilliseconds()
+                            ?.toDouble()
+                    val id1 = obj.id
+                    val id2 = parser.asString(itemData["id"])
+                    if (id1 == id2) {
+                        ParsingHelper.compare(time1, time2 ?: 0.0, true)
+                    } else {
+                        ParsingHelper.compare(id1, id2, true)
+                    }
+                },
+                createObject = { _, obj, itemData ->
+                    obj ?: SubaccountFill.create(null, parser, parser.asMap(itemData), localizer)
+                },
+                syncItems = true,
+            )?.toIList()
+        }
+
+        internal fun merge(
+            existing: IList<SubaccountFill>?,
+            new: IList<SubaccountFill>?,
+        ): IList<SubaccountFill> {
+            return ParsingHelper.merge(
+                existing = existing,
+                new = new,
+                comparison = { obj, newItem ->
+                    if (obj.id == newItem.id) {
+                        ParsingHelper.compare(obj.createdAtMilliseconds, newItem.createdAtMilliseconds, true)
+                    } else {
+                        ParsingHelper.compare(obj.id, newItem.id, true)
+                    }
+                },
+                syncItems = true,
+            ).toIList()
         }
     }
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/base/MergeWithIds.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/base/MergeWithIds.kt
@@ -3,13 +3,13 @@ package exchange.dydx.abacus.processor.base
 /**
  * Merge two lists of payloads, dropping older items if a new item with the same ID exists.
  */
-fun mergeWithIds(
-    new: List<Any>,
-    existing: List<Any>,
-    id: (Any) -> String?,
-): List<Any> {
+fun <T> mergeWithIds(
+    new: List<T>,
+    existing: List<T>,
+    id: (T) -> String?,
+): List<T> {
     val ids = mutableSetOf<String>()
-    val merged = mutableListOf<Any>()
+    val merged = mutableListOf<T>()
     new.forEach { item ->
         id(item)?.let { itemId ->
             ids.add(itemId)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/AccountProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/AccountProcessor.kt
@@ -4,12 +4,16 @@ import exchange.dydx.abacus.output.AccountBalance
 import exchange.dydx.abacus.output.StakingRewards
 import exchange.dydx.abacus.output.UnbondingDelegation
 import exchange.dydx.abacus.processor.base.BaseProcessor
+import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.responses.SocketInfo
+import exchange.dydx.abacus.state.internalstate.InternalAccountState
+import exchange.dydx.abacus.state.internalstate.InternalSubaccountState
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.utils.IMutableList
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
+import indexer.codegen.IndexerFillResponseObject
 import kollections.iMutableListOf
 
 /*
@@ -182,12 +186,15 @@ import kollections.iMutableListOf
  */
 
 @Suppress("UNCHECKED_CAST")
-internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
-    private val subaccountsProcessor = V4SubaccountsProcessor(parser)
+internal class V4AccountProcessor(
+    parser: ParserProtocol,
+    localizer: LocalizerProtocol?,
+) : BaseProcessor(parser) {
+    private val subaccountsProcessor = V4SubaccountsProcessor(parser, localizer)
     private val balancesProcessor = AccountBalancesProcessor(parser)
     private val delegationsProcessor = AccountDelegationsProcessor(parser)
     private val tradingRewardsProcessor = AccountTradingRewardsProcessor(parser)
-    private var launchIncentivePointsProcessor = LaunchIncentivePointsProcessor(parser)
+    private val launchIncentivePointsProcessor = LaunchIncentivePointsProcessor(parser)
 
     internal fun receivedAccountBalances(
         existing: Map<String, Any>?,
@@ -275,14 +282,27 @@ internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser
         return modified
     }
 
-    internal fun receivedFills(
+    internal fun processFills(
+        existing: InternalAccountState,
+        payload: List<IndexerFillResponseObject>?,
+        subaccountNumber: Int,
+    ): InternalAccountState {
+        val subaccount = existing.subaccounts[subaccountNumber] ?: InternalSubaccountState(subaccountNumber = subaccountNumber)
+        val newSubaccount = subaccountsProcessor.processFills(subaccount, payload)
+        if (newSubaccount != subaccount) {
+            existing.subaccounts[subaccountNumber] = newSubaccount
+        }
+        return existing
+    }
+
+    internal fun receivedFillsDeprecated(
         existing: Map<String, Any>?,
         payload: Map<String, Any>?,
         subaccountNumber: Int,
     ): Map<String, Any> {
         val modified = existing?.mutable() ?: mutableMapOf()
         val subaccount = parser.asNativeMap(parser.value(existing, "subaccounts.$subaccountNumber"))
-        val modifiedsubaccount = subaccountsProcessor.receivedFills(subaccount, payload)
+        val modifiedsubaccount = subaccountsProcessor.receivedFillsDeprecated(subaccount, payload)
         modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
         return modified
     }
@@ -347,7 +367,39 @@ internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser
         return modified
     }
 
-    internal fun subscribed(
+    internal fun processSubscribed(
+        existing: InternalAccountState,
+        content: Map<String, Any>,
+        height: BlockAndTime?,
+    ): InternalAccountState {
+        var account: InternalAccountState? = null
+
+        val subaccountNumber = parser.asInt(parser.value(content, "subaccount.subaccountNumber"))
+        if (subaccountNumber != null) {
+            val subaccount = existing.subaccounts[subaccountNumber] ?: InternalSubaccountState(subaccountNumber = subaccountNumber)
+            val modifiedsubaccount = subaccountsProcessor.processSubscribed(subaccount, content, height)
+            existing.subaccounts[subaccountNumber] = modifiedsubaccount
+        } else {
+            val parentSubaccountNumber =
+                parser.asInt(parser.value(content, "subaccount.parentSubaccountNumber"))
+            if (parentSubaccountNumber != null) {
+                account = processSubscribedParentSubaccount(existing, content, height)
+            }
+        }
+
+        // TODO: Updating the account with the trading rewards
+
+//        /* block trading rewards are only sent in subaccounts.0 channel */
+//        val tradingRewardsPayload =
+//            parser.value(content, "tradingReward")
+//        if (tradingRewardsPayload != null) {
+//            modified = receivedBlockTradingReward(modified, tradingRewardsPayload)
+//        }
+
+        return account ?: existing
+    }
+
+    internal fun subscribedDeprecated(
         existing: Map<String, Any>?,
         content: Map<String, Any>,
         height: BlockAndTime?,
@@ -357,13 +409,13 @@ internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser
         if (subaccountNumber != null) {
             val subaccount =
                 parser.asNativeMap(parser.value(existing, "subaccounts.$subaccountNumber"))
-            val modifiedsubaccount = subaccountsProcessor.subscribed(subaccount, content, height)
+            val modifiedsubaccount = subaccountsProcessor.subscribedDeprecated(subaccount, content, height)
             modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
         } else {
             val parentSubaccountNumber =
                 parser.asInt(parser.value(content, "subaccount.parentSubaccountNumber"))
             if (parentSubaccountNumber != null) {
-                modified = subscribedParentSubaccount(modified, content, height).mutable()
+                modified = subscribedParentSubaccountDeprecated(modified, content, height).mutable()
             }
         }
 
@@ -376,11 +428,9 @@ internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser
         return modified
     }
 
-    private fun subscribedParentSubaccount(
-        existing: Map<String, Any>,
+    private fun getContentBySubaccountNumber(
         content: Map<String, Any>,
-        height: BlockAndTime?,
-    ): Map<String, Any> {
+    ): Map<Int, Map<String, Any>> {
         /*
         We will go through all segments in the content, regroup them based on subaccountNumber,
         and send to subaccountProcessor's existing code
@@ -415,6 +465,35 @@ internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser
                 }
             }
         }
+        return contentBySubaccountNumber
+    }
+
+    private fun processSubscribedParentSubaccount(
+        existing: InternalAccountState,
+        content: Map<String, Any>,
+        height: BlockAndTime?,
+    ): InternalAccountState {
+        val contentBySubaccountNumber = getContentBySubaccountNumber(content)
+
+        /*
+        Now we have a map of subaccountNumber to content, we can send it to subaccountProcessor
+         */
+        for ((subaccountNumber, subaccountContent) in contentBySubaccountNumber) {
+            val subaccount = existing.subaccounts[subaccountNumber] ?: InternalSubaccountState(subaccountNumber = subaccountNumber)
+            val modifiedsubaccount =
+                subaccountsProcessor.processSubscribed(subaccount, subaccountContent, height)
+            existing.subaccounts[subaccountNumber] = modifiedsubaccount
+        }
+        return existing
+    }
+
+    private fun subscribedParentSubaccountDeprecated(
+        existing: Map<String, Any>,
+        content: Map<String, Any>,
+        height: BlockAndTime?,
+    ): Map<String, Any> {
+        val contentBySubaccountNumber = getContentBySubaccountNumber(content)
+
         /*
         Now we have a map of subaccountNumber to content, we can send it to subaccountProcessor
          */
@@ -423,10 +502,44 @@ internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser
             val subaccount =
                 parser.asNativeMap(parser.value(modified, "subaccounts.$subaccountNumber"))
             val modifiedsubaccount =
-                subaccountsProcessor.subscribed(subaccount, subaccountContent, height)
+                subaccountsProcessor.subscribedDeprecated(subaccount, subaccountContent, height)
             modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
         }
         return modified
+    }
+
+    internal fun processChannelData(
+        existing: InternalAccountState,
+        content: Map<String, Any>,
+        info: SocketInfo,
+        height: BlockAndTime?,
+    ): InternalAccountState {
+        val subaccountNumber = info.childSubaccountNumber ?: parser.asInt(
+            parser.value(
+                content,
+                "subaccounts.subaccountNumber",
+            ),
+        )
+            ?: subaccountNumberFromInfo(info)
+
+        if (subaccountNumber != null) {
+            val subaccount = existing.subaccounts[subaccountNumber] ?: InternalSubaccountState(
+                subaccountNumber = subaccountNumber,
+            )
+            val modifiedsubaccount =
+                subaccountsProcessor.processChannelData(subaccount, content, height)
+            existing.subaccounts[subaccountNumber] = modifiedsubaccount
+
+            // TODO: Updating the account with the trading rewards
+
+//            /* block trading rewards are only sent in subaccounts.0 channel */
+//            val tradingRewardsPayload = content["tradingReward"]
+//            if (tradingRewardsPayload != null) {
+//                modified = receivedBlockTradingReward(modified, tradingRewardsPayload)
+//            }
+//            return modified
+        }
+        return existing
     }
 
     @Suppress("FunctionName")
@@ -443,7 +556,7 @@ internal class V4AccountProcessor(parser: ParserProtocol) : BaseProcessor(parser
             var modified = existing?.toMutableMap() ?: mutableMapOf()
             val subaccount =
                 parser.asNativeMap(parser.value(existing, "subaccounts.$subaccountNumber"))
-            val modifiedsubaccount = subaccountsProcessor.channel_data(subaccount, content, height)
+            val modifiedsubaccount = subaccountsProcessor.channel_dataDeprecated(subaccount, content, height)
             modified.safeSet("subaccounts.$subaccountNumber", modifiedsubaccount)
 
             /* block trading rewards are only sent in subaccounts.0 channel */

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/FillProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/FillProcessor.kt
@@ -1,13 +1,24 @@
 package exchange.dydx.abacus.processor.wallet.account
 
+import exchange.dydx.abacus.output.FillLiquidity
+import exchange.dydx.abacus.output.SubaccountFill
+import exchange.dydx.abacus.output.SubaccountFillResources
 import exchange.dydx.abacus.output.input.MarginMode
+import exchange.dydx.abacus.output.input.OrderSide
+import exchange.dydx.abacus.output.input.OrderType
 import exchange.dydx.abacus.processor.base.BaseProcessor
 import exchange.dydx.abacus.processor.utils.OrderTypeProcessor
+import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
 import exchange.dydx.abacus.utils.safeSet
+import indexer.codegen.IndexerFillResponseObject
 
-internal class FillProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
+internal class FillProcessor(
+    parser: ParserProtocol,
+    private val localizer: LocalizerProtocol?,
+) : BaseProcessor(parser) {
     private val fillKeyMap = mapOf(
         "string" to mapOf(
             "id" to "id",
@@ -61,7 +72,59 @@ internal class FillProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
         "SELL" to "Sell",
     )
 
-    internal fun received(
+    internal fun process(
+        payload: IndexerFillResponseObject,
+        subaccountNumber: Int,
+    ): SubaccountFill? {
+        fun doProcess(): SubaccountFill? {
+            val fillSubaccountNumber = parser.asInt(payload.subaccountNumber) ?: subaccountNumber
+
+            val id = payload.id ?: return null
+            val marketId = payload.market ?: return null
+            val side = payload.side?.name?.let { OrderSide.invoke(rawValue = it) } ?: return null
+            val liquidity =
+                payload.liquidity?.name?.let { FillLiquidity.invoke(rawValue = it) } ?: return null
+
+            val typeString = OrderTypeProcessor.orderType(
+                type = payload.type?.name,
+                clientMetadata = parser.asInt(payload.clientMetadata),
+            )
+            val type = typeString?.let { OrderType.invoke(rawValue = it) } ?: return null
+
+            return SubaccountFill(
+                id = id,
+                marketId = marketId,
+                orderId = payload.orderId,
+                subaccountNumber = fillSubaccountNumber,
+                marginMode = if (fillSubaccountNumber >= NUM_PARENT_SUBACCOUNTS) MarginMode.Isolated else MarginMode.Cross,
+                side = side,
+                type = type,
+                liquidity = liquidity,
+                price = parser.asDouble(payload.price) ?: return null,
+                size = parser.asDouble(payload.size) ?: return null,
+                fee = parser.asDouble(payload.fee) ?: return null,
+                createdAtMilliseconds = parser.asDatetime(payload.createdAt)?.toEpochMilliseconds()
+                    ?.toDouble() ?: return null,
+                resources = SubaccountFillResources(
+                    sideString = sideMap[payload.side.name]?.let { localizer?.localize(it) },
+                    liquidityString = liquidityMap[payload.liquidity.name]?.let { localizer?.localize(it) },
+                    typeString = typeMap[typeString]?.let { localizer?.localize(it) },
+                    sideStringKey = sideMap[payload.side.name],
+                    liquidityStringKey = liquidityMap[payload.liquidity.name],
+                    typeStringKey = typeMap[typeString],
+                    iconLocal = sideIconMap[payload.side.name],
+                ),
+            )
+        }
+
+        return doProcess().also { fill ->
+            if (fill == null) {
+                Logger.e { "Failed to parse fill: $payload" }
+            }
+        }
+    }
+
+    internal fun receivedDeprecated(
         existing: Map<String, Any>?,
         payload: Map<String, Any>,
         subaccountNumber: Int,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/FillProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/FillProcessor.kt
@@ -15,10 +15,17 @@ import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
 import exchange.dydx.abacus.utils.safeSet
 import indexer.codegen.IndexerFillResponseObject
 
+internal interface FillProcessorProtocol {
+    fun process(
+        payload: IndexerFillResponseObject,
+        subaccountNumber: Int,
+    ): SubaccountFill?
+}
+
 internal class FillProcessor(
     parser: ParserProtocol,
     private val localizer: LocalizerProtocol?,
-) : BaseProcessor(parser) {
+) : BaseProcessor(parser), FillProcessorProtocol {
     private val fillKeyMap = mapOf(
         "string" to mapOf(
             "id" to "id",
@@ -72,7 +79,7 @@ internal class FillProcessor(
         "SELL" to "Sell",
     )
 
-    internal fun process(
+    override fun process(
         payload: IndexerFillResponseObject,
         subaccountNumber: Int,
     ): SubaccountFill? {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/FillsProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/FillsProcessor.kt
@@ -17,7 +17,7 @@ internal class FillsProcessor(
         existing: List<SubaccountFill>?,
         payload: List<IndexerFillResponseObject>,
         subaccountNumber: Int
-    ): List<SubaccountFill>? {
+    ): List<SubaccountFill> {
         val new = payload.mapNotNull { eachPayload ->
             itemProcessor.process(
                 payload = eachPayload,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/FillsProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/FillsProcessor.kt
@@ -1,18 +1,41 @@
 package exchange.dydx.abacus.processor.wallet.account
 
+import exchange.dydx.abacus.output.SubaccountFill
 import exchange.dydx.abacus.processor.base.BaseProcessor
 import exchange.dydx.abacus.processor.base.mergeWithIds
+import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.abacus.protocols.ParserProtocol
+import indexer.codegen.IndexerFillResponseObject
 
-internal class FillsProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
-    private val itemProcessor = FillProcessor(parser = parser)
+internal class FillsProcessor(
+    parser: ParserProtocol,
+    localizer: LocalizerProtocol?,
+) : BaseProcessor(parser) {
+    private val itemProcessor = FillProcessor(parser = parser, localizer = localizer)
 
-    fun received(existing: List<Any>?, payload: List<Any>, subaccountNumber: Int): List<Any>? {
+    fun process(
+        existing: List<SubaccountFill>?,
+        payload: List<IndexerFillResponseObject>,
+        subaccountNumber: Int
+    ): List<SubaccountFill>? {
+        val new = payload.mapNotNull { eachPayload ->
+            itemProcessor.process(
+                payload = eachPayload,
+                subaccountNumber = subaccountNumber,
+            )
+        }
+        existing?.let {
+            return mergeWithIds(new, existing) { item -> item.id }
+        }
+        return new
+    }
+
+    fun receivedDeprecated(existing: List<Any>?, payload: List<Any>, subaccountNumber: Int): List<Any>? {
         val new = payload.mapNotNull { eachPayload ->
             parser.asNativeMap(eachPayload)?.let { eachPayloadData ->
                 val modified = eachPayloadData.toMutableMap()
 
-                itemProcessor.received(
+                itemProcessor.receivedDeprecated(
                     null,
                     modified,
                     subaccountNumber,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/FillsProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/FillsProcessor.kt
@@ -10,8 +10,8 @@ import indexer.codegen.IndexerFillResponseObject
 internal class FillsProcessor(
     parser: ParserProtocol,
     localizer: LocalizerProtocol?,
+    private val fillProcessor: FillProcessorProtocol = FillProcessor(parser = parser, localizer = localizer),
 ) : BaseProcessor(parser) {
-    private val itemProcessor = FillProcessor(parser = parser, localizer = localizer)
 
     fun process(
         existing: List<SubaccountFill>?,
@@ -19,7 +19,7 @@ internal class FillsProcessor(
         subaccountNumber: Int
     ): List<SubaccountFill> {
         val new = payload.mapNotNull { eachPayload ->
-            itemProcessor.process(
+            fillProcessor.process(
                 payload = eachPayload,
                 subaccountNumber = subaccountNumber,
             )
@@ -35,6 +35,7 @@ internal class FillsProcessor(
             parser.asNativeMap(eachPayload)?.let { eachPayloadData ->
                 val modified = eachPayloadData.toMutableMap()
 
+                val itemProcessor = fillProcessor as FillProcessor
                 itemProcessor.receivedDeprecated(
                     null,
                     modified,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/SubaccountProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/SubaccountProcessor.kt
@@ -287,7 +287,10 @@ internal open class SubaccountProcessor(
             payload = payload ?: emptyList(),
             subaccountNumber = subaccount.subaccountNumber,
         )
-        return if (subaccount.fills != newFills) subaccount.copy(fills = newFills) else subaccount
+        if (subaccount.fills != newFills) {
+            subaccount.fills = newFills
+        }
+        return subaccount
     }
 
     private fun receivedFillsDeprecated(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/SubaccountProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/wallet/account/SubaccountProcessor.kt
@@ -2,19 +2,28 @@ package exchange.dydx.abacus.processor.wallet.account
 
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 import exchange.dydx.abacus.processor.base.BaseProcessor
+import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.state.internalstate.InternalSubaccountState
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.Numeric
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
+import exchange.dydx.abacus.utils.toJson
+import indexer.codegen.IndexerFillResponse
+import indexer.codegen.IndexerFillResponseObject
+import kotlinx.serialization.json.Json
 
 @Suppress("UNCHECKED_CAST")
-internal open class SubaccountProcessor(parser: ParserProtocol) : BaseProcessor(parser) {
+internal open class SubaccountProcessor(
+    parser: ParserProtocol,
+    localizer: LocalizerProtocol?,
+) : BaseProcessor(parser) {
     internal val assetPositionsProcessor = AssetPositionsProcessor(parser)
     internal val ordersProcessor = OrdersProcessor(parser)
     private val perpetualPositionsProcessor = PerpetualPositionsProcessor(parser)
-    private val fillsProcessor = FillsProcessor(parser)
+    private val fillsProcessor = FillsProcessor(parser, localizer)
     private val transfersProcessor = TransfersProcessor(parser)
     private val fundingPaymentsProcessor = FundingPaymentsProcessor(parser)
     private val historicalPNLsProcessor = HistoricalPNLsProcessor(parser)
@@ -49,24 +58,54 @@ internal open class SubaccountProcessor(parser: ParserProtocol) : BaseProcessor(
         ),
     )
 
-    internal fun subscribed(
+    internal fun processSubscribed(
+        existing: InternalSubaccountState,
+        content: Map<String, Any>,
+        height: BlockAndTime?,
+    ): InternalSubaccountState {
+        return processSocket(existing, content, true, height)
+    }
+
+    internal fun subscribedDeprecated(
         existing: Map<String, Any>?,
         content: Map<String, Any>,
         height: BlockAndTime?,
     ): Map<String, Any> {
-        return socket(existing, content, true, height)
+        return socketDeprecated(existing, content, true, height)
+    }
+
+    internal fun processChannelData(
+        existing: InternalSubaccountState,
+        content: Map<String, Any>,
+        height: BlockAndTime?,
+    ): InternalSubaccountState {
+        return processSocket(existing, content, false, height)
     }
 
     @Suppress("FunctionName")
-    internal fun channel_data(
+    internal fun channel_dataDeprecated(
         existing: Map<String, Any>?,
         content: Map<String, Any>,
         height: BlockAndTime?,
     ): Map<String, Any> {
-        return socket(existing, content, false, height)
+        return socketDeprecated(existing, content, false, height)
     }
 
-    internal open fun socket(
+    internal open fun processSocket(
+        existing: InternalSubaccountState,
+        content: Map<String, Any>,
+        subscribed: Boolean,
+        height: BlockAndTime?,
+    ): InternalSubaccountState {
+        val fillResponse = Json.decodeFromString<IndexerFillResponse?>(content.toJson())
+        if (fillResponse == null) {
+            Logger.e { "Unable to parse IndexerFillResponse: $content" }
+        }
+
+        return processFills(existing, fillResponse?.fills?.toList(), false)
+    }
+
+    internal open fun socketDeprecated(
         existing: Map<String, Any>?,
         content: Map<String, Any>,
         subscribed: Boolean,
@@ -92,7 +131,7 @@ internal open class SubaccountProcessor(parser: ParserProtocol) : BaseProcessor(
 
         val fillsPayload = parser.asNativeList(content["fills"])
         if (fillsPayload != null) {
-            subaccount = receivedFills(subaccount, fillsPayload, false)
+            subaccount = receivedFillsDeprecated(subaccount, fillsPayload, false)
         }
 
         val transfersPayload = content["transfers"]
@@ -238,7 +277,20 @@ internal open class SubaccountProcessor(parser: ParserProtocol) : BaseProcessor(
         return Pair(existing, false)
     }
 
-    private fun receivedFills(
+    private fun processFills(
+        subaccount: InternalSubaccountState,
+        payload: List<IndexerFillResponseObject>?,
+        reset: Boolean,
+    ): InternalSubaccountState {
+        val newFills = fillsProcessor.process(
+            existing = if (reset) null else subaccount.fills,
+            payload = payload ?: emptyList(),
+            subaccountNumber = subaccount.subaccountNumber,
+        )
+        return if (subaccount.fills != newFills) subaccount.copy(fills = newFills) else subaccount
+    }
+
+    private fun receivedFillsDeprecated(
         subaccount: Map<String, Any>,
         payload: List<Any>?,
         reset: Boolean,
@@ -246,7 +298,7 @@ internal open class SubaccountProcessor(parser: ParserProtocol) : BaseProcessor(
         val subaccountNumber = parser.asInt(subaccount["subaccountNumber"]) ?: 0
         return receivedObject(subaccount, "fills", payload) { existing, payload ->
             parser.asNativeList(payload)?.let {
-                fillsProcessor.received(if (reset) null else parser.asNativeList(existing), it, subaccountNumber)
+                fillsProcessor.receivedDeprecated(if (reset) null else parser.asNativeList(existing), it, subaccountNumber)
             }
         } ?: subaccount
     }
@@ -335,12 +387,19 @@ internal open class SubaccountProcessor(parser: ParserProtocol) : BaseProcessor(
         }
     }
 
-    internal fun receivedFills(
+    internal fun processFills(
+        existing: InternalSubaccountState,
+        payload: List<IndexerFillResponseObject>?,
+    ): InternalSubaccountState {
+        return processFills(existing, payload, true)
+    }
+
+    internal fun receivedFillsDeprecated(
         existing: Map<String, Any>?,
         payload: Map<String, Any>?,
     ): Map<String, Any>? {
         val modified = existing?.mutable() ?: mutableMapOf()
-        return receivedFills(modified, parser.asNativeList(payload?.get("fills")), true)
+        return receivedFillsDeprecated(modified, parser.asNativeList(payload?.get("fills")), true)
     }
 
     internal fun receivedTransfers(
@@ -477,7 +536,10 @@ internal open class SubaccountProcessor(parser: ParserProtocol) : BaseProcessor(
     }
 }
 
-internal class V4SubaccountProcessor(parser: ParserProtocol) : SubaccountProcessor(parser) {
+internal class V4SubaccountProcessor(
+    parser: ParserProtocol,
+    localizer: LocalizerProtocol?,
+) : SubaccountProcessor(parser, localizer) {
     override fun received(
         existing: Map<String, Any>,
         height: BlockAndTime?,
@@ -499,8 +561,11 @@ internal class V4SubaccountProcessor(parser: ParserProtocol) : SubaccountProcess
     }
 }
 
-internal class V4SubaccountsProcessor(parser: ParserProtocol) : SubaccountProcessor(parser) {
-    private val subaccountProcessor = V4SubaccountProcessor(parser)
+internal class V4SubaccountsProcessor(
+    parser: ParserProtocol,
+    localizer: LocalizerProtocol?,
+) : SubaccountProcessor(parser, localizer) {
+    private val subaccountProcessor = V4SubaccountProcessor(parser, localizer)
     internal fun receivedSubaccounts(
         existing: Map<String, Any>?,
         payload: List<Any>?,
@@ -530,13 +595,13 @@ internal class V4SubaccountsProcessor(parser: ParserProtocol) : SubaccountProces
             ?: parser.asNativeMap(content["subaccounts"])
     }
 
-    override fun socket(
+    override fun socketDeprecated(
         existing: Map<String, Any>?,
         content: Map<String, Any>,
         subscribed: Boolean,
         height: BlockAndTime?,
     ): Map<String, Any> {
-        val modified = super.socket(existing, content, subscribed, height).mutable()
+        val modified = super.socketDeprecated(existing, content, subscribed, height).mutable()
 
         val assetPositionsPayload =
             parser.asNativeList(content["assetPositions"]) as? List<Map<String, Any>>

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
@@ -1,5 +1,22 @@
 package exchange.dydx.abacus.state.internalstate
 
+import exchange.dydx.abacus.output.SubaccountFill
+
 internal data class InternalState(
     val transfer: InternalTransferInputState = InternalTransferInputState(),
+    val wallet: InternalWalletState = InternalWalletState(),
+)
+
+internal data class InternalWalletState(
+    var account: InternalAccountState = InternalAccountState(),
+    var walletAddress: String? = null,
+)
+
+internal data class InternalAccountState(
+    var subaccounts: MutableMap<Int, InternalSubaccountState> = mutableMapOf(),
+)
+
+internal data class InternalSubaccountState(
+    var fills: List<SubaccountFill>? = null,
+    var subaccountNumber: Int,
 )

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/PerpTradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/PerpTradingStateMachine.kt
@@ -10,8 +10,9 @@ class PerpTradingStateMachine(
     formatter: Formatter?,
     maxSubaccountNumber: Int,
     useParentSubaccount: Boolean,
+    staticTyping: Boolean = false,
 ) :
-    TradingStateMachine(environment, localizer, formatter, maxSubaccountNumber, useParentSubaccount) {
+    TradingStateMachine(environment, localizer, formatter, maxSubaccountNumber, useParentSubaccount, staticTyping) {
     /*
     Placeholder for now. Eventually, the code specifically for Perpetual will be in this class
      */

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
@@ -106,12 +106,13 @@ internal class StateManagerAdaptorV2(
     var dataNotification: DataNotificationProtocol?,
     private val presentationProtocol: PresentationProtocol?,
 ) : ConnectionDelegate {
-    var stateMachine: TradingStateMachine = PerpTradingStateMachine(
-        environment,
-        uiImplementations.localizer,
-        Formatter(uiImplementations.formatter),
-        127,
-        appConfigs.accountConfigs.subaccountConfigs.useParentSubaccount,
+    val stateMachine: TradingStateMachine = PerpTradingStateMachine(
+        environment = environment,
+        localizer = uiImplementations.localizer,
+        formatter = Formatter(uiImplementations.formatter),
+        maxSubaccountNumber = 127,
+        useParentSubaccount = appConfigs.accountConfigs.subaccountConfigs.useParentSubaccount,
+        staticTyping = appConfigs.staticTyping,
     )
 
     internal val jsonEncoder = JsonEncoder()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/Configs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/Configs.kt
@@ -190,6 +190,7 @@ data class AppConfigsV2(
     var loadRemote: Boolean = true,
     var enableLogger: Boolean = false,
     var triggerOrderToast: Boolean = false,
+    var staticTyping: Boolean = false,
 ) {
     companion object {
         val forApp = AppConfigsV2(

--- a/src/commonTest/kotlin/exchange.dydx.abacus/localizer/MockLocalizer.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/localizer/MockLocalizer.kt
@@ -1,0 +1,9 @@
+package exchange.dydx.abacus.localizer
+
+import exchange.dydx.abacus.protocols.LocalizerProtocol
+
+class MockLocalizer : LocalizerProtocol {
+    override fun localize(path: String, paramsAsJson: String?): String {
+        return path
+    }
+}

--- a/src/commonTest/kotlin/exchange.dydx.abacus/localizer/MockLocalizer.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/localizer/MockLocalizer.kt
@@ -1,9 +1,0 @@
-package exchange.dydx.abacus.localizer
-
-import exchange.dydx.abacus.protocols.LocalizerProtocol
-
-class MockLocalizer : LocalizerProtocol {
-    override fun localize(path: String, paramsAsJson: String?): String {
-        return path
-    }
-}

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/wallet/account/FillProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/wallet/account/FillProcessorTests.kt
@@ -1,0 +1,80 @@
+package exchange.dydx.abacus.processor.wallet.account
+
+import exchange.dydx.abacus.localizer.MockLocalizer
+import exchange.dydx.abacus.output.FillLiquidity
+import exchange.dydx.abacus.output.SubaccountFill
+import exchange.dydx.abacus.output.SubaccountFillResources
+import exchange.dydx.abacus.output.input.MarginMode
+import exchange.dydx.abacus.output.input.OrderSide
+import exchange.dydx.abacus.output.input.OrderType
+import exchange.dydx.abacus.utils.Parser
+import indexer.codegen.IndexerFillResponseObject
+import indexer.codegen.IndexerFillType
+import indexer.codegen.IndexerLiquidity
+import indexer.codegen.IndexerMarketType
+import indexer.codegen.IndexerOrderSide
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FillProcessorTests {
+
+    private val fillProcessor = FillProcessor(
+        parser = Parser(),
+        localizer = MockLocalizer(),
+    )
+
+    private val createdAt = Instant.parse("2021-01-01T00:00:00Z")
+
+    private val fillPayload = IndexerFillResponseObject(
+        id = "1",
+        side = IndexerOrderSide.BUY,
+        liquidity = IndexerLiquidity.MAKER,
+        type = IndexerFillType.LIMIT,
+        market = "WETH-DAI",
+        marketType = IndexerMarketType.PERPETUAL,
+        price = "1.0",
+        size = "2.0",
+        fee = "3.0",
+        createdAt = createdAt.toString(),
+        createdAtHeight = "111",
+        orderId = "2222",
+        clientMetadata = "0",
+        subaccountNumber = 0.0,
+    )
+
+    @Test
+    fun testProcess() {
+        val fill = fillProcessor.process(
+            payload = fillPayload,
+            subaccountNumber = 0,
+        )
+
+        assertEquals(
+            SubaccountFill(
+                id = "1",
+                side = OrderSide.Buy,
+                liquidity = FillLiquidity.maker,
+                type = OrderType.Limit,
+                price = 1.0,
+                size = 2.0,
+                fee = 3.0,
+                orderId = "2222",
+                subaccountNumber = 0,
+                marketId = "WETH-DAI",
+                marginMode = MarginMode.Cross,
+                createdAtMilliseconds = createdAt.toEpochMilliseconds().toDouble(),
+                resources = SubaccountFillResources(
+                    sideString = "APP.GENERAL.BUY",
+                    liquidityString = "APP.TRADE.MAKER",
+                    typeString = "APP.TRADE.LIMIT_ORDER_SHORT",
+                    sideStringKey = "APP.GENERAL.BUY",
+                    liquidityStringKey = "APP.TRADE.MAKER",
+                    typeStringKey = "APP.TRADE.LIMIT_ORDER_SHORT",
+                    iconLocal = "Buy",
+                ),
+            ),
+            fill,
+        )
+    }
+}

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/wallet/account/FillProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/wallet/account/FillProcessorTests.kt
@@ -1,12 +1,12 @@
 package exchange.dydx.abacus.processor.wallet.account
 
-import exchange.dydx.abacus.localizer.MockLocalizer
 import exchange.dydx.abacus.output.FillLiquidity
 import exchange.dydx.abacus.output.SubaccountFill
 import exchange.dydx.abacus.output.SubaccountFillResources
 import exchange.dydx.abacus.output.input.MarginMode
 import exchange.dydx.abacus.output.input.OrderSide
 import exchange.dydx.abacus.output.input.OrderType
+import exchange.dydx.abacus.tests.mock.LocalizerProtocolMock
 import exchange.dydx.abacus.utils.Parser
 import indexer.codegen.IndexerFillResponseObject
 import indexer.codegen.IndexerFillType
@@ -21,7 +21,7 @@ class FillProcessorTests {
 
     private val fillProcessor = FillProcessor(
         parser = Parser(),
-        localizer = MockLocalizer(),
+        localizer = LocalizerProtocolMock(),
     )
 
     private val createdAt = Instant.parse("2021-01-01T00:00:00Z")

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/wallet/account/FillsProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/wallet/account/FillsProcessorTests.kt
@@ -1,0 +1,105 @@
+package exchange.dydx.abacus.processor.wallet.account
+
+import exchange.dydx.abacus.output.FillLiquidity
+import exchange.dydx.abacus.output.SubaccountFill
+import exchange.dydx.abacus.output.SubaccountFillResources
+import exchange.dydx.abacus.output.input.MarginMode
+import exchange.dydx.abacus.output.input.OrderSide
+import exchange.dydx.abacus.output.input.OrderType
+import exchange.dydx.abacus.tests.mock.LocalizerProtocolMock
+import exchange.dydx.abacus.tests.mock.processor.wallet.account.FillProcessorMock
+import exchange.dydx.abacus.utils.Parser
+import indexer.codegen.IndexerFillResponseObject
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FillsProcessorTests {
+    private val fillProcessor = FillProcessorMock()
+    private val fillsProcessor = FillsProcessor(
+        parser = Parser(),
+        localizer = LocalizerProtocolMock(),
+        fillProcessor = fillProcessor,
+    )
+
+    @Test
+    fun testProcess_emptyPayload() {
+        val output = fillsProcessor.process(
+            existing = null,
+            payload = emptyList(),
+            subaccountNumber = 0,
+        )
+        assertEquals(0, output.size)
+    }
+
+    @Test
+    fun testProcess_nonEmptyPayload() {
+        fillProcessor.processAction = { input, _ ->
+            createSubaccountFill(input.id!!)
+        }
+
+        val output = fillsProcessor.process(
+            existing = null,
+            payload = listOf(
+                IndexerFillResponseObject(
+                    id = "1",
+                ),
+            ),
+            subaccountNumber = 0,
+        )
+        assertEquals(1, output.size)
+        assertEquals(output[0].id, "1")
+    }
+
+    @Test
+    fun testProcess_withMerge() {
+        fillProcessor.processAction = { input, _ ->
+            createSubaccountFill(input.id!!)
+        }
+
+        val output = fillsProcessor.process(
+            existing = listOf(
+                createSubaccountFill("1"),
+            ),
+            payload = listOf(
+                IndexerFillResponseObject(
+                    id = "1",
+                ),
+                IndexerFillResponseObject(
+                    id = "2",
+                ),
+            ),
+            subaccountNumber = 0,
+        )
+        assertEquals(2, output.size)
+        assertEquals(output[0].id, "1")
+        assertEquals(output[1].id, "2")
+    }
+
+    private fun createSubaccountFill(id: String): SubaccountFill {
+        val createdAt = Instant.parse("2021-01-01T00:00:00Z")
+        return SubaccountFill(
+            id = id,
+            side = OrderSide.Buy,
+            liquidity = FillLiquidity.maker,
+            type = OrderType.Limit,
+            price = 1.0,
+            size = 2.0,
+            fee = 3.0,
+            orderId = "2222",
+            subaccountNumber = 0,
+            marketId = "WETH-DAI",
+            marginMode = MarginMode.Cross,
+            createdAtMilliseconds = createdAt.toEpochMilliseconds().toDouble(),
+            resources = SubaccountFillResources(
+                sideString = "APP.GENERAL.BUY",
+                liquidityString = "APP.TRADE.MAKER",
+                typeString = "APP.TRADE.LIMIT_ORDER_SHORT",
+                sideStringKey = "APP.GENERAL.BUY",
+                liquidityStringKey = "APP.TRADE.MAKER",
+                typeStringKey = "APP.TRADE.LIMIT_ORDER_SHORT",
+                iconLocal = "Buy",
+            ),
+        )
+    }
+}

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/extensions/TradingStateMachine+Markets.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/extensions/TradingStateMachine+Markets.kt
@@ -115,19 +115,6 @@ fun TradingStateMachine.loadv4FillsReceived(mock: AbacusMockData, endpoint: Stri
     return rest(AbUrl.fromString(endpoint), mock.fillsChannel.v4_rest, 0, null)
 }
 
-fun TradingStateMachine.loadFillsReceived(mock: AbacusMockData): StateResponse {
-    return rest(
-        AbUrl(
-            host = "api.stage.dydx.exchange",
-            path = "/v3/fills",
-            scheme = "https://",
-        ),
-        mock.accountsChannel.fillsReceived,
-        0,
-        null,
-    )
-}
-
 fun TradingStateMachine.loadSimpleAccounts(mock: AbacusMockData): StateResponse {
     return socket(mock.socketUrl, mock.accountsChannel.simpleSubscribed, 0, null)
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/mock/LocalizerProtocolMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/mock/LocalizerProtocolMock.kt
@@ -7,6 +7,6 @@ class LocalizerProtocolMock : LocalizerProtocol {
 
     override fun localize(path: String, paramsAsJson: String?): String {
         localizeCallCount++
-        return path + paramsAsJson
+        return path + (paramsAsJson ?: "")
     }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/mock/processor/wallet/account/FillProcessorMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/mock/processor/wallet/account/FillProcessorMock.kt
@@ -1,0 +1,18 @@
+package exchange.dydx.abacus.tests.mock.processor.wallet.account
+
+import exchange.dydx.abacus.output.SubaccountFill
+import exchange.dydx.abacus.processor.wallet.account.FillProcessorProtocol
+import indexer.codegen.IndexerFillResponseObject
+
+class FillProcessorMock : FillProcessorProtocol {
+    var processCallCount = 0
+    var processAction: ((payload: IndexerFillResponseObject, subaccountNumber: Int) -> SubaccountFill?)? = null
+
+    override fun process(
+        payload: IndexerFillResponseObject,
+        subaccountNumber: Int
+    ): SubaccountFill? {
+        processCallCount++
+        return processAction?.invoke(payload, subaccountNumber)
+    }
+}

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.30'
+    spec.version = '1.8.31'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.29'
+    spec.version                  = '1.8.29'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
                 
                 
                 
-    if false
+    if !Dir.exist?('build/cocoapods/framework/Abacus.framework') || Dir.empty?('build/cocoapods/framework/Abacus.framework')
         raise "
 
         Kotlin framework 'Abacus' doesn't exist yet, so a proper Xcode project can't be generated.

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.28'
+    spec.version = '1.8.29'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.32'
+    spec.version = '1.8.33'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Constructing subaccount fills with static typed data and codegen models from Indexer.  This can serve as a reference for future migration.

- Feature-flagged via `staticTyping` from Abacus config and retaining all existing behavior with the data map.   
- New processor functions have names starting with "process".
- Previous data map-based functions are renamed with trailing "Deprecated".  
- Tested with Android.

