### PR TITLE
chore: add swap venues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.45"
+version = "1.8.46"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -78,7 +78,6 @@ private val NEUTRON_SWAP_VENUE = mapOf(
     "chain_id" to "neutron-1",
 )
 
-
 private const val IBC_BRIDGE_ID = "IBC"
 private const val CCTP_BRIDGE_ID = "CCTP"
 private const val AXELAR_BRIDGE_ID = "AXELAR"

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -37,15 +37,10 @@ import exchange.dydx.abacus.state.model.squidRouteV2
 import exchange.dydx.abacus.state.model.squidStatus
 import exchange.dydx.abacus.state.model.squidV2SdkInfo
 import exchange.dydx.abacus.state.model.transfer
-import exchange.dydx.abacus.utils.AXELAR_BRIDGE_ID
 import exchange.dydx.abacus.utils.AnalyticsUtils
-import exchange.dydx.abacus.utils.CCTP_BRIDGE_ID
-import exchange.dydx.abacus.utils.IBC_BRIDGE_ID
 import exchange.dydx.abacus.utils.IMap
 import exchange.dydx.abacus.utils.Logger
-import exchange.dydx.abacus.utils.NEUTRON_SWAP_VENUE
 import exchange.dydx.abacus.utils.Numeric
-import exchange.dydx.abacus.utils.OSMOSIS_SWAP_VENUE
 import exchange.dydx.abacus.utils.SLIPPAGE_PERCENT
 import exchange.dydx.abacus.utils.filterNotNull
 import exchange.dydx.abacus.utils.iMapOf

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -40,7 +40,9 @@ import exchange.dydx.abacus.state.model.transfer
 import exchange.dydx.abacus.utils.AnalyticsUtils
 import exchange.dydx.abacus.utils.IMap
 import exchange.dydx.abacus.utils.Logger
+import exchange.dydx.abacus.utils.NEUTRON_SWAP_VENUE
 import exchange.dydx.abacus.utils.Numeric
+import exchange.dydx.abacus.utils.OSMOSIS_SWAP_VENUE
 import exchange.dydx.abacus.utils.SLIPPAGE_PERCENT
 import exchange.dydx.abacus.utils.filterNotNull
 import exchange.dydx.abacus.utils.iMapOf
@@ -283,6 +285,10 @@ internal class OnboardingSupervisor(
                     nobleChainId to accountAddress.toNobleAddress(),
                     neutronChainId to accountAddress.toNeutronAddress(),
                     chainId to accountAddress,
+                ),
+                "swap_venues" to listOf(
+                    OSMOSIS_SWAP_VENUE,
+                    NEUTRON_SWAP_VENUE,
                 ),
                 "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
             )
@@ -1052,6 +1058,10 @@ internal class OnboardingSupervisor(
                 nobleChainId to accountAddress.toNobleAddress(),
                 neutronChainId to accountAddress.toNeutronAddress(),
                 toChain to toAddress,
+            ),
+            "swap_venues" to listOf(
+                OSMOSIS_SWAP_VENUE,
+                NEUTRON_SWAP_VENUE,
             ),
             "allow_multi_tx" to false,
             "allow_unsafe" to true,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -37,7 +37,10 @@ import exchange.dydx.abacus.state.model.squidRouteV2
 import exchange.dydx.abacus.state.model.squidStatus
 import exchange.dydx.abacus.state.model.squidV2SdkInfo
 import exchange.dydx.abacus.state.model.transfer
+import exchange.dydx.abacus.utils.AXELAR_BRIDGE_ID
 import exchange.dydx.abacus.utils.AnalyticsUtils
+import exchange.dydx.abacus.utils.CCTP_BRIDGE_ID
+import exchange.dydx.abacus.utils.IBC_BRIDGE_ID
 import exchange.dydx.abacus.utils.IMap
 import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.NEUTRON_SWAP_VENUE
@@ -64,6 +67,21 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
+
+private val OSMOSIS_SWAP_VENUE = mapOf(
+    "name" to "osmosis-poolmanager",
+    "chain_id" to "osmosis-1",
+)
+
+private val NEUTRON_SWAP_VENUE = mapOf(
+    "name" to "neutron-astroport",
+    "chain_id" to "neutron-1",
+)
+
+
+private const val IBC_BRIDGE_ID = "IBC"
+private const val CCTP_BRIDGE_ID = "CCTP"
+private const val AXELAR_BRIDGE_ID = "AXELAR"
 
 internal class OnboardingSupervisor(
     stateMachine: TradingStateMachine,
@@ -290,6 +308,10 @@ internal class OnboardingSupervisor(
                     OSMOSIS_SWAP_VENUE,
                     NEUTRON_SWAP_VENUE,
                 ),
+                "bridges" to listOf(
+                    IBC_BRIDGE_ID,
+                    AXELAR_BRIDGE_ID,
+                ),
                 "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
             )
 
@@ -347,8 +369,8 @@ internal class OnboardingSupervisor(
             ),
             "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
             "bridges" to listOf(
-                "CCTP",
-                "IBC",
+                CCTP_BRIDGE_ID,
+                IBC_BRIDGE_ID,
             ),
         )
         val oldState = stateMachine.state
@@ -1063,6 +1085,10 @@ internal class OnboardingSupervisor(
                 OSMOSIS_SWAP_VENUE,
                 NEUTRON_SWAP_VENUE,
             ),
+            "bridges" to listOf(
+                IBC_BRIDGE_ID,
+                AXELAR_BRIDGE_ID,
+            ),
             "allow_multi_tx" to false,
             "allow_unsafe" to true,
             "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
@@ -1118,8 +1144,8 @@ internal class OnboardingSupervisor(
             "smart_relay" to true,
             "allow_unsafe" to true,
             "bridges" to listOf(
-                "CCTP",
-                "IBC",
+                CCTP_BRIDGE_ID,
+                IBC_BRIDGE_ID,
             ),
         )
         val oldState = stateMachine.state

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -26,3 +26,13 @@ internal const val GEO_POLLING_DURATION_SECONDS = 10.0
 
 // Autosweep Constants
 internal const val MIN_USDC_AMOUNT_FOR_AUTO_SWEEP = 20000
+
+internal val OSMOSIS_SWAP_VENUE = mapOf(
+    "name" to "osmosis-poolmanager",
+    "chain_id" to "osmosis-1",
+)
+
+internal val NEUTRON_SWAP_VENUE = mapOf(
+    "name" to "neutron-astroport",
+    "chain_id" to "neutron-1",
+)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -26,13 +26,3 @@ internal const val GEO_POLLING_DURATION_SECONDS = 10.0
 
 // Autosweep Constants
 internal const val MIN_USDC_AMOUNT_FOR_AUTO_SWEEP = 20000
-
-internal val OSMOSIS_SWAP_VENUE = mapOf(
-    "name" to "osmosis-poolmanager",
-    "chain_id" to "osmosis-1",
-)
-
-internal val NEUTRON_SWAP_VENUE = mapOf(
-    "name" to "neutron-astroport",
-    "chain_id" to "neutron-1",
-)

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
                 
                 
                 
-    if false
+    if !Dir.exist?('build/cocoapods/framework/Abacus.framework') || Dir.empty?('build/cocoapods/framework/Abacus.framework')
         raise "
 
         Kotlin framework 'Abacus' doesn't exist yet, so a proper Xcode project can't be generated.

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.45'
+    spec.version = '1.8.46'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
                 
                 
                 
-    if !Dir.exist?('build/cocoapods/framework/Abacus.framework') || Dir.empty?('build/cocoapods/framework/Abacus.framework')
+    if false
         raise "
 
         Kotlin framework 'Abacus' doesn't exist yet, so a proper Xcode project can't be generated.


### PR DESCRIPTION
context: https://dydx-team.slack.com/archives/C0738MMRX9C/p1721247027232859

Edge case found for small axelar transfers - non osmosis/neutron swap venues can become preferred (in this case, terra). to remediate this (since we don't have a fallback address for terra) we're restricting swap venues for non-cctp withdrawals and deposits.