### PR TITLE
fix: only autosweep subaccount funds back to 0 if it's a child subaccount of parent 0 + don't pick it as isolated trade subaccount candidate

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.52"
+version = "1.8.53"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/MarginCalculator.kt
@@ -156,7 +156,10 @@ internal object MarginCalculator {
         val marketId = parser.asString(tradeInput?.get("marketId")) ?: return null
         val subaccounts = parser.asNativeMap(account?.get("subaccounts")) ?: return null
 
-        val utilizedSubaccountsMarketIdMap = subaccounts.mapValues {
+        // FE only supports subaccounts that are related to the "main" account (i.e. subaccount 0) and its children
+        // If there are other utilized subaccounts (e.g. subaccount 1 or 129), ignore them as candidates
+        val relevantSubaccounts = subaccounts.filterKeys { key -> parser.asInt(key)?.let { it % NUM_PARENT_SUBACCOUNTS == 0 } ?: false }
+        val utilizedSubaccountsMarketIdMap = relevantSubaccounts.mapValues {
             val openPositions = parser.asNativeMap(parser.value(it.value, "openPositions"))
             val openOrders = parser.asNativeMap(parser.value(it.value, "orders"))?.filter {
                 val order = parser.asMap(it.value)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -1571,8 +1571,9 @@ internal class SubaccountSupervisor(
         val subaccounts = stateMachine.state?.account?.subaccounts ?: return
 
         val subaccountQuoteBalanceMap = subaccounts.mapValues { subaccount ->
-            // If the subaccount is the parentSubaccount, skip
-            if (subaccount.value.subaccountNumber == subaccountNumber) {
+            val currentSubaccountNumber = subaccount.value.subaccountNumber
+            // If the current subaccount is the parent, or if it's is not a child of parent subaccount 0 (reserved for FE), skip
+            if (currentSubaccountNumber == subaccountNumber || currentSubaccountNumber < NUM_PARENT_SUBACCOUNTS || currentSubaccountNumber % NUM_PARENT_SUBACCOUNTS != 0) {
                 return@mapValues 0.0
             }
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.52'
+    spec.version = '1.8.53'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
we don't want to autosweep subaccount funds back to 0 if it's not a child subaccount of parent 0
i.e. we won't sweep if:
1. subaccount is a parent subaccount (i.e. < 128; since 2 % 128 = 2)
2. subaccount is a child of other parent subaccounts. (e.g. subaccount 129) assuming we can just leave it alone since FE only cares about subaccount 0 as parent right now, and subaccount 129 will only be added via API and API users can just deal with the sweep back logic themselves

we also don't want to pick empty subaccounts that are a parent subaccount (or not related to subaccount 0) as isolated trade candidates