### PR TITLE
slippage: update slippage logic + add back index slippage validations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.53"
+version = "1.8.54"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -5,6 +5,7 @@ package exchange.dydx.abacus.calculator
 import abs
 import exchange.dydx.abacus.calculator.SlippageConstants.MAJOR_MARKETS
 import exchange.dydx.abacus.calculator.SlippageConstants.MARKET_ORDER_MAX_SLIPPAGE
+import exchange.dydx.abacus.calculator.SlippageConstants.SLIPPAGE_STEP_SIZE
 import exchange.dydx.abacus.calculator.SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER
 import exchange.dydx.abacus.calculator.SlippageConstants.STOP_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET
 import exchange.dydx.abacus.calculator.SlippageConstants.TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER
@@ -42,6 +43,7 @@ internal object SlippageConstants {
     const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER_MAJOR_MARKET = 0.05
     const val STOP_MARKET_ORDER_SLIPPAGE_BUFFER = 0.1
     const val TAKE_PROFIT_MARKET_ORDER_SLIPPAGE_BUFFER = 0.1
+    const val SLIPPAGE_STEP_SIZE = 0.00001
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -1455,18 +1457,9 @@ internal class TradeInputCalculator(
             "MARKET" -> {
                 parser.asNativeMap(trade["marketOrder"])?.let { marketOrder ->
                     val feeRate = parser.asDouble(parser.value(user, "takerFeeRate"))
-                    val bestPrice = marketOrderBestPrice(marketOrder)
+                    val midMarketPrice = marketOrderbookMidPrice(market)
                     val worstPrice = marketOrderWorstPrice(marketOrder)
-                    val slippage =
-                        if (worstPrice != null && bestPrice != null && bestPrice > Numeric.double.ZERO) {
-                            Rounder.round(
-                                (worstPrice - bestPrice).abs() / bestPrice,
-                                0.00001,
-                            )
-                        } else {
-                            null
-                        }
-
+                    val slippageFromMidPrice = marketOrderSlippageFromMidPrice(worstPrice, midMarketPrice)
                     val price = marketOrderPrice(marketOrder)
                     val side = parser.asString(trade["side"])
                     val payloadPrice = if (price != null) {
@@ -1500,12 +1493,11 @@ internal class TradeInputCalculator(
                         parser.asDouble(market?.get("oraclePrice")) // if no indexPrice(v4), use oraclePrice
                     val priceDiff =
                         slippage(worstPrice, oraclePrice, parser.asString(trade["side"]))
-                    val slippageStepSize = 0.00001
                     val indexSlippage =
                         if (priceDiff != null && oraclePrice != null && oraclePrice > Numeric.double.ZERO) {
                             Rounder.quickRound(
                                 priceDiff / oraclePrice,
-                                slippageStepSize,
+                                SLIPPAGE_STEP_SIZE,
                             )
                         } else {
                             null
@@ -1530,7 +1522,7 @@ internal class TradeInputCalculator(
                         "total",
                         if (total == Numeric.double.ZERO) Numeric.double.ZERO else total,
                     )
-                    summary.safeSet("slippage", slippage)
+                    summary.safeSet("slippage", slippageFromMidPrice)
                     summary.safeSet("indexSlippage", indexSlippage)
                     summary.safeSet("filled", marketOrderFilled(marketOrder))
                     summary.safeSet("reward", reward)
@@ -1545,30 +1537,20 @@ internal class TradeInputCalculator(
             "STOP_MARKET", "TAKE_PROFIT_MARKET" -> {
                 parser.asNativeMap(trade["marketOrder"])?.let { marketOrder ->
                     val feeRate = parser.asDouble(parser.value(user, "takerFeeRate"))
-                    val bestPrice = marketOrderBestPrice(marketOrder)
+                    val midMarketPrice = marketOrderbookMidPrice(market)
                     val worstPrice = marketOrderWorstPrice(marketOrder)
-                    val slippageStepSize = 0.00001
-                    val slippage =
-                        if (worstPrice != null && bestPrice != null && bestPrice > Numeric.double.ZERO) {
-                            Rounder.quickRound(
-                                (worstPrice - bestPrice).abs() / bestPrice,
-                                slippageStepSize,
-                            )
+                    val slippageFromMidPrice = marketOrderSlippageFromMidPrice(worstPrice, midMarketPrice)
+
+                    val triggerPrice = parser.asDouble(parser.value(trade, "price.triggerPrice"))
+                    val marketOrderPrice = marketOrderPrice(marketOrder)
+                    val priceSlippage = if (midMarketPrice != null && marketOrderPrice != null) (marketOrderPrice - midMarketPrice) else null
+                    val slippagePercentage =
+                        if (priceSlippage != null && midMarketPrice != null) {
+                            abs(priceSlippage / midMarketPrice)
                         } else {
                             null
                         }
 
-                    val triggerPrice =
-                        parser.asDouble(parser.value(trade, "price.triggerPrice"))
-                    val marketOrderPrice = marketOrderPrice(marketOrder)
-                    val priceslippage =
-                        if (bestPrice != null && marketOrderPrice != null) (marketOrderPrice - bestPrice) else null
-                    val slippagePercentage =
-                        if (priceslippage != null && bestPrice != null) {
-                            abs(priceslippage / bestPrice)
-                        } else {
-                            null
-                        }
                     val adjustedslippagePercentage = if (slippagePercentage != null) {
                         val majorMarket = MAJOR_MARKETS.contains(parser.asString(trade["marketId"]))
                         if (majorMarket) {
@@ -1588,11 +1570,11 @@ internal class TradeInputCalculator(
                         null
                     }
 
-                    val price = if (triggerPrice != null && slippagePercentage != null) {
+                    val price = if (triggerPrice != null && slippageFromMidPrice != null) {
                         if (parser.asString(trade["side"]) == "BUY") {
-                            triggerPrice * (Numeric.double.ONE + slippagePercentage)
+                            triggerPrice * (Numeric.double.ONE + slippageFromMidPrice)
                         } else {
-                            triggerPrice * (Numeric.double.ONE - slippagePercentage)
+                            triggerPrice * (Numeric.double.ONE - slippageFromMidPrice)
                         }
                     } else {
                         null
@@ -1643,7 +1625,7 @@ internal class TradeInputCalculator(
                         "total",
                         if (total == Numeric.double.ZERO) Numeric.double.ZERO else total,
                     )
-                    summary.safeSet("slippage", slippage)
+                    summary.safeSet("slippage", slippageFromMidPrice)
                     summary.safeSet("filled", marketOrderFilled(marketOrder))
                     summary.safeSet("reward", reward)
                     summary.safeSet(
@@ -1748,19 +1730,25 @@ internal class TradeInputCalculator(
         }
     }
 
-    private fun marketOrderBestPrice(marketOrder: Map<String, Any>): Double? {
-        parser.asNativeList(marketOrder["orderbook"])?.let { orderbook ->
-            if (orderbook.isNotEmpty()) {
-                parser.asNativeMap(orderbook.firstOrNull())?.let { firstLine ->
-                    parser.asDouble(firstLine["price"])?.let { bestPrice ->
-                        if (bestPrice != Numeric.double.ZERO) {
-                            return bestPrice
-                        }
-                    }
+    private fun marketOrderbookMidPrice(market: Map<String, Any>?): Double? {
+        return parser.asNativeMap(market?.get("orderbook_consolidated"))?.let { orderbook ->
+            parser.asDouble(parser.value(orderbook, "asks.0.price"))?.let { firstAskPrice ->
+                parser.asDouble(parser.value(orderbook, "bids.0.price"))?.let { firstBidPrice ->
+                    (firstAskPrice + firstBidPrice) / 2.0
                 }
             }
         }
-        return null
+    }
+
+    private fun marketOrderSlippageFromMidPrice(worstPrice: Double?, midMarketPrice: Double?): Double? {
+        return if (worstPrice != null && midMarketPrice != null && midMarketPrice > Numeric.double.ZERO) {
+            Rounder.round(
+                (worstPrice - midMarketPrice).abs() / midMarketPrice,
+                SLIPPAGE_STEP_SIZE,
+            )
+        } else {
+            null
+        }
     }
 
     private fun marketOrderWorstPrice(marketOrder: Map<String, Any>): Double? {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -1543,13 +1543,8 @@ internal class TradeInputCalculator(
 
                     val triggerPrice = parser.asDouble(parser.value(trade, "price.triggerPrice"))
                     val marketOrderPrice = marketOrderPrice(marketOrder)
-                    val priceSlippage = if (midMarketPrice != null && marketOrderPrice != null) (marketOrderPrice - midMarketPrice) else null
-                    val slippagePercentage =
-                        if (priceSlippage != null && midMarketPrice != null) {
-                            abs(priceSlippage / midMarketPrice)
-                        } else {
-                            null
-                        }
+                    val slippagePercentage = if (midMarketPrice != null && marketOrderPrice != null && midMarketPrice > Numeric.double.ZERO)
+                        abs((marketOrderPrice - midMarketPrice) / midMarketPrice) else null
 
                     val adjustedslippagePercentage = if (slippagePercentage != null) {
                         val majorMarket = MAJOR_MARKETS.contains(parser.asString(trade["marketId"]))

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeMarketOrderInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeMarketOrderInputValidator.kt
@@ -8,6 +8,7 @@ import exchange.dydx.abacus.state.manager.V4Environment
 import exchange.dydx.abacus.validator.BaseInputValidator
 import exchange.dydx.abacus.validator.PositionChange
 import exchange.dydx.abacus.validator.TradeValidatorProtocol
+import kotlin.math.min
 
 internal class TradeMarketOrderInputValidator(
     localizer: LocalizerProtocol?,
@@ -56,7 +57,7 @@ internal class TradeMarketOrderInputValidator(
             if (error != null) {
                 errors.add(error)
             }
-            error = orderbookSlippage(trade, restricted)
+            error = orderbookOrIndexSlippage(trade, restricted)
             if (error != null) {
                 errors.add(error)
             }
@@ -79,61 +80,77 @@ internal class TradeMarketOrderInputValidator(
         return if (filled != false) {
             null
         } else {
-            error(
-                if (restricted) "WARNING" else "ERROR",
-                "MARKET_ORDER_NOT_ENOUGH_LIQUIDITY",
-                listOf("size.size"),
-                "APP.TRADE.MODIFY_SIZE_FIELD",
-                "ERRORS.TRADE_BOX_TITLE.MARKET_ORDER_NOT_ENOUGH_LIQUIDITY",
-                "ERRORS.TRADE_BOX.MARKET_ORDER_NOT_ENOUGH_LIQUIDITY",
+            createTradeBoxWarningOrError(
+                errorLevel = if (restricted) "WARNING" else "ERROR",
+                errorCode = "MARKET_ORDER_NOT_ENOUGH_LIQUIDITY",
+                fields = listOf("size.size"),
+                actionStringKey = "APP.TRADE.MODIFY_SIZE_FIELD",
             )
         }
     }
 
-    private fun orderbookSlippage(
+    private fun orderbookOrIndexSlippage(
         trade: Map<String, Any>,
         restricted: Boolean
     ): Map<String, Any>? {
         /*
         MARKET_ORDER_WARNING_ORDERBOOK_SLIPPAGE
         MARKET_ORDER_ERROR_ORDERBOOK_SLIPPAGE
+
+        MARKET_ORDER_WARNING_INDEX_PRICE_SLIPPAGE
+        MARKET_ORDER_ERROR_INDEX_PRICE_SLIPPAGE
          */
-        parser.asNativeMap(trade["summary"])?.let { summary ->
-            parser.asDouble(summary["slippage"])?.let { slippage ->
-                val slippageValue = slippage.abs()
-                if (slippageValue >= MARKET_ORDER_ERROR_SLIPPAGE) {
-                    return error(
-                        if (restricted) "WARNING" else "ERROR",
-                        "MARKET_ORDER_ERROR_ORDERBOOK_SLIPPAGE",
-                        listOf("size.size"),
-                        "APP.TRADE.MODIFY_SIZE_FIELD",
-                        "ERRORS.TRADE_BOX_TITLE.MARKET_ORDER_ERROR_ORDERBOOK_SLIPPAGE",
-                        "ERRORS.TRADE_BOX.MARKET_ORDER_ERROR_ORDERBOOK_SLIPPAGE",
-                        mapOf(
-                            "SLIPPAGE" to mapOf(
-                                "value" to slippageValue,
-                                "format" to "percent",
-                            ),
-                        ),
-                    )
-                } else if (slippageValue >= MARKET_ORDER_WARNING_SLIPPAGE) {
-                    return error(
-                        "WARNING",
-                        "MARKET_ORDER_WARNING_ORDERBOOK_SLIPPAGE",
-                        listOf("size.size"),
-                        null,
-                        "WARNINGS.TRADE_BOX_TITLE.MARKET_ORDER_WARNING_ORDERBOOK_SLIPPAGE",
-                        "WARNINGS.TRADE_BOX.MARKET_ORDER_WARNING_ORDERBOOK_SLIPPAGE",
-                        mapOf(
-                            "SLIPPAGE" to mapOf(
-                                "value" to slippageValue,
-                                "format" to "percent",
-                            ),
-                        ),
-                    )
-                }
-            }
+        val summary = parser.asNativeMap(trade["summary"]) ?: return null
+
+        // missing orderbook slippage (mid price) is most likely due to a one sided liquidity situation
+        // and should be caught by liquidity validation
+        val orderbookSlippage = parser.asDouble(summary["slippage"]) ?: return null
+        val indexSlippage = parser.asDouble(summary["indexSlippage"])
+        val orderbookSlippageValue = orderbookSlippage.abs()
+        val minSlippageValue = min(orderbookSlippageValue, indexSlippage ?: orderbookSlippageValue)
+
+        val isOrderbookSlippageRelevant = indexSlippage == null || orderbookSlippageValue < indexSlippage
+        val slippageType = if (isOrderbookSlippageRelevant) "ORDERBOOK" else "INDEX_PRICE"
+
+        return when {
+            minSlippageValue >= MARKET_ORDER_ERROR_SLIPPAGE -> createTradeBoxWarningOrError(
+                errorLevel = if (restricted) "WARNING" else "ERROR",
+                errorCode = "MARKET_ORDER_ERROR_${slippageType}_SLIPPAGE",
+                actionStringKey = "APP.TRADE.PLACE_LIMIT_ORDER",
+                slippagePercentValue = minSlippageValue,
+            )
+            minSlippageValue >= MARKET_ORDER_WARNING_SLIPPAGE -> createTradeBoxWarningOrError(
+                errorLevel = "WARNING",
+                errorCode = "MARKET_ORDER_WARNING_${slippageType}_SLIPPAGE",
+                actionStringKey = "APP.TRADE.PLACE_LIMIT_ORDER",
+                slippagePercentValue = minSlippageValue,
+            )
+            else -> null
         }
-        return null
+    }
+
+    private fun createTradeBoxWarningOrError(
+        errorLevel: String,
+        errorCode: String,
+        fields: List<String>? = null,
+        actionStringKey: String? = null,
+        slippagePercentValue: Double? = null
+    ): Map<String, Any> {
+        return error(
+            type = errorLevel,
+            errorCode,
+            fields,
+            actionStringKey,
+            "ERRORS.TRADE_BOX_TITLE.$errorCode",
+            "ERRORS.TRADE_BOX.$errorCode",
+            slippagePercentValue?.let {
+                mapOf(
+                    "SLIPPAGE" to mapOf(
+                        "value" to it,
+                        "format" to "percent",
+                    ),
+                )
+            },
+        )
     }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/validation/TradeMarketOrderTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/validation/TradeMarketOrderTests.kt
@@ -79,7 +79,7 @@ class TradeMarketOrderTests : ValidationsTests() {
                                 "size": 1.0,
                                 "usdcSize": 1024.26,
                                 "total": -1024.26,
-                                "slippage": 0.05989,
+                                "slippage": 0.06,
                                 "indexSlippage": 0.06,
                                 "filled": true
                             },
@@ -127,7 +127,7 @@ class TradeMarketOrderTests : ValidationsTests() {
                                 "size": 10.0,
                                 "usdcSize": 13820.26,
                                 "total": -13820.26,
-                                "slippage": 0.79982,
+                                "slippage": 0.8,
                                 "indexSlippage": 0.8,
                                 "filled": true
                             },

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.8.53'
+    spec.version = '1.8.54'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
                 
                 
                 
-    if !Dir.exist?('build/cocoapods/framework/Abacus.framework') || Dir.empty?('build/cocoapods/framework/Abacus.framework')
+    if false
         raise "
 
         Kotlin framework 'Abacus' doesn't exist yet, so a proper Xcode project can't be generated.


### PR DESCRIPTION
1. update orderbook slippage calculation to use mid market price
2. update slippage warning/errors logic*
3. update slippage error to show "place limit order" action string

*show slippage warning/error when:
- min(oracle slippage, orderbook slippage) > 5%/10%
- if missing oracle slippage, but orderbook slippage is >5%/10%

if orderbook slippage is missing (i.e. no mid price), that should be caught by liquidity validation
![image](https://github.com/user-attachments/assets/13ff7bad-ea14-4372-a687-a561520b4866)
![image](https://github.com/user-attachments/assets/185d9b79-155d-4eee-b92e-5f719cb9837e)
