### PR TITLE
chore: update conditional order slippage, promote solana to major market

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Abacus is published to an npm library (https://www.npmjs.com/package/@dydxprotoc
 
 Shared code should have unit tests written in Kotlin residing in the src/CommonTest directory. Run the tests with the following command
 
-> ./gradlew test
+> ./gradlew jvmtest
 
 # Integration Tests
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.43"
+version = "1.8.44"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -3,6 +3,7 @@
 package exchange.dydx.abacus.calculator
 
 import abs
+import exchange.dydx.abacus.calculator.SlippageConstants.MAJOR_MARKETS
 import exchange.dydx.abacus.calculator.SlippageConstants.MARKET_ORDER_MAX_SLIPPAGE
 import exchange.dydx.abacus.calculator.SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER
 import exchange.dydx.abacus.calculator.SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
@@ -35,11 +36,12 @@ enum class TradeCalculation(val rawValue: String) {
 }
 
 internal object SlippageConstants {
+    val MAJOR_MARKETS = listOf("ETH-USD", "BTC-USD", "SOL-USD")
     const val MARKET_ORDER_MAX_SLIPPAGE = 0.05
-    const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
-    const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.1
-    const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER = 0.2
-    const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER = 0.2
+    const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.05
+    const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.05
+    const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER = 0.1
+    const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER = 0.1
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -1568,10 +1570,7 @@ internal class TradeInputCalculator(
                             null
                         }
                     val adjustedslippagePercentage = if (slippagePercentage != null) {
-                        val majorMarket = when (parser.asString(trade["marketId"])) {
-                            "BTC-USD", "ETH-USD" -> true
-                            else -> false
-                        }
+                        val majorMarket = MAJOR_MARKETS.contains(parser.asString(trade["marketId"]))
                         if (majorMarket) {
                             if (type == "STOP_MARKET") {
                                 slippagePercentage + STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
@@ -86,7 +86,7 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
         size: Double?,
     ): MutableMap<String, Any> {
         val modified = triggerPrices.mutable()
-    val entryPrice = parser.asDouble(parser.value(position, "entryPrice.current"))
+        val entryPrice = parser.asDouble(parser.value(position, "entryPrice.current"))
         val inputType = parser.asString(parser.value(modified, "input"))
         val positionSide = parser.asString(parser.value(position, "resources.indicator.current"))
         val positionSize = parser.asDouble(parser.value(position, "size.current"))?.abs() ?: return modified

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TriggerOrdersInputCalculator.kt
@@ -1,6 +1,7 @@
 package exchange.dydx.abacus.calculator
 
 import abs
+import exchange.dydx.abacus.calculator.SlippageConstants.MAJOR_MARKETS
 import exchange.dydx.abacus.calculator.SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER
 import exchange.dydx.abacus.calculator.SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
 import exchange.dydx.abacus.calculator.SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
@@ -85,7 +86,7 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
         size: Double?,
     ): MutableMap<String, Any> {
         val modified = triggerPrices.mutable()
-        val entryPrice = parser.asDouble(parser.value(position, "entryPrice.current"))
+    val entryPrice = parser.asDouble(parser.value(position, "entryPrice.current"))
         val inputType = parser.asString(parser.value(modified, "input"))
         val positionSide = parser.asString(parser.value(position, "resources.indicator.current"))
         val positionSize = parser.asDouble(parser.value(position, "size.current"))?.abs() ?: return modified
@@ -283,10 +284,7 @@ internal class TriggerOrdersInputCalculator(val parser: ParserProtocol) {
             OrderType.TakeProfitMarket, OrderType.StopMarket -> {
                 val triggerPrice =
                     parser.asDouble(parser.value(triggerOrder, "price.triggerPrice"))
-                val majorMarket = when (parser.asString(triggerOrder["marketId"])) {
-                    "BTC-USD", "ETH-USD" -> true
-                    else -> false
-                }
+                val majorMarket = MAJOR_MARKETS.contains(parser.asString(triggerOrder["marketId"]))
                 val slippagePercentage = if (majorMarket) {
                     if (type == OrderType.StopMarket) {
                         STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/TriggerOrdersInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/TriggerOrdersInputTests.kt
@@ -202,7 +202,7 @@ class TriggerOrderInputTests : V4BaseTests() {
                                 "input": "stopLossOrder.price.triggerPrice"
                             },
                             "summary": {
-                                "price": "800.0"
+                                "price": "900.0"
                             }
                         }
                     }
@@ -334,7 +334,7 @@ class TriggerOrderInputTests : V4BaseTests() {
                                 "input": "takeProfitOrder.price.triggerPrice"
                             },
                             "summary": {
-                                "price": "800.0"
+                                "price": "900.0"
                             }
                         }
                     }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
@@ -805,7 +805,7 @@ open class V4TradeInputTests : V4BaseTests() {
                 "input": {
                     "trade": {
                         "summary": {
-                            "payloadPrice": 900.0
+                            "payloadPrice": 1000.0
                         }
                     }
                 }
@@ -839,7 +839,7 @@ open class V4TradeInputTests : V4BaseTests() {
                 "input": {
                     "trade": {
                         "summary": {
-                            "payloadPrice": 1800.0
+                            "payloadPrice": 1900.0
                         }
                     }
                 }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.43'
+    spec.version                  = '1.8.44'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
per request of product: 

```
BTC/ETH/SOL from 10% -> 5%
All others from 20% -> 10%

*note SOL is now being included in the BTC/ETH category
````