### PR TITLE
feat: Add svm support to skip processor 

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRoutePayloadProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRoutePayloadProcessor.kt
@@ -22,7 +22,7 @@ internal class SkipRoutePayloadProcessor(parser: ParserProtocol) : BaseProcessor
             "route.source_asset_denom" to "fromAddress",
             "route.dest_asset_chain_id" to "toChainId",
             "route.dest_asset_denom" to "toAddress",
-
+            "txs.0.svm_tx.tx" to "solanaTransaction",
 //            SQUID PARAMS THAT ARE NOW DEPRECATED:
 //            "route.transactionRequest.routeType" to "routeType",
 //            "route.transactionRequest.gasPrice" to "gasPrice",
@@ -34,17 +34,20 @@ internal class SkipRoutePayloadProcessor(parser: ParserProtocol) : BaseProcessor
 
     enum class TxType {
         EVM,
-        COSMOS
+        COSMOS,
+        SOLANA
     }
 
-//    DO-LATER: https://linear.app/dydx/issue/OTE-350/%5Babacus%5D-cleanup
+    //    DO-LATER: https://linear.app/dydx/issue/OTE-350/%5Babacus%5D-cleanup
 //    Create custom exceptions for better error handling specificity and expressiveness
     @Suppress("TooGenericExceptionThrown")
     internal fun getTxType(payload: Map<String, Any>): TxType {
         val evm = parser.value(payload, "txs.0.evm_tx")
         val cosmos = parser.value(payload, "txs.0.cosmos_tx")
+        val solana = parser.value(payload, "txs.0.svm_tx")
         if (evm != null) return TxType.EVM
         if (cosmos != null) return TxType.COSMOS
+        if (solana != null) return TxType.SOLANA
         throw Error("SkipRoutePayloadProcessor: txType is not evm or cosmos")
     }
 
@@ -102,6 +105,16 @@ internal class SkipRoutePayloadProcessor(parser: ParserProtocol) : BaseProcessor
 //            save all messages in array
             modified.safeSet("data", jsonEncodePayload(formattedMessage))
             modified.safeSet("allMessages", jsonEncodePayload(allFormattedMessages))
+        }
+        if (txType == TxType.SOLANA) {
+            if (modified["solanaTransaction"] != null) {
+                modified.safeSet("data", modified["solanaTransaction"])
+                modified.remove("solanaTransaction")
+
+                // These are EVM specific fields and do not make sense for solana
+                modified.remove("gasPrice")
+                modified.remove("gasLimit")
+            }
         }
         return modified
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
@@ -113,11 +113,11 @@ class V4StateManagerConfigs(
     }
 
     fun skipV1Chains(): String {
-        return "$skipHost/v2/info/chains?include_evm=true$onlyTestnets"
+        return "$skipHost/v2/info/chains?include_svm=true&include_evm=true$onlyTestnets"
     }
 
     fun skipV1Assets(): String {
-        return "$skipHost/v2/fungible/assets?include_evm_assets=true$onlyTestnets"
+        return "$skipHost/v2/fungible/assets?include_svm_assets=true&include_evm_assets=true$onlyTestnets"
     }
 
     fun skipV2MsgsDirect(): String {

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
@@ -225,6 +225,7 @@ class SkipProcessorTests {
         )
         val expectedChains = listOf(
             SelectionOption(stringKey = "Ethereum", string = "Ethereum", type = "1", iconUrl = "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"),
+            SelectionOption(type = "solana", string = "Solana", stringKey = "Solana", iconUrl = "https://raw.githubusercontent.com/skip-mev/skip-go-registry/main/chains/solana/logo.svg"),
             SelectionOption(stringKey = "aura", string = "aura", type = "xstaxy-1", iconUrl = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/xstaxy/chain.png"),
             SelectionOption(stringKey = "cheqd", string = "cheqd", type = "cheqd-mainnet-1", iconUrl = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/cheqd-mainnet/chain.png"),
             SelectionOption(stringKey = "kujira", string = "kujira", type = "kaiyo-1", iconUrl = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/kaiyo/chain.png"),

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
@@ -16,10 +16,10 @@ class SkipRouteProcessorTests {
 
     /**
      * Tests an EVM CCTP deposit.
-     * This processes an EVM -> Noble USDC transaction (we only support deposits from EVM chains)
+     * This processes an EVM -> Noble USDC transaction
      */
     @Test
-    fun testReceivedCCTPDeposit() {
+    fun testReceivedEvmCCTPDeposit() {
         val payload = skipRouteMock.payload
         val result = skipRouteProcessor.received(existing = mapOf(), payload = templateToMap(payload), decimals = 6.0)
         val expected = mapOf(
@@ -37,6 +37,30 @@ class SkipRouteProcessorTests {
                 "toAddress" to "uusdc",
                 "gasPrice" to DEFAULT_GAS_PRICE,
                 "gasLimit" to DEFAULT_GAS_LIMIT,
+            ),
+        )
+        assertEquals(expected, result)
+    }
+
+    /**
+     * Tests an SVM CCTP deposit.
+     * This processes an SVM -> Noble USDC transaction
+     */
+    @Test
+    fun testReceivedSolanaCCTPDeposit() {
+        val payload = skipRouteMock.payloadCCTPSolanaToNoble
+        val result = skipRouteProcessor.received(existing = mapOf(), payload = templateToMap(payload), decimals = 6.0)
+        val expected = mapOf(
+            "toAmountUSD" to 1498.18,
+            "toAmount" to 1499.8,
+            "bridgeFee" to .2,
+            "slippage" to "1",
+            "requestPayload" to mapOf(
+                "data" to "mock-encoded-solana-tx",
+                "fromChainId" to "solana",
+                "fromAddress" to "98bVPZQCHZmCt9v3ni9kwtjKgLuzHBpstQkdPyAucBNx",
+                "toChainId" to "noble-1",
+                "toAddress" to "uusdc",
             ),
         )
         assertEquals(expected, result)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipChainsMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipChainsMock.kt
@@ -4,6 +4,28 @@ internal class SkipChainsMock {
     internal val payload = """{
     "chains": [
         {
+          "chain_name": "Solana",
+          "chain_id": "solana",
+          "pfm_enabled": false,
+          "cosmos_module_support": {
+            "authz": false,
+            "feegrant": false
+          },
+          "supports_memo": false,
+          "logo_uri": "https://raw.githubusercontent.com/skip-mev/skip-go-registry/main/chains/solana/logo.svg",
+          "bech32_prefix": "",
+          "fee_assets": [],
+          "chain_type": "svm",
+          "ibc_capabilities": {
+            "cosmos_pfm": false,
+            "cosmos_ibc_hooks": false,
+            "cosmos_memo": false,
+            "cosmos_autopilot": false
+          },
+          "is_testnet": false,
+          "pretty_name": "Solana"
+        },
+        {
             "chain_name": "kujira",
             "chain_id": "kaiyo-1",
             "pfm_enabled": false,

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipRouteMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipRouteMock.kt
@@ -615,6 +615,97 @@ internal class SkipRouteMock {
         }
     """.trimIndent()
 
+    internal val payloadCCTPSolanaToNoble = """
+        {
+            "msgs": [
+                {
+                    "svm_tx": {
+                        "chain_id": "solana",
+                        "tx": "mock-encoded-solana-tx",
+                        "signer_address": "26qv4GCcx98RihuK3c4T6ozB3J7L6VwCuFVc7Ta2A3Uo"
+                    }
+                }
+            ],
+            "txs": [
+                {
+                    "svm_tx": {
+                        "chain_id": "solana",
+                        "tx": "mock-encoded-solana-tx",
+                        "signer_address": "26qv4GCcx98RihuK3c4T6ozB3J7L6VwCuFVc7Ta2A3Uo"
+                    },
+                    "operations_indices": [
+                        0
+                    ]
+                }
+            ],
+            "route": {
+                "source_asset_denom": "98bVPZQCHZmCt9v3ni9kwtjKgLuzHBpstQkdPyAucBNx",
+                "source_asset_chain_id": "solana",
+                "dest_asset_denom": "uusdc",
+                "dest_asset_chain_id": "noble-1",
+                "amount_in": "1500000000",
+                "amount_out": "1499800000",
+                "operations": [
+                    {
+                        "cctp_transfer": {
+                            "from_chain_id": "solana",
+                            "to_chain_id": "noble-1",
+                            "burn_token": "98bVPZQCHZmCt9v3ni9kwtjKgLuzHBpstQkdPyAucBNx",
+                            "denom_in": "98bVPZQCHZmCt9v3ni9kwtjKgLuzHBpstQkdPyAucBNx",
+                            "denom_out": "uusdc",
+                            "bridge_id": "CCTP",
+                            "smart_relay": true
+                        },
+                        "tx_index": 0,
+                        "amount_in": "1500000000",
+                        "amount_out": "1499800000"
+                    }
+                ],
+                "chain_ids": [
+                    "solana",
+                    "noble-1"
+                ],
+                "does_swap": false,
+                "estimated_amount_out": "1499800000",
+                "swap_venues": [],
+                "txs_required": 1,
+                "usd_amount_in": "1498.38",
+                "usd_amount_out": "1498.18",
+                "estimated_fees": [
+                    {
+                        "fee_type": "SMART_RELAY",
+                        "bridge_id": "CCTP",
+                        "amount": "200000",
+                        "usd_amount": "0.20",
+                        "origin_asset": {
+                            "denom": "98bVPZQCHZmCt9v3ni9kwtjKgLuzHBpstQkdPyAucBNx",
+                            "chain_id": "solana",
+                            "origin_denom": "98bVPZQCHZmCt9v3ni9kwtjKgLuzHBpstQkdPyAucBNx",
+                            "origin_chain_id": "solana",
+                            "trace": "",
+                            "is_cw20": false,
+                            "is_evm": false,
+                            "is_svm": false,
+                            "symbol": "USDC",
+                            "name": "USD Coin",
+                            "logo_uri": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/98bVPZQCHZmCt9v3ni9kwtjKgLuzHBpstQkdPyAucBNx/logo.png",
+                            "decimals": 6,
+                            "coingecko_id": "usd-coin",
+                            "recommended_symbol": "USDC"
+                        },
+                        "chain_id": "solana",
+                        "tx_index": 0
+                    }
+                ],
+                "required_chain_addresses": [
+                    "solana",
+                    "noble-1"
+                ],
+                "estimated_route_duration_seconds": 25
+            }
+        }
+    """.trimIndent()
+
     internal val payloadError = """
     {
   "code": 3,


### PR DESCRIPTION
Adds SVM support to skip API calls and the skip route processor.

Chains and assets returned by skip are filtered by the apps, so Solana chains and assets should appear hidden until filters on the apps are modified to include them.