### PR TITLE
feat: expose skip warnings [OTE-621]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.60"
+version = "1.8.61"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
@@ -487,6 +487,7 @@ data class TransferInput(
     val requestPayload: TransferInputRequestPayload?,
     val errors: String?,
     val errorMessage: String?,
+    val warning: String?,
 ) {
     val isCctp: Boolean
         get() = cctpChainIds?.any { it.isCctpEnabled(this) } ?: false
@@ -574,6 +575,7 @@ data class TransferInput(
                     } else {
                         null
                     }
+                val warning = parser.asString(route?.get("warning"))
 
                 return if (existing?.type !== type ||
                     existing?.size !== size ||
@@ -591,7 +593,8 @@ data class TransferInput(
                     existing.resources !== resources ||
                     existing.requestPayload !== requestPayload ||
                     existing.errors != errors ||
-                    existing.errorMessage != errorMessage
+                    existing.errorMessage != errorMessage ||
+                    existing.warning != warning
                 ) {
                     TransferInput(
                         type,
@@ -611,6 +614,7 @@ data class TransferInput(
                         requestPayload,
                         errors,
                         errorMessage,
+                        warning,
                     )
                 } else {
                     existing

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessor.kt
@@ -14,6 +14,7 @@ internal class SkipRouteProcessor(internal val parser: ParserProtocol) {
             "route.usd_amount_out" to "toAmountUSD",
             "route.estimated_amount_out" to "toAmount",
             "route.swap_price_impact_percent" to "aggregatePriceImpact",
+            "route.warning" to "warning",
 
 //            SQUID PARAMS THAT ARE NOW DEPRECATED:
 //            "route.estimate.gasCosts.0.amountUSD" to "gasFee",

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
@@ -125,6 +125,10 @@ class SkipRouteProcessorTests {
             "aggregatePriceImpact" to "0.2607",
             "bridgeFee" to 26.15,
             "slippage" to "1",
+            "warning" to jsonEncoder.encode(mapOf(
+                "type" to "BAD_PRICE_WARNING",
+                "message" to "Difference in USD value of route input and output is large. Input USD value: 130.13 Output USD value: 103.17",
+            )),
             "requestPayload" to mapOf(
                 "fromChainId" to "dydx-mainnet-1",
                 "fromAddress" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
@@ -198,6 +202,10 @@ class SkipRouteProcessorTests {
             "toAmount" to 59.995433,
             "bridgeFee" to 40.0,
             "slippage" to "1",
+            "warning" to jsonEncoder.encode(mapOf(
+                "type" to "BAD_PRICE_WARNING",
+                "message" to "Difference in USD value of route input and output is large. Input USD value: 99.99 Output USD value: 59.99",
+            )),
             "requestPayload" to mapOf(
                 "fromChainId" to "noble-1",
                 "fromAddress" to "uusdc",

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
@@ -125,10 +125,12 @@ class SkipRouteProcessorTests {
             "aggregatePriceImpact" to "0.2607",
             "bridgeFee" to 26.15,
             "slippage" to "1",
-            "warning" to jsonEncoder.encode(mapOf(
-                "type" to "BAD_PRICE_WARNING",
-                "message" to "Difference in USD value of route input and output is large. Input USD value: 130.13 Output USD value: 103.17",
-            )),
+            "warning" to jsonEncoder.encode(
+                mapOf(
+                    "type" to "BAD_PRICE_WARNING",
+                    "message" to "Difference in USD value of route input and output is large. Input USD value: 130.13 Output USD value: 103.17",
+                ),
+            ),
             "requestPayload" to mapOf(
                 "fromChainId" to "dydx-mainnet-1",
                 "fromAddress" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
@@ -202,10 +204,12 @@ class SkipRouteProcessorTests {
             "toAmount" to 59.995433,
             "bridgeFee" to 40.0,
             "slippage" to "1",
-            "warning" to jsonEncoder.encode(mapOf(
-                "type" to "BAD_PRICE_WARNING",
-                "message" to "Difference in USD value of route input and output is large. Input USD value: 99.99 Output USD value: 59.99",
-            )),
+            "warning" to jsonEncoder.encode(
+                mapOf(
+                    "type" to "BAD_PRICE_WARNING",
+                    "message" to "Difference in USD value of route input and output is large. Input USD value: 99.99 Output USD value: 59.99",
+                ),
+            ),
             "requestPayload" to mapOf(
                 "fromChainId" to "noble-1",
                 "fromAddress" to "uusdc",

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.60'
+    spec.version = '1.8.61'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Save skip's `warning` property in their `msgs_direct` response to state.
This will allow us to warn users if their proposed route will consume an inordinate amount of their funds due to transfer fees