### PR TITLE
fix: smart relay w/ multi msg support [OTE-563]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.39"
+version = "1.8.40"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
@@ -264,6 +264,7 @@ data class TransferInputRequestPayload(
     val routeType: String?,
     val targetAddress: String?,
     val data: String?,
+    val allMessagesArray: String?,
     val value: String?,
     val gasLimit: String?,
     val gasPrice: String?,
@@ -288,6 +289,8 @@ data class TransferInputRequestPayload(
                 val routeType = parser.asString(data["routeType"])
                 val targetAddress = parser.asString(data["targetAddress"])
                 val dataValue = parser.asString(data["data"])
+//                parse input to make sure it's strings
+                val allMessagesArray = parser.asString(data["allMessagesArray"])
                 val value = parser.asString(data["value"])
                 val gasLimit = parser.asString(data["gasLimit"])
                 val gasPrice = parser.asString(data["gasPrice"])
@@ -304,6 +307,7 @@ data class TransferInputRequestPayload(
                     existing?.routeType != routeType ||
                     existing?.targetAddress != targetAddress ||
                     existing?.data != dataValue ||
+                    existing?.allMessagesArray != allMessagesArray ||
                     existing?.value != value ||
                     existing?.gasLimit != gasLimit ||
                     existing?.gasPrice != gasPrice ||
@@ -320,6 +324,7 @@ data class TransferInputRequestPayload(
                         routeType,
                         targetAddress,
                         dataValue,
+                        allMessagesArray,
                         value,
                         gasLimit,
                         gasPrice,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
@@ -264,7 +264,7 @@ data class TransferInputRequestPayload(
     val routeType: String?,
     val targetAddress: String?,
     val data: String?,
-    val allMessagesArray: String?,
+    val allMessages: String?,
     val value: String?,
     val gasLimit: String?,
     val gasPrice: String?,
@@ -289,8 +289,7 @@ data class TransferInputRequestPayload(
                 val routeType = parser.asString(data["routeType"])
                 val targetAddress = parser.asString(data["targetAddress"])
                 val dataValue = parser.asString(data["data"])
-//                parse input to make sure it's strings
-                val allMessagesArray = parser.asString(data["allMessagesArray"])
+                val allMessages = parser.asString(data["allMessages"])
                 val value = parser.asString(data["value"])
                 val gasLimit = parser.asString(data["gasLimit"])
                 val gasPrice = parser.asString(data["gasPrice"])
@@ -307,7 +306,7 @@ data class TransferInputRequestPayload(
                     existing?.routeType != routeType ||
                     existing?.targetAddress != targetAddress ||
                     existing?.data != dataValue ||
-                    existing?.allMessagesArray != allMessagesArray ||
+                    existing?.allMessages != allMessages ||
                     existing?.value != value ||
                     existing?.gasLimit != gasLimit ||
                     existing?.gasPrice != gasPrice ||
@@ -324,7 +323,7 @@ data class TransferInputRequestPayload(
                         routeType,
                         targetAddress,
                         dataValue,
-                        allMessagesArray,
+                        allMessages,
                         value,
                         gasLimit,
                         gasPrice,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRoutePayloadProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRoutePayloadProcessor.kt
@@ -96,7 +96,7 @@ internal class SkipRoutePayloadProcessor(parser: ParserProtocol) : BaseProcessor
             val allFormattedMessages = formatAllMessages(payload)
 //            save all messages in array
             modified.safeSet("data", jsonEncodePayload(formattedMessage))
-            modified.safeSet("allMessagesArray", jsonEncodePayload(allFormattedMessages))
+            modified.safeSet("allMessages", jsonEncodePayload(allFormattedMessages))
         }
         return modified
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
@@ -156,6 +156,7 @@ enum class TransactionType(val rawValue: String) {
     SendNobleIBC("sendNobleIBC"),
     WithdrawToNobleIBC("withdrawToNobleIBC"),
     CctpWithdraw("cctpWithdraw"),
+    CctpMultiMsgWithdraw("cctpMultiMsgWithdraw"),
     SignCompliancePayload("signCompliancePayload"),
     SetSelectedGasDenom("setSelectedGasDenom");
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/CctpWithdrawState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/CctpWithdrawState.kt
@@ -3,8 +3,11 @@ package exchange.dydx.abacus.state.manager
 import exchange.dydx.abacus.protocols.TransactionCallback
 
 data class CctpWithdrawState(
-    val payload: String?,
+//    JSON string of a single map representing a tx's single message
+    val singleMessagePayload: String?,
     val callback: TransactionCallback?,
+//    JSON string of a list of maps representing a tx's multiple messages
+    val multiMessagePayload: String?,
 )
 
 internal var pendingCctpWithdraw: CctpWithdrawState? = null

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -475,9 +475,13 @@ internal open class AccountSupervisor(
                     pendingCctpWithdraw?.let { walletState ->
                         processingCctpWithdraw = true
                         val callback = walletState.callback
+//                        if walletState has a singleMessagePayload, it's a single message tx
+//                        otherwise walletState represents a multi message tx (like smart relay) and we should use the relevant transaction
+                        val transactionType = if (walletState.multiMessagePayload == null) TransactionType.CctpWithdraw else TransactionType.CctpMultiMsgWithdraw
+                        val payload = if (walletState.multiMessagePayload == null) walletState.singleMessagePayload else walletState.multiMessagePayload
                         helper.transaction(
-                            TransactionType.CctpWithdraw,
-                            walletState.payload,
+                            transactionType,
+                            payload,
                         ) { hash ->
                             val error = helper.parseTransactionResponse(hash)
                             if (error != null) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -51,6 +51,7 @@ import exchange.dydx.abacus.utils.AnalyticsUtils
 import exchange.dydx.abacus.utils.CoroutineTimer
 import exchange.dydx.abacus.utils.IMap
 import exchange.dydx.abacus.utils.Logger
+import exchange.dydx.abacus.utils.MIN_USDC_AMOUNT_FOR_AUTO_SWEEP
 import exchange.dydx.abacus.utils.SLIPPAGE_PERCENT
 import exchange.dydx.abacus.utils.iMapOf
 import exchange.dydx.abacus.utils.mutable
@@ -467,7 +468,7 @@ internal open class AccountSupervisor(
             if (balance != null) {
                 val amount = helper.parser.asDecimal(balance["amount"])
 //                minimum usdc required for successful tx (gas fee)
-                if (amount != null && amount > 5000) {
+                if (amount != null && amount > MIN_USDC_AMOUNT_FOR_AUTO_SWEEP) {
                     if (processingCctpWithdraw) {
                         return@getOnChain
                     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -1593,7 +1593,7 @@ internal class OnboardingSupervisor(
                             } else {
                                 pendingCctpWithdraw = CctpWithdrawState(
                                     singleMessagePayload = null,
-                                    multiMessagePayload = state?.input?.transfer?.requestPayload?.allMessagesArray,
+                                    multiMessagePayload = state?.input?.transfer?.requestPayload?.allMessages,
                                     callback = callback,
                                 )
                             }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -1487,13 +1487,14 @@ internal class OnboardingSupervisor(
                             } else {
                                 pendingCctpWithdraw = CctpWithdrawState(
 //                                    we use skip state with squid route
-                                    state?.input?.transfer?.requestPayload?.data,
-                                    callback,
+                                    singleMessagePayload = state?.input?.transfer?.requestPayload?.data,
+                                    callback = callback,
+                                    multiMessagePayload = null,
                                 )
                             }
                         }
                     } else {
-                        Logger.e { "cctpToNoble error, code: $code" }
+                        Logger.e { "cctpToNobleSquid error, code: $code" }
                         val error = ParsingError(
                             ParsingErrorType.MissingContent,
                             "Missing squid response",
@@ -1501,7 +1502,7 @@ internal class OnboardingSupervisor(
                         helper.send(error, callback)
                     }
                 } else {
-                    Logger.e { "cctpToNoble error, code: $code" }
+                    Logger.e { "cctpToNobleSquid error, code: $code" }
                     val error = ParsingError(
                         ParsingErrorType.MissingContent,
                         "Missing squid response",
@@ -1518,7 +1519,6 @@ internal class OnboardingSupervisor(
         }
     }
 
-    @Suppress("ForbiddenComment")
     private fun cctpToNobleSkip(
         state: PerpetualState?,
         decimals: Int,
@@ -1592,8 +1592,9 @@ internal class OnboardingSupervisor(
                                 helper.send(error, callback)
                             } else {
                                 pendingCctpWithdraw = CctpWithdrawState(
-                                    state?.input?.transfer?.requestPayload?.data,
-                                    callback,
+                                    singleMessagePayload = null,
+                                    multiMessagePayload = state?.input?.transfer?.requestPayload?.allMessagesArray,
+                                    callback = callback,
                                 )
                             }
                         }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -1107,6 +1107,10 @@ internal class OnboardingSupervisor(
             "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
             "smart_relay" to true,
             "allow_unsafe" to true,
+            "bridges" to listOf(
+                "CCTP",
+                "IBC",
+            ),
         )
         val oldState = stateMachine.state
         val header = iMapOf(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -23,3 +23,6 @@ internal const val NATIVE_TOKEN_DEFAULT_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeee
 
 // Polling durations
 internal const val GEO_POLLING_DURATION_SECONDS = 10.0
+
+// Autosweep Constants
+internal const val MIN_USDC_AMOUNT_FOR_AUTO_SWEEP = 20000

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
@@ -60,25 +60,25 @@ class SkipRouteProcessorTests {
             "timeoutHeight" to mapOf<String, Any>(),
             "timeoutTimestamp" to 1718308711061386287,
         )
-        val expectedData = jsonEncoder.encode(
+        val expectedDataRaw =
             mapOf(
                 "msg" to expectedMsg,
                 "value" to expectedMsg,
                 "msgTypeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
                 "typeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
-            ),
-        )
+            )
         val expected = mapOf(
             "toAmountUSD" to 11.01,
             "toAmount" to 10.996029,
-            "slippage" to "1",
             "bridgeFee" to 0.0,
+            "slippage" to "1",
             "requestPayload" to mapOf(
                 "fromChainId" to "dydx-mainnet-1",
                 "fromAddress" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                 "toChainId" to "noble-1",
                 "toAddress" to "uusdc",
-                "data" to expectedData,
+                "data" to jsonEncoder.encode(expectedDataRaw),
+                "allMessagesArray" to jsonEncoder.encode(listOf(expectedDataRaw)),
             ),
         )
         assertEquals(expected, result)
@@ -132,46 +132,70 @@ class SkipRouteProcessorTests {
     }
 
     /**
-     * Tests a CCTP withdrawal initiated from the cctpToNobleSkip method
-     * This payload is used by the chain transaction method WithdrawToNobleIBC
-     * This processes a Dydx -> Noble CCTP transaction
+     * Tests a CCTP withdrawal initiated from the getNobleBalance method
+     * This payload is used by the chain transaction method cctpMultiMsgWithdraw
+     * This processes a Noble -> CCTP transaction
      */
     @Test
-    fun testReceivedCCTPDydxToNoble() {
-        val payload = skipRouteMock.payloadCCTPDydxToNoble
+    fun testReceivedCCTPNobleToUSDCEthWithdrawal() {
+        val payload = skipRouteMock.payloadNobleToUSDCEthWithdrawal
         val result = skipRouteProcessor.received(existing = mapOf(), payload = templateToMap(payload), decimals = 6.0)
         val jsonEncoder = JsonEncoder()
         val expectedMsg = mapOf(
-            "sourcePort" to "transfer",
-            "sourceChannel" to "channel-0",
-            "token" to mapOf(
-                "denom" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
-                "amount" to "10996029",
+            "from" to "noble1nhzuazjhyfu474er6v4ey8zn6wa5fy6gthndxf",
+            "amount" to "59995433",
+            "destinationDomain" to 0,
+            "mintRecipient" to "AAAAAAAAAAAAAAAAD3gzd3v8nvcti3aulU04Sd1x+Ck=",
+            "burnToken" to "uusdc",
+            "destinationCaller" to "AAAAAAAAAAAAAAAA/AWtdMb+LnBG4JHWrU9mDSoVl2I=",
+        )
+        val expectedMsg2 = mapOf(
+            "fromAddress" to "noble1nhzuazjhyfu474er6v4ey8zn6wa5fy6gthndxf",
+            "toAddress" to "noble1dyw0geqa2cy0ppdjcxfpzusjpwmq85r5a35hqe",
+            "amount" to listOf(
+                mapOf(
+                    "denom" to "uusdc",
+                    "amount" to "40000000",
+                ),
             ),
-            "sender" to "dydx1nhzuazjhyfu474er6v4ey8zn6wa5fy6g2dgp7s",
-            "receiver" to "noble1nhzuazjhyfu474er6v4ey8zn6wa5fy6gthndxf",
-            "timeoutHeight" to mapOf<String, Any>(),
-            "timeoutTimestamp" to 1718308711061386287,
         )
         val expectedData = jsonEncoder.encode(
             mapOf(
                 "msg" to expectedMsg,
                 "value" to expectedMsg,
-                "msgTypeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
-                "typeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
+                "msgTypeUrl" to "/circle.cctp.v1.MsgDepositForBurnWithCaller",
+                "typeUrl" to "/circle.cctp.v1.MsgDepositForBurnWithCaller",
+            ),
+        )
+
+        val expectedMessagesArray = jsonEncoder.encode(
+            listOf(
+                mapOf(
+                    "msg" to expectedMsg,
+                    "value" to expectedMsg,
+                    "msgTypeUrl" to "/circle.cctp.v1.MsgDepositForBurnWithCaller",
+                    "typeUrl" to "/circle.cctp.v1.MsgDepositForBurnWithCaller",
+                ),
+                mapOf(
+                    "msg" to expectedMsg2,
+                    "value" to expectedMsg2,
+                    "msgTypeUrl" to "/cosmos.bank.v1beta1.MsgSend",
+                    "typeUrl" to "/cosmos.bank.v1beta1.MsgSend",
+                ),
             ),
         )
         val expected = mapOf(
-            "toAmountUSD" to 11.01,
-            "toAmount" to 10.996029,
-            "bridgeFee" to 0.0,
+            "toAmountUSD" to 59.99,
+            "toAmount" to 59.995433,
+            "bridgeFee" to 40.0,
             "slippage" to "1",
             "requestPayload" to mapOf(
-                "fromChainId" to "dydx-mainnet-1",
-                "fromAddress" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
-                "toChainId" to "noble-1",
-                "toAddress" to "uusdc",
+                "fromChainId" to "noble-1",
+                "fromAddress" to "uusdc",
+                "toChainId" to "1",
+                "toAddress" to "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                 "data" to expectedData,
+                "allMessagesArray" to expectedMessagesArray,
             ),
         )
         assertEquals(expected, result)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
@@ -78,7 +78,7 @@ class SkipRouteProcessorTests {
                 "toChainId" to "noble-1",
                 "toAddress" to "uusdc",
                 "data" to jsonEncoder.encode(expectedDataRaw),
-                "allMessagesArray" to jsonEncoder.encode(listOf(expectedDataRaw)),
+                "allMessages" to jsonEncoder.encode(listOf(expectedDataRaw)),
             ),
         )
         assertEquals(expected, result)
@@ -125,7 +125,7 @@ class SkipRouteProcessorTests {
                 "toChainId" to "1",
                 "toAddress" to "ethereum-native",
                 "data" to jsonEncoder.encode(expectedDataRaw),
-                "allMessagesArray" to jsonEncoder.encode(listOf(expectedDataRaw)),
+                "allMessages" to jsonEncoder.encode(listOf(expectedDataRaw)),
             ),
         )
 
@@ -196,7 +196,7 @@ class SkipRouteProcessorTests {
                 "toChainId" to "1",
                 "toAddress" to "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                 "data" to expectedData,
-                "allMessagesArray" to expectedMessagesArray,
+                "allMessages" to expectedMessagesArray,
             ),
         )
         assertEquals(expected, result)
@@ -241,7 +241,7 @@ class SkipRouteProcessorTests {
                 "toChainId" to "dydx-mainnet-1",
                 "toAddress" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                 "data" to jsonEncoder.encode(expectedDataRaw),
-                "allMessagesArray" to jsonEncoder.encode(listOf(expectedDataRaw)),
+                "allMessages" to jsonEncoder.encode(listOf(expectedDataRaw)),
             ),
         )
         assertEquals(expected, result)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
@@ -105,14 +105,14 @@ class SkipRouteProcessorTests {
             "timeoutTimestamp" to 1718399715601228463,
             "memo" to "{\"forward\":{\"channel\":\"channel-1\",\"next\":{\"wasm\":{\"contract\":\"osmo1vkdakqqg5htq5c3wy2kj2geq536q665xdexrtjuwqckpads2c2nsvhhcyv\",\"msg\":{\"swap_and_action\":{\"affiliates\":[],\"min_asset\":{\"native\":{\"amount\":\"37656643372307734\",\"denom\":\"ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5\"}},\"post_swap_action\":{\"ibc_transfer\":{\"ibc_info\":{\"memo\":\"{\\\"destination_chain\\\":\\\"Ethereum\\\",\\\"destination_address\\\":\\\"0xD397883c12b71ea39e0d9f6755030205f31A1c96\\\",\\\"payload\\\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,15,120,51,119,123,252,158,247,45,139,118,174,149,77,56,73,221,113,248,41],\\\"type\\\":2,\\\"fee\\\":{\\\"amount\\\":\\\"7692677672185391\\\",\\\"recipient\\\":\\\"axelar1aythygn6z5thymj6tmzfwekzh05ewg3l7d6y89\\\"}}\",\"receiver\":\"axelar1dv4u5k73pzqrxlzujxg3qp8kvc3pje7jtdvu72npnt5zhq05ejcsn5qme5\",\"recover_address\":\"osmo1nhzuazjhyfu474er6v4ey8zn6wa5fy6gt044g4\",\"source_channel\":\"channel-208\"}}},\"timeout_timestamp\":1718399715601274600,\"user_swap\":{\"swap_exact_asset_in\":{\"operations\":[{\"denom_in\":\"ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4\",\"denom_out\":\"factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc\",\"pool\":\"1437\"},{\"denom_in\":\"factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc\",\"denom_out\":\"ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5\",\"pool\":\"1441\"}],\"swap_venue_name\":\"osmosis-poolmanager\"}}}}}},\"port\":\"transfer\",\"receiver\":\"osmo1vkdakqqg5htq5c3wy2kj2geq536q665xdexrtjuwqckpads2c2nsvhhcyv\",\"retries\":2,\"timeout\":1718399715601230847}}",
         )
-        val expectedData = jsonEncoder.encode(
+        val expectedDataRaw =
             mapOf(
                 "msg" to expectedMsg,
                 "value" to expectedMsg,
                 "msgTypeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
                 "typeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
-            ),
-        )
+            )
+
         val expected = mapOf(
             "toAmountUSD" to 103.17,
             "toAmount" to 0.03034433583519616,
@@ -124,7 +124,8 @@ class SkipRouteProcessorTests {
                 "fromAddress" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                 "toChainId" to "1",
                 "toAddress" to "ethereum-native",
-                "data" to expectedData,
+                "data" to jsonEncoder.encode(expectedDataRaw),
+                "allMessagesArray" to jsonEncoder.encode(listOf(expectedDataRaw)),
             ),
         )
 
@@ -223,13 +224,11 @@ class SkipRouteProcessorTests {
             "timeoutHeight" to mapOf<String, Any>(),
             "timeoutTimestamp" to 1718318348813666048,
         )
-        val expectedData = jsonEncoder.encode(
-            mapOf(
-                "msg" to expectedMsg,
-                "value" to expectedMsg,
-                "msgTypeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
-                "typeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
-            ),
+        val expectedDataRaw = mapOf(
+            "msg" to expectedMsg,
+            "value" to expectedMsg,
+            "msgTypeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
+            "typeUrl" to "/ibc.applications.transfer.v1.MsgTransfer",
         )
         val expected = mapOf(
             "toAmountUSD" to 0.01,
@@ -241,7 +240,8 @@ class SkipRouteProcessorTests {
                 "fromAddress" to "uusdc",
                 "toChainId" to "dydx-mainnet-1",
                 "toAddress" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
-                "data" to expectedData,
+                "data" to jsonEncoder.encode(expectedDataRaw),
+                "allMessagesArray" to jsonEncoder.encode(listOf(expectedDataRaw)),
             ),
         )
         assertEquals(expected, result)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipRouteMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipRouteMock.kt
@@ -515,6 +515,106 @@ internal class SkipRouteMock {
         }
     """.trimIndent()
 
+    internal val payloadNobleToUSDCEthWithdrawal = """
+        {
+            "msgs": [],
+            "txs": [
+                {
+                    "cosmos_tx": {
+                        "chain_id": "noble-1",
+                        "path": [
+                            "noble-1",
+                            "1"
+                        ],
+                        "msgs": [
+                            {
+                                "msg": "{\"from\":\"noble1nhzuazjhyfu474er6v4ey8zn6wa5fy6gthndxf\",\"amount\":\"59995433\",\"destination_domain\":0,\"mint_recipient\":\"AAAAAAAAAAAAAAAAD3gzd3v8nvcti3aulU04Sd1x+Ck=\",\"burn_token\":\"uusdc\",\"destination_caller\":\"AAAAAAAAAAAAAAAA/AWtdMb+LnBG4JHWrU9mDSoVl2I=\"}",
+                                "msg_type_url": "/circle.cctp.v1.MsgDepositForBurnWithCaller"
+                            },
+                            {
+                                "msg": "{\"from_address\":\"noble1nhzuazjhyfu474er6v4ey8zn6wa5fy6gthndxf\",\"to_address\":\"noble1dyw0geqa2cy0ppdjcxfpzusjpwmq85r5a35hqe\",\"amount\":[{\"denom\":\"uusdc\",\"amount\":\"40000000\"}]}",
+                                "msg_type_url": "/cosmos.bank.v1beta1.MsgSend"
+                            }
+                        ],
+                        "signer_address": "noble1nhzuazjhyfu474er6v4ey8zn6wa5fy6gthndxf"
+                    },
+                    "operations_indices": [
+                        0
+                    ]
+                }
+            ],
+            "route": {
+                "source_asset_denom": "uusdc",
+                "source_asset_chain_id": "noble-1",
+                "dest_asset_denom": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                "dest_asset_chain_id": "1",
+                "amount_in": "99995433",
+                "amount_out": "59995433",
+                "operations": [
+                    {
+                        "cctp_transfer": {
+                            "from_chain_id": "noble-1",
+                            "to_chain_id": "1",
+                            "burn_token": "uusdc",
+                            "denom_in": "uusdc",
+                            "denom_out": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                            "bridge_id": "CCTP",
+                            "smart_relay": true
+                        },
+                        "tx_index": 0,
+                        "amount_in": "99995433",
+                        "amount_out": "59995433"
+                    }
+                ],
+                "chain_ids": [
+                    "noble-1",
+                    "1"
+                ],
+                "does_swap": false,
+                "estimated_amount_out": "59995433",
+                "swap_venues": [],
+                "txs_required": 1,
+                "usd_amount_in": "99.99",
+                "usd_amount_out": "59.99",
+                "warning": {
+                    "type": "BAD_PRICE_WARNING",
+                    "message": "Difference in USD value of route input and output is large. Input USD value: 99.99 Output USD value: 59.99"
+                },
+                "estimated_fees": [
+                    {
+                        "fee_type": "SMART_RELAY",
+                        "bridge_id": "CCTP",
+                        "amount": "40000000",
+                        "usd_amount": "40.00",
+                        "origin_asset": {
+                            "denom": "uusdc",
+                            "chain_id": "noble-1",
+                            "origin_denom": "uusdc",
+                            "origin_chain_id": "noble-1",
+                            "trace": "",
+                            "is_cw20": false,
+                            "is_evm": false,
+                            "is_svm": false,
+                            "symbol": "USDC",
+                            "name": "USDC",
+                            "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/USDCoin.png",
+                            "decimals": 6,
+                            "description": "USD Coin",
+                            "coingecko_id": "usd-coin",
+                            "recommended_symbol": "USDC"
+                        },
+                        "chain_id": "noble-1",
+                        "tx_index": 0
+                    }
+                ],
+                "required_chain_addresses": [
+                    "noble-1",
+                    "1"
+                ]
+            }
+        }
+    """.trimIndent()
+
     internal val payloadError = """
     {
   "code": 3,

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.40'
+    spec.version                  = '1.8.40'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
                 
                 
                 
-    if false
+    if !Dir.exist?('build/cocoapods/framework/Abacus.framework') || Dir.empty?('build/cocoapods/framework/Abacus.framework')
         raise "
 
         Kotlin framework 'Abacus' doesn't exist yet, so a proper Xcode project can't be generated.

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.39'
+    spec.version = '1.8.40'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
fixes smart relay by adding multi message support.

only cctp smart relays are multi msg objects right now. we support this by:
- adding `allMessages` to abacus' state
- format all messages, not just the first one, in the `SkipRoutePayloadProcessor` and set it to the `allMessages` state property
- refactor `payload` to `singleMessagePayload` in the `cctpWithdrawState`
- add `multiMessagePayload` to `cctpWithdrawState`
- based on whether a `cctpWithdrawState` has `multi` or `single` message payload, use `CctpMultiMsgWithdraw` or `CctpWithdraw`

this PR also:
- bumps minimum uusdc needed in noble wallet to 20000 (~.02USDC) due to increases fees now that foundation is no longer subsidizing CCTP relays
- restricts cctp withdrawals to cctp and ibc bridges. this prevents the routing algorithm from choosing axelar, which would break the withdrawal flow since cctp assets go through a different codepath
