### PR TITLE
feat: hide usdt assets [OTE-669]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.77"
+version = "1.8.78"
 
 repositories {
     google()

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.77'
+    spec.version = '1.8.78'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
https://linear.app/dydx/issue/OTE-669/hide-usdt-assets-from-onboarding-modal

This PR filters out tokens if their symbol contains `USDT` 

This is a temporary measure until the [IBC USDT rate limits](https://ibc.range.org/ibc/rate-limits) reset on saturday.

<img width="1561" alt="image" src="https://github.com/user-attachments/assets/89382c86-00a9-439d-a868-1819bc135dd2">
