### PR TITLE
fix: cancel order logging - fix skipping it because of unnecessary break

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.34"
+version = "1.8.35"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -376,7 +376,6 @@ internal class SubaccountSupervisor(
                         }
                         placeOrderRecord.lastOrderStatus = order.status
                     }
-                    break
                 }
 
                 val cancelOrderRecord = cancelOrderRecords.firstOrNull {
@@ -397,7 +396,6 @@ internal class SubaccountSupervisor(
                         )?.toIMap(),
                     )
                     cancelOrderRecords.remove(cancelOrderRecord)
-                    break
                 }
             }
         }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.34'
+    spec.version = '1.8.35'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
remove `break`s in `parseOrdersToMatchPlaceOrdersAndCancelOrders` which caused a local order placement that's canceled to skip cancel confirmation logging

tested locally
don't see why there needs to be a `break`