### PR TITLE
Codegen for IndexerAPIOrderStatus

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.31"
+version = "1.8.32"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.29"
+version = "1.8.30"
 
 repositories {
     google()

--- a/json_add_attr.sh
+++ b/json_add_attr.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Check if the correct number of arguments is provided
+if [ "$#" -ne 4 ]; then
+    echo "Usage: $0 <json_file> <json_path> <attribute_name> <attribute_value>"
+    exit 1
+fi
+
+# Assign arguments to variables
+json_file=$1
+json_path=$2
+attribute_name=$3
+attribute_value=$4
+
+# Check if the JSON file exists
+if [ ! -f "$json_file" ]; then
+    echo "File $json_file does not exist."
+    exit 1
+fi
+
+# Add the new attribute to the specified location in the JSON file using jq
+jq --arg path "$json_path" --arg name "$attribute_name" --arg value "$attribute_value" '
+  getpath($path | split(".") | map(select(. != ""))) as $obj |
+  setpath(($path | split(".") | map(select(. != ""))) + [$name]; $value)
+' "$json_file" > tmp.$$.json && mv tmp.$$.json "$json_file"
+
+echo "Attribute $attribute_name with value $attribute_value has been added to $json_file at path $json_path."

--- a/src/commonMain/kotlin/indexer/codegen/IndexerAPIOrderStatus.kt
+++ b/src/commonMain/kotlin/indexer/codegen/IndexerAPIOrderStatus.kt
@@ -15,6 +15,14 @@ import kotlinx.serialization.Serializable
 
 /**
  *
+ * Values: OPEN,FILLED,CANCELED,BESTEFFORTCANCELED,UNTRIGGERED,BESTEFFORTOPENED
  */
 @Serializable
-class IndexerAPIOrderStatus()
+enum class IndexerAPIOrderStatus(val value: kotlin.String) {
+    OPEN("OPEN"), // :/
+    FILLED("FILLED"), // :/
+    CANCELED("CANCELED"), // :/
+    BESTEFFORTCANCELED("BEST_EFFORT_CANCELED"), // :/
+    UNTRIGGERED("UNTRIGGERED"), // :/
+    BESTEFFORTOPENED("BEST_EFFORT_OPENED"); // :/
+}

--- a/swagger_codegen.sh
+++ b/swagger_codegen.sh
@@ -16,7 +16,19 @@ trap cleanup EXIT
 
 curl -o $TMP_DIR/swagger.json https://raw.githubusercontent.com/dydxprotocol/v4-chain/main/indexer/services/comlink/public/swagger.json
 
+# Remove required attribute
 ${CURRENT_DIR}/json_remove_attr.sh -f $TMP_DIR/swagger.json -a required
+
+# Remove APIOrderStatus
+${CURRENT_DIR}/json_remove_attr.sh -f  $TMP_DIR/swagger.json -a APIOrderStatus
+
+# Codegen doesn't support allOf with enum, so we need to replace it with the enum directly
+
+# Add APIOrderStatus with content of OrderStatus and BestEffortOrderStatus
+${CURRENT_DIR}/json_add_attr.sh $TMP_DIR/swagger.json '.components.schemas' APIOrderStatus TO_REPLACE
+
+# Remove "TO_REPLACE" with the content of OrderStatus and BestEffortOrderStatus
+sed -i '' "s/\"TO_REPLACE\"/{ \"enum\": [\"OPEN\",\"FILLED\",\"CANCELED\",\"BEST_EFFORT_CANCELED\",\"UNTRIGGERED\",\"BEST_EFFORT_OPENED\"],\"type\": \"string\" }/g" $TMP_DIR/swagger.json 
 
 cd "$TMP_DIR"
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.29'
+    spec.version = '1.8.30'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.31'
+    spec.version = '1.8.32'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
The codegen tool doesn't support union type such as 

`export type APIOrderStatus = OrderStatus | BestEffortOpenedStatus`

So we will have to hack it to make it work for `APIOrderStatus` (the only union type so far).