### PR TITLE
Calculate height by comparing local system time

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.66"
+version = "1.8.67"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Network.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Network.kt
@@ -20,7 +20,11 @@ enum class NetworkStatus(val rawValue: String) {
 }
 
 @JsExport
-class BlockAndTime(val block: Int, val time: Instant)
+class BlockAndTime(
+    val block: Int,
+    val time: Instant,
+    val localTime: Instant = ServerTime.now()
+)
 
 @JsExport
 internal class NetworkState() {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionsSupervisor.kt
@@ -13,6 +13,7 @@ import exchange.dydx.abacus.utils.AnalyticsUtils
 import exchange.dydx.abacus.utils.CoroutineTimer
 import exchange.dydx.abacus.utils.JsonEncoder
 import exchange.dydx.abacus.utils.Logger
+import exchange.dydx.abacus.utils.ServerTime
 import exchange.dydx.abacus.utils.iMapOf
 import exchange.dydx.abacus.utils.safeSet
 import kotlinx.datetime.Clock
@@ -382,10 +383,10 @@ internal class ConnectionsSupervisor(
         val latestBlockAndTime =
             connectionStats.validatorState.blockAndTime ?: connectionStats.indexerState.blockAndTime
                 ?: return null
-        val currentTime = Clock.System.now()
-        val lapsedTime = currentTime - latestBlockAndTime.time
+        val currentTime = ServerTime.now()
+        val lapsedTime = currentTime - latestBlockAndTime.localTime
         return if (lapsedTime.inWholeMilliseconds <= 0L) {
-            // This should never happen unless the clock is wrong, then we don't want to estimate height
+            // This should never happen we use system time, then we don't want to estimate height
             null
         } else {
             val firstBlockAndTime = connectionStats.firstBlockAndTime

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.66'
+    spec.version = '1.8.67'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Currently, the estimated block height for short time orders is calculated by the lapse of the block time (from the server) and the local system time.  This won't work if the system clock is wrong (i.e., running behind), and user will get an order submission failure.

We now add a `localTime` that records the local system time when updating `BlockAndTime`, and use it for the calculation.  Since for the purpose of calculating time lapse the "first block time" and "last block time" are now both in local system time, the calculation logic works even when the system clock is inaccurate.
