### PR TITLE
feat: improved onboarding ux [OTE-509]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.70"
+version = "1.8.71"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -8,6 +8,8 @@ import exchange.dydx.abacus.processor.router.IRouterProcessor
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.state.internalstate.InternalTransferInputState
 import exchange.dydx.abacus.state.manager.CctpConfig.cctpChainIds
+import exchange.dydx.abacus.utils.ARBITRUM_CHAIN_ID
+import exchange.dydx.abacus.utils.EVM_CHAIN_TYPE
 import exchange.dydx.abacus.utils.NATIVE_TOKEN_DEFAULT_ADDRESS
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
@@ -159,8 +161,7 @@ internal class SkipProcessor(
     }
 
     override fun defaultChainId(): String? {
-//        eth mainnet chainId is 1
-        val selectedChain = getChainById("1") ?: parser.asNativeMap(this.chains?.firstOrNull())
+        val selectedChain = getChainById(chainId = ARBITRUM_CHAIN_ID) ?: parser.asNativeMap(this.chains?.firstOrNull())
 
         return parser.asString(selectedChain?.get("chain_id"))
     }
@@ -168,7 +169,7 @@ internal class SkipProcessor(
     override fun getTokenByDenomAndChainId(tokenDenom: String?, chainId: String?): Map<String, Any>? {
         val tokensList = filteredTokens(chainId)
         tokensList?.find {
-            parser.asString(parser.asNativeMap(it)?.get("denom")) == tokenDenom
+            parser.asString(parser.asNativeMap(it)?.get("denom")) == (tokenDenom ?: NATIVE_TOKEN_DEFAULT_ADDRESS)
         }?.let {
             return parser.asNativeMap(it)
         }
@@ -221,18 +222,33 @@ internal class SkipProcessor(
     }
 
     override fun defaultTokenAddress(chainId: String?): String? {
-        return chainId?.let { cid ->
-            // Retrieve the list of filtered tokens for the given chainId
-            val filteredTokens = this.filteredTokens(cid)?.mapNotNull {
-                parser.asString(parser.asNativeMap(it)?.get("denom"))
-            }.orEmpty()
-            // Find a matching CctpChainTokenInfo and check if its tokenAddress is in the filtered tokens
-            cctpChainIds?.firstOrNull { it.chainId == cid && filteredTokens.contains(it.tokenAddress) }?.tokenAddress
-                ?: run {
-                    // Fallback to the first token's address from the filtered list if no CctpChainTokenInfo match is found
-                    filteredTokens.firstOrNull()
-                }
+        if (chainId == null) {
+            return null
         }
+        val filteredTokensForChainId = filteredTokens(chainId) ?: return null
+
+        // Find if any CctpChainTokenInfo item belongs to the provided chainId
+        val cctpChain = cctpChainIds?.find { it.chainId == chainId }
+//        If one does, then check for a token in the filteredTokens whose denom matches the found cctpChainTokenInfo, if one exists
+        val filteredCctpToken = filteredTokensForChainId.find {
+            parser.asString(parser.asNativeMap(it)?.get("denom")) == cctpChain?.tokenAddress
+        }
+        if (filteredCctpToken != null) {
+            return parser.asString(parser.asNativeMap(filteredCctpToken)?.get("denom"))
+        }
+//        If no cctp item available, check for a native token item
+        val nativeChain = filteredTokensForChainId?.find {
+            parser.asString(parser.asNativeMap(it)?.get("denom")) == NATIVE_TOKEN_DEFAULT_ADDRESS
+        }
+        if (nativeChain != null) {
+            return parser.asString(parser.asNativeMap(nativeChain)?.get("denom"))
+        }
+//        Otherwise, just grab the first available token if any exist
+        val firstTokenOrNull = parser.asNativeMap(filteredTokensForChainId?.firstOrNull())
+        if (firstTokenOrNull != null) {
+            return parser.asString(parser.asNativeMap(firstTokenOrNull)?.get("denom"))
+        }
+        return null
     }
 
     override fun chainResources(chainId: String?): Map<String, TransferInputChainResource>? {
@@ -270,7 +286,7 @@ internal class SkipProcessor(
         this.chains?.let {
             for (chain in it) {
                 parser.asNativeMap(chain)?.let { chain ->
-                    if (parser.asString(chain.get("chainType")) != "cosmos") {
+                    if (parser.asString(chain.get("chain_type")) == EVM_CHAIN_TYPE) {
                         options.add(chainProcessor.received(chain))
                     }
                 }
@@ -293,6 +309,8 @@ internal class SkipProcessor(
             }
         }
         options.sortBy { parser.asString(it.stringKey) }
-        return options
+
+        val sortedOptions = options.sortedBy { if (it.type === NATIVE_TOKEN_DEFAULT_ADDRESS) 0 else 1 }
+        return sortedOptions
     }
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -8,8 +8,8 @@ import exchange.dydx.abacus.processor.router.IRouterProcessor
 import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.state.internalstate.InternalTransferInputState
 import exchange.dydx.abacus.state.manager.CctpConfig.cctpChainIds
-import exchange.dydx.abacus.utils.ARBITRUM_CHAIN_ID
-import exchange.dydx.abacus.utils.EVM_CHAIN_TYPE
+import exchange.dydx.abacus.utils.ALLOWED_CHAIN_TYPES
+import exchange.dydx.abacus.utils.ETHEREUM_CHAIN_ID
 import exchange.dydx.abacus.utils.NATIVE_TOKEN_DEFAULT_ADDRESS
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
@@ -161,7 +161,7 @@ internal class SkipProcessor(
     }
 
     override fun defaultChainId(): String? {
-        val selectedChain = getChainById(chainId = ARBITRUM_CHAIN_ID) ?: parser.asNativeMap(this.chains?.firstOrNull())
+        val selectedChain = getChainById(chainId = ETHEREUM_CHAIN_ID) ?: parser.asNativeMap(this.chains?.firstOrNull())
 
         return parser.asString(selectedChain?.get("chain_id"))
     }
@@ -286,7 +286,7 @@ internal class SkipProcessor(
         this.chains?.let {
             for (chain in it) {
                 parser.asNativeMap(chain)?.let { chain ->
-                    if (parser.asString(chain.get("chain_type")) == EVM_CHAIN_TYPE) {
+                    if (parser.asString(chain.get("chain_type")) in ALLOWED_CHAIN_TYPES) {
                         options.add(chainProcessor.received(chain))
                     }
                 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
@@ -113,11 +113,11 @@ class V4StateManagerConfigs(
     }
 
     fun skipV1Chains(): String {
-        return "$skipHost/v2/info/chains?include_svm=true&include_evm=true$onlyTestnets"
+        return "$skipHost/v2/info/chains?include_evm=true$includeSvmChains$onlyTestnets"
     }
 
     fun skipV1Assets(): String {
-        return "$skipHost/v2/fungible/assets?include_svm_assets=true&include_evm_assets=true$onlyTestnets"
+        return "$skipHost/v2/fungible/assets?include_evm_assets=true$includeSvmAssets$onlyTestnets"
     }
 
     fun skipV2MsgsDirect(): String {
@@ -133,6 +133,15 @@ class V4StateManagerConfigs(
     }
 
     val nobleDenom = "uusdc"
+
+    private val includeSvmChains: String
+        get() {
+            return if (environment.isMainNet) "" else "&include_svm=true"
+        }
+    private val includeSvmAssets: String
+        get() {
+            return if (environment.isMainNet) "" else "&include_svm_assets=true"
+        }
 
     private val onlyTestnets: String
         get() {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -21,7 +21,7 @@ internal const val CONDITIONAL_ORDER_FLAGS = 32
 // Asset Constants
 internal const val NATIVE_TOKEN_DEFAULT_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
 internal const val ETHEREUM_CHAIN_ID = "1"
-internal val ALLOWED_CHAIN_TYPES = listOf("evm")
+internal val ALLOWED_CHAIN_TYPES = listOf("evm", "svm")
 
 // Polling durations
 internal const val GEO_POLLING_DURATION_SECONDS = 10.0

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -20,6 +20,8 @@ internal const val CONDITIONAL_ORDER_FLAGS = 32
 
 // Asset Constants
 internal const val NATIVE_TOKEN_DEFAULT_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+internal const val ARBITRUM_CHAIN_ID = "42161"
+internal const val EVM_CHAIN_TYPE = "evm"
 
 // Polling durations
 internal const val GEO_POLLING_DURATION_SECONDS = 10.0

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -20,8 +20,8 @@ internal const val CONDITIONAL_ORDER_FLAGS = 32
 
 // Asset Constants
 internal const val NATIVE_TOKEN_DEFAULT_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
-internal const val ARBITRUM_CHAIN_ID = "42161"
-internal const val EVM_CHAIN_TYPE = "evm"
+internal const val ETHEREUM_CHAIN_ID = "1"
+internal val ALLOWED_CHAIN_TYPES = listOf("evm")
 
 // Polling durations
 internal const val GEO_POLLING_DURATION_SECONDS = 10.0

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
@@ -229,11 +229,11 @@ class SkipProcessorTests {
             SelectionOption(type = "solana", string = "Solana", stringKey = "Solana", iconUrl = "https://raw.githubusercontent.com/skip-mev/skip-go-registry/main/chains/solana/logo.svg"),
         )
         val expectedChainResources = mapOf(
-            "42161" to TransferInputChainResource(
-                chainName = "Arbitrum",
-                chainId = 42161,
-                rpc = "https://arb-mainnet.g.alchemy.com/v2/$testApiKey",
-                iconUrl = "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/info/logo.png",
+            "1" to TransferInputChainResource(
+                chainName = "Ethereum",
+                chainId = 1,
+                rpc = "https://eth-mainnet.g.alchemy.com/v2/$testApiKey",
+                iconUrl = "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png",
             ),
         )
         val expectedModified = mapOf(
@@ -244,7 +244,7 @@ class SkipProcessorTests {
                 "withdrawalOptions" to mapOf(
                     "chains" to expectedChains,
                 ),
-                "chain" to "42161",
+                "chain" to "1",
             ),
         )
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
@@ -224,20 +224,16 @@ class SkipProcessorTests {
             payload = payload,
         )
         val expectedChains = listOf(
+            SelectionOption(stringKey = "Arbitrum", string = "Arbitrum", type = "42161", iconUrl = "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/info/logo.png"),
             SelectionOption(stringKey = "Ethereum", string = "Ethereum", type = "1", iconUrl = "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"),
             SelectionOption(type = "solana", string = "Solana", stringKey = "Solana", iconUrl = "https://raw.githubusercontent.com/skip-mev/skip-go-registry/main/chains/solana/logo.svg"),
-            SelectionOption(stringKey = "aura", string = "aura", type = "xstaxy-1", iconUrl = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/xstaxy/chain.png"),
-            SelectionOption(stringKey = "cheqd", string = "cheqd", type = "cheqd-mainnet-1", iconUrl = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/cheqd-mainnet/chain.png"),
-            SelectionOption(stringKey = "kujira", string = "kujira", type = "kaiyo-1", iconUrl = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/kaiyo/chain.png"),
-            SelectionOption(stringKey = "osmosis", string = "osmosis", type = "osmosis-1", iconUrl = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/osmosis/chain.png"),
-            SelectionOption(stringKey = "stride", string = "stride", type = "stride-1", iconUrl = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/stride/chain.png"),
         )
         val expectedChainResources = mapOf(
-            "1" to TransferInputChainResource(
-                chainName = "Ethereum",
-                chainId = 1,
-                rpc = "https://eth-mainnet.g.alchemy.com/v2/$testApiKey",
-                iconUrl = "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png",
+            "42161" to TransferInputChainResource(
+                chainName = "Arbitrum",
+                chainId = 42161,
+                rpc = "https://arb-mainnet.g.alchemy.com/v2/$testApiKey",
+                iconUrl = "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/info/logo.png",
             ),
         )
         val expectedModified = mapOf(
@@ -248,7 +244,7 @@ class SkipProcessorTests {
                 "withdrawalOptions" to mapOf(
                     "chains" to expectedChains,
                 ),
-                "chain" to "1",
+                "chain" to "42161",
             ),
         )
 
@@ -280,6 +276,12 @@ class SkipProcessorTests {
         )
         val expectedTokens = listOf(
             SelectionOption(
+                stringKey = "ZEthereum",
+                string = "ZEthereum",
+                type = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                iconUrl = "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-blue.svg",
+            ),
+            SelectionOption(
                 stringKey = "Euro Coin",
                 string = "Euro Coin",
                 type = "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
@@ -300,7 +302,7 @@ class SkipProcessorTests {
         )
         val expectedModified = mapOf(
             "transfer" to mapOf(
-                "token" to "0x97e6E0a40a3D02F12d1cEC30ebfbAE04e37C119E",
+                "token" to "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
                 "depositOptions" to mapOf(
                     "tokens" to expectedTokens,
                 ),
@@ -330,6 +332,13 @@ class SkipProcessorTests {
                 symbol = "UMEE",
                 decimals = 6,
                 iconUrl = "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/umee.svg",
+            ),
+            "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" to TransferInputTokenResource(
+                name = "ZEthereum",
+                address = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                symbol = "ETH",
+                decimals = 18,
+                iconUrl = "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-blue.svg",
             ),
         )
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipChainsMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipChainsMock.kt
@@ -203,7 +203,29 @@ internal class SkipChainsMock {
         "cosmos_autopilot": false
       },
       "is_testnet": false
-    }
+    },
+    {
+    "chain_name": "Arbitrum",
+    "chain_id": "42161",
+    "pfm_enabled": false,
+    "cosmos_module_support": {
+        "authz": false,
+        "feegrant": false
+    },
+    "supports_memo": false,
+    "logo_uri": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/arbitrum/info/logo.png",
+    "bech32_prefix": "",
+    "fee_assets": [],
+    "chain_type": "evm",
+    "ibc_capabilities": {
+        "cosmos_pfm": false,
+        "cosmos_ibc_hooks": false,
+        "cosmos_memo": false,
+        "cosmos_autopilot": false
+    },
+    "is_testnet": false,
+    "pretty_name": "Arbitrum"
+}
     ]
 }"""
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipTokensMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipTokensMock.kt
@@ -52,6 +52,23 @@ class SkipTokensMock {
                     "token_contract": "0x923e030f951A2401426a3407a9bcc7EB715d9a0b",
                     "coingecko_id": "umee",
                     "recommended_symbol": "UMEE"
+                },
+                {
+                    "denom": "ethereum-native",
+                    "chain_id": "1",
+                    "origin_denom": "ethereum-native",
+                    "origin_chain_id": "1",
+                    "trace": "",
+                    "is_cw20": false,
+                    "is_evm": true,
+                    "is_svm": false,
+                    "symbol": "ETH",
+                    "name": "ZEthereum",
+                    "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-blue.svg",
+                    "decimals": 18,
+                    "description": "",
+                    "coingecko_id": "ethereum",
+                    "recommended_symbol": "ETH"
                 }
             ]
         }"""

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.70'
+    spec.version = '1.8.71'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
what this PR does:
- filter out non EVM and non SVM chains (we had a typo that was preventing this before, lol)
- **THIS PR NO LONGER DOES THIS** prefer Arb as default chain (Ethereum has very high fees)
  - NOTE: this means that arb is the default chains for withdrawals **and deposits** since the skip processor doesn't have access to the current transfer type. we can differentiate the 2 but it's an extra lift which may be non-trivial
- sorts native asset as the first item after usdc asset if applicable

what this PR does not:
- do anything to CCTP USDC asset ordering. USDC assets on CCTP are already sorted to the top in web so we aren't changing abacus behavior here.
- do anything to Non-CCTP USDC asset ordering. If desired, we can move USDC assets on non CCTP chains to the top, but for now native assets are at the top.
- prefer Arb as default chain (Ethereum has very high fees)

Withdrawals
https://www.loom.com/share/5de427b2c4ec4d54bea5c09d53bf3244?sid=530ddb5e-7b1e-420a-a213-fd09f5f59959


Deposits
https://www.loom.com/share/f4d106d812f84e588be159bffb0b37f6?sid=a70b5995-be9f-4cad-9159-98ad6163702c