### PR TITLE
transaction error handling: parse query result error for subaccount update

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
@@ -44,7 +44,6 @@ class V4TransactionErrors {
     }
 }
 
-
 // Copied from protocol subaccounts update (https://github.com/dydxprotocol/v4-chain/blob/b2dfda2a4b0ea587691c41ba436b46d0d9987a25/protocol/x/subaccounts/types/update.go#L58)
 enum class SubaccountUpdateFailedResult(val rawValue: String) {
     NewlyUndercollateralized("NewlyUndercollateralized"),

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
@@ -5,6 +5,9 @@ import exchange.dydx.abacus.responses.ParsingErrorType
 
 class V4TransactionErrors {
     companion object {
+        private const val QUERY_RESULT_ERROR_PREFIX = "Query failed"
+        private val FAILED_SUBACCOUNT_UPDATE_RESULT_PATTERN = Regex("""Subaccount with id \{[^}]+\} failed with UpdateResult:\s*([A-Za-z]+):""")
+
         fun error(code: Int?, message: String?, codespace: String? = null): ParsingError? {
             return if (code != null) {
                 if (code != 0 && codespace != null) {
@@ -16,7 +19,7 @@ class V4TransactionErrors {
                 } else {
                     null
                 }
-            } else if (message?.startsWith("Query failed") == true) {
+            } else if (message?.startsWith(QUERY_RESULT_ERROR_PREFIX) == true) {
                 parseQueryResultErrorFromMessage(message)
             } else {
                 ParsingError(ParsingErrorType.BackendError, message ?: "Unknown error", null)
@@ -30,14 +33,13 @@ class V4TransactionErrors {
         }
 
         private fun parseSubaccountUpdateError(message: String): ParsingError? {
-            val failedSubaccountUpdateResultPattern = Regex("""Subaccount with id \{[^}]+\} failed with UpdateResult:\s*([A-Za-z]+):""")
-            val matchResult = failedSubaccountUpdateResultPattern.find(message)
+            val matchResult = FAILED_SUBACCOUNT_UPDATE_RESULT_PATTERN.find(message)
             return matchResult?.groups?.get(1)?.value?.let {
                 val matchedUpdateResult = SubaccountUpdateFailedResult.invoke(it)
                 ParsingError(
                     ParsingErrorType.BackendError,
-                    "Subaccount update error: $matchedUpdateResult",
-                    "ERRORS.QUERY_ERROR_SUBACCOUNTS_${matchedUpdateResult.uppercase()}",
+                    "Subaccount update error: $it",
+                    if (matchedUpdateResult != null) "ERRORS.QUERY_ERROR_SUBACCOUNTS_${matchedUpdateResult.toString().uppercase()}" else null,
                 )
             }
         }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
@@ -37,7 +37,7 @@ class V4TransactionErrors {
                 ParsingError(
                     ParsingErrorType.BackendError,
                     "Subaccount update error: $matchedUpdateResult",
-                    "ERRORS.QUERY_ERROR_SUBACCOUNTS_$matchedUpdateResult",
+                    "ERRORS.QUERY_ERROR_SUBACCOUNTS_${matchedUpdateResult.uppercase()}",
                 )
             }
         }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
@@ -16,9 +16,46 @@ class V4TransactionErrors {
                 } else {
                     null
                 }
+            } else if (message?.startsWith("Query failed") == true) {
+                parseQueryResultErrorFromMessage(message)
             } else {
                 ParsingError(ParsingErrorType.BackendError, message ?: "Unknown error", null)
             }
+        }
+
+        private fun parseQueryResultErrorFromMessage(message: String): ParsingError {
+            // Workaround: Regex match different query results until protocol can return codespace/code
+            parseSubaccountUpdateError(message)?.let { return it }
+            return ParsingError(ParsingErrorType.BackendError, "Unknown query result error", null)
+        }
+
+        private fun parseSubaccountUpdateError(message: String): ParsingError? {
+            val failedSubaccountUpdateResultPattern = Regex("""Subaccount with id \{[^}]+\} failed with UpdateResult:\s*([A-Za-z]+):""")
+            val matchResult = failedSubaccountUpdateResultPattern.find(message)
+            return matchResult?.groups?.get(1)?.value?.let {
+                val matchedUpdateResult = SubaccountUpdateFailedResult.invoke(it)
+                ParsingError(
+                    ParsingErrorType.BackendError,
+                    "Subaccount update error: $matchedUpdateResult",
+                    "ERRORS.QUERY_ERROR_SUBACCOUNTS_$matchedUpdateResult",
+                )
+            }
+        }
+    }
+}
+
+
+// Copied from protocol subaccounts update (https://github.com/dydxprotocol/v4-chain/blob/b2dfda2a4b0ea587691c41ba436b46d0d9987a25/protocol/x/subaccounts/types/update.go#L58)
+enum class SubaccountUpdateFailedResult(val rawValue: String) {
+    NewlyUndercollateralized("NewlyUndercollateralized"),
+    StillUndercollateralized("StillUndercollateralized"),
+    WithdrawalsAndTransfersBlocked("WithdrawalsAndTransfersBlocked"),
+    UpdateCausedError("UpdateCausedError"),
+    ViolatesIsolatedSubaccountConstraints("ViolatesIsolatedSubaccountConstraints");
+
+    companion object {
+        fun invoke(rawValue: String): SubaccountUpdateFailedResult? {
+            return SubaccountUpdateFailedResult.values().find { it.rawValue == rawValue }
         }
     }
 }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.53'
+    spec.version                  = '1.8.53'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
                 
                 
                 
-    if false
+    if !Dir.exist?('build/cocoapods/framework/Abacus.framework') || Dir.empty?('build/cocoapods/framework/Abacus.framework')
         raise "
 
         Kotlin framework 'Abacus' doesn't exist yet, so a proper Xcode project can't be generated.


### PR DESCRIPTION
while most tx errors are broadcast errors with codespace + code, sometimes there can be errors from simulation/query that are not properly formatted / missing those info. to get around it, i'm adding string matching to parse the error message to see if it starts with "Query failed", and then do additional string matching

in particular, add support for better subaccount update failed result handling, so we can show an error such as 
![image](https://github.com/user-attachments/assets/b5a87e23-18db-46c2-9e96-da577e75464c)
instead of 
![image](https://github.com/user-attachments/assets/d217b5b9-2365-4984-a2b0-6b09156e0274) during isolated trade/ margin update. this is usually caught by FE validation but just in case it isn't .3.

- this also needs slight updating on FE/web to make sure we're sending in the Error's error message to abacus (https://github.com/dydxprotocol/v4-web/pull/823)