### PR TITLE
chore: expose setter for last edited input (size)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.35"
+version = "1.8.36"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
@@ -28,6 +28,7 @@ enum class TradeInputField(val rawValue: String) {
     size("size.size"),
     usdcSize("size.usdcSize"),
     leverage("size.leverage"),
+    lastInput("size.input"),
 
     limitPrice("price.limitPrice"),
     triggerPrice("price.triggerPrice"),
@@ -243,6 +244,15 @@ fun TradingStateMachine.trade(
                             "$data is not a valid string",
                         )
                     }
+                }
+
+                TradeInputField.lastInput.rawValue -> {
+                    trade.safeSet(typeText, parser.asString(data))
+                    changes = StateChanges(
+                        iListOf(Changes.input),
+                        null,
+                        subaccountNumbers,
+                    )
                 }
 
                 TradeInputField.size.rawValue,

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.35'
+    spec.version = '1.8.36'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
exposes ability for caller to manually update the last edited input (necessary for https://github.com/dydxprotocol/v4-web/pull/790) which requires manually implicitly updating the last edited input on toggle (since we are no longer showing both usdc + asset inputs in one view)