### PR TITLE
fix: use smart relay and allow unsafe with cctp withdraws

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.28"
+version = "1.8.29"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -650,12 +650,12 @@ internal open class AccountSupervisor(
                         helper.transaction(TransactionType.SendNobleIBC, ibcPayload) {
                             val error = helper.parseTransactionResponse(it)
                             if (error != null) {
-                                Logger.e { "sweepNobleBalanceToDydx error: $error" }
+                                Logger.e { "sweepNobleBalanceToDydxSquid error: $error" }
                             }
                         }
                     }
                 } else {
-                    Logger.e { "sweepNobleBalanceToDydx error, code: $code" }
+                    Logger.e { "sweepNobleBalanceToDydxSquid error, code: $code" }
                 }
             }
         }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -491,7 +491,7 @@ internal open class AccountSupervisor(
                         }
                     }
 //                        else, transfer noble balance back to dydx
-                        ?: run { transferNobleBalance(amount) }
+                        ?: run { sweepNobleBalanceToDydx(amount) }
                 } else if (balance["error"] != null) {
                     Logger.e { "Error checking noble balance: $response" }
                 }
@@ -596,19 +596,15 @@ internal open class AccountSupervisor(
         }
     }
 
-//    DO-LATER: https://linear.app/dydx/issue/OTE-350/%5Babacus%5D-cleanup
-//    rename to transferNobleToDydx or something more descriptive.
-//    This function is a unidirection transfer function that sweeps funds
-//    from a noble account into a user's given subaccount
-    private fun transferNobleBalance(amount: BigDecimal) {
+    private fun sweepNobleBalanceToDydx(amount: BigDecimal) {
         if (StatsigConfig.useSkip) {
-            transferNobleBalanceSkip(amount = amount)
+            sweepNobleBalanceToDydxSkip(amount = amount)
         } else {
-            transferNobleBalanceSquid(amount = amount)
+            sweepNobleBalanceToDydxSquid(amount = amount)
         }
     }
 
-    private fun transferNobleBalanceSquid(amount: BigDecimal) {
+    private fun sweepNobleBalanceToDydxSquid(amount: BigDecimal) {
         val url = helper.configs.squidRoute()
         val fromChain = helper.configs.nobleChainId()
         val fromToken = helper.configs.nobleDenom
@@ -654,18 +650,18 @@ internal open class AccountSupervisor(
                         helper.transaction(TransactionType.SendNobleIBC, ibcPayload) {
                             val error = helper.parseTransactionResponse(it)
                             if (error != null) {
-                                Logger.e { "transferNobleBalance error: $error" }
+                                Logger.e { "sweepNobleBalanceToDydx error: $error" }
                             }
                         }
                     }
                 } else {
-                    Logger.e { "transferNobleBalance error, code: $code" }
+                    Logger.e { "sweepNobleBalanceToDydx error, code: $code" }
                 }
             }
         }
     }
 
-    private fun transferNobleBalanceSkip(amount: BigDecimal) {
+    private fun sweepNobleBalanceToDydxSkip(amount: BigDecimal) {
         val url = helper.configs.skipV2MsgsDirect()
         val fromChain = helper.configs.nobleChainId()
         val fromToken = helper.configs.nobleDenom
@@ -691,7 +687,7 @@ internal open class AccountSupervisor(
                 "Content-Type" to "application/json",
             )
         helper.post(url, header, body.toJsonPrettyPrint()) { _, response, code, _ ->
-            if (response == null) {
+            if (response != null) {
                 val json = helper.parser.decodeJsonObject(response)
                 if (json != null) {
                     val skipRoutePayloadProcessor = SkipRoutePayloadProcessor(parser = helper.parser)
@@ -704,13 +700,13 @@ internal open class AccountSupervisor(
                         helper.transaction(TransactionType.SendNobleIBC, ibcPayload) {
                             val error = helper.parseTransactionResponse(it)
                             if (error != null) {
-                                Logger.e { "transferNobleBalanceSkip error: $error" }
+                                Logger.e { "sweepNobleBalanceToDydxSkip error: $error" }
                             }
                         }
                     }
                 }
             } else {
-                Logger.e { "transferNobleBalanceSkip error, code: $code" }
+                Logger.e { "sweepNobleBalanceToDydxSkip error, code: $code" }
             }
         }
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -1067,8 +1067,8 @@ internal class OnboardingSupervisor(
         val url = helper.configs.skipV2MsgsDirect()
         val fromAddress = accountAddress.toNobleAddress() ?: return
 
-        val fromChain = helper.configs.nobleChainId() ?: return
-        val fromToken = helper.configs.nobleDenom ?: return
+        val fromChain = helper.configs.nobleChainId()
+        val fromToken = helper.configs.nobleDenom
         val body: Map<String, Any> = mapOf(
             "amount_in" to fromAmountString,
             "source_asset_denom" to fromToken,
@@ -1080,7 +1080,7 @@ internal class OnboardingSupervisor(
                 toChain to toAddress,
             ),
             "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
-            "smart_relay" to true,
+//            "smart_relay" to true,
             "allow_unsafe" to true,
         )
         val oldState = stateMachine.state

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -1080,7 +1080,8 @@ internal class OnboardingSupervisor(
                 toChain to toAddress,
             ),
             "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
-            "smart_relay" to false,
+            "smart_relay" to true,
+            "allow_unsafe" to true,
         )
         val oldState = stateMachine.state
         val header = iMapOf(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -1080,7 +1080,7 @@ internal class OnboardingSupervisor(
                 toChain to toAddress,
             ),
             "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
-//            "smart_relay" to true,
+            "smart_relay" to true,
             "allow_unsafe" to true,
         )
         val oldState = stateMachine.state

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -1521,8 +1521,6 @@ internal class OnboardingSupervisor(
         val fromAmountString = helper.parser.asString(fromAmount)
 
         if (
-            nobleChain != null &&
-            nobleToken != null &&
             nobleAddress != null &&
             chainId != null &&
             nativeChainUSDCDenom != null &&

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.28'
+    spec.version = '1.8.29'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Turning on smart relay to prep for strangelove divorce. once we no longer depend on grant funds to subsidize user fees, we will want to use skip's smart relay feature for CCTP withdrawals.

this unfortunately will make some withdrawals quite a bit more pricy. we are going to add copy around that to help users understand the increased fees, which we believe is a more user friendly solution than the current solution of having skip throw errors if the fees are too high (hence, we are setting allow_unsafe to true)