### PR TITLE
fix: bump autosweep min to 50000 [OTE-673]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.81"
+version = "1.8.82"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -27,7 +27,7 @@ internal val ALLOWED_CHAIN_TYPES = listOf("evm", "svm")
 internal const val GEO_POLLING_DURATION_SECONDS = 600.0
 
 // Autosweep Constants
-internal const val MIN_USDC_AMOUNT_FOR_AUTO_SWEEP = 20000
+internal const val MIN_USDC_AMOUNT_FOR_AUTO_SWEEP = 50000
 
 // Gas Constants based on historical Squid responses
 internal const val DEFAULT_GAS_LIMIT = 1500000

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.81'
+    spec.version = '1.8.82'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Autosweep min of 20000 is not enough for gas fees. It's possible to get a failed IBC due to gas fees but the code keeps retrying over and over, leading to a noisy dev console/network tab

Whats happening here?
- Abacus performs autosweeping for users

What is autosweeping?
- Autosweeping is the act of periodically (every 10 seconds as of today) IBC transferring funds from the user's noble wallet to their dydx wallet