### PR TITLE
feat: evm swaps for deposits [OTE-700]

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/IRouterProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/IRouterProcessor.kt
@@ -7,7 +7,6 @@ import exchange.dydx.abacus.output.input.TransferInputTokenResource
 interface IRouterProcessor {
     var tokens: List<Any>?
     var chains: List<Any>?
-    var evmSwapVenues: List<Any?>
     var exchangeDestinationChainId: String?
 
     fun receivedEvmSwapVenues(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/IRouterProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/IRouterProcessor.kt
@@ -7,7 +7,13 @@ import exchange.dydx.abacus.output.input.TransferInputTokenResource
 interface IRouterProcessor {
     var tokens: List<Any>?
     var chains: List<Any>?
+    var evmSwapVenues: List<Any?>
     var exchangeDestinationChainId: String?
+
+    fun receivedEvmSwapVenues(
+        existing: Map<String, Any>?,
+        payload: Map<String, Any>,
+    )
 
     fun receivedChains(
         existing: Map<String, Any>?,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -16,7 +16,6 @@ import exchange.dydx.abacus.utils.safeSet
 
 private const val UNISWAP_SUFFIX = "uniswap"
 
-@Suppress("NotImplementedDeclaration")
 internal class SkipProcessor(
     parser: ParserProtocol,
     private val internalState: InternalTransferInputState

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -27,8 +27,6 @@ internal class SkipProcessor(
 //    actual type of the tokens payload is Map<str, Map<str, List<Map<str, Any>>>>
     override var tokens: List<Any>? = null
 
-    override var evmSwapVenues: List<Any?> = listOf()
-
     var skipTokens: Map<String, Map<String, List<Map<String, Any>>>>? = null
     override var exchangeDestinationChainId: String? = null
 
@@ -79,7 +77,7 @@ internal class SkipProcessor(
             )
         }
         if (evmSwapVenues != null) {
-            this.evmSwapVenues = evmSwapVenues
+            this.internalState.evmSwapVenues = evmSwapVenues
         }
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -14,6 +14,7 @@ import exchange.dydx.abacus.utils.NATIVE_TOKEN_DEFAULT_ADDRESS
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
 
+//   Skip only supports uniswap evm swaps right now. We can expand this later
 private const val UNISWAP_SUFFIX = "uniswap"
 
 internal class SkipProcessor(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessor.kt
@@ -68,7 +68,7 @@ internal class SkipProcessor(
         existing: Map<String, Any>?,
         payload: Map<String, Any>
     ) {
-        val venues = parser.asNativeList(payload?.get("venues"))
+        val venues = parser.asNativeList(payload.get("venues"))
         val evmSwapVenues = venues?.filter {
             parser.asString(parser.asMap(it)?.get("name"))?.endsWith(UNISWAP_SUFFIX) == true
         }?.map {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/squid/SquidProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/squid/SquidProcessor.kt
@@ -11,7 +11,6 @@ import exchange.dydx.abacus.state.manager.CctpConfig.cctpChainIds
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
 
-@Suppress("NotImplementedDeclaration")
 internal class SquidProcessor(
     parser: ParserProtocol,
     private val internalState: InternalTransferInputState,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/squid/SquidProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/squid/SquidProcessor.kt
@@ -17,7 +17,6 @@ internal class SquidProcessor(
 ) : BaseProcessor(parser), IRouterProcessor {
     override var chains: List<Any>? = null
     override var tokens: List<Any>? = null
-    override var evmSwapVenues: List<Any?> = listOf()
     override var exchangeDestinationChainId: String? = null
 
     override fun receivedEvmSwapVenues(existing: Map<String, Any>?, payload: Map<String, Any>) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/squid/SquidProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/squid/SquidProcessor.kt
@@ -11,13 +11,19 @@ import exchange.dydx.abacus.state.manager.CctpConfig.cctpChainIds
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
 
+@Suppress("NotImplementedDeclaration")
 internal class SquidProcessor(
     parser: ParserProtocol,
     private val internalState: InternalTransferInputState,
 ) : BaseProcessor(parser), IRouterProcessor {
     override var chains: List<Any>? = null
     override var tokens: List<Any>? = null
+    override var evmSwapVenues: List<Any?> = listOf()
     override var exchangeDestinationChainId: String? = null
+
+    override fun receivedEvmSwapVenues(existing: Map<String, Any>?, payload: Map<String, Any>) {
+        throw NotImplementedError("receivedEvmSwapVenues is not implemented in SquidProcessor!")
+    }
 
     override fun receivedChains(
         existing: Map<String, Any>?,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalTransferInputState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalTransferInputState.kt
@@ -9,4 +9,5 @@ internal data class InternalTransferInputState(
     var tokens: List<SelectionOption>? = null,
     var chainResources: Map<String, TransferInputChainResource>? = null,
     var tokenResources: Map<String, TransferInputTokenResource>? = null,
+    var evmSwapVenues: List<Any?> = listOf(),
 )

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/configs/V4StateManagerConfigs.kt
@@ -132,6 +132,8 @@ class V4StateManagerConfigs(
         return "$skipHost/v2/tx/status"
     }
 
+    val skipV2Venues = "$skipHost/v2/fungible/venues"
+
     val nobleDenom = "uusdc"
 
     private val includeSvmChains: String

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Squid.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Squid.kt
@@ -29,6 +29,13 @@ internal fun TradingStateMachine.routerTokens(payload: String): StateChanges? {
     }
 }
 
+internal fun TradingStateMachine.evmSwapVenues(payload: String) {
+    val json = parser.decodeJsonObject(payload)
+    if (json != null) {
+        routerProcessor.receivedEvmSwapVenues(input, json)
+    }
+}
+
 internal fun TradingStateMachine.squidV2SdkInfo(payload: String): StateChanges? {
     val json = parser.decodeJsonObject(payload)
     return if (json != null) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -304,7 +304,7 @@ internal class OnboardingSupervisor(
             OSMOSIS_SWAP_VENUE,
             NEUTRON_SWAP_VENUE,
         )
-        val evmSwapVenues = stateMachine.routerProcessor.evmSwapVenues
+        val evmSwapVenues = stateMachine.internalState.transfer.evmSwapVenues
         val swapVenues = evmSwapVenues + nonEvmSwapVenues
         if (fromAmount != null && fromAmount > 0) {
             val body: Map<String, Any> = mapOf(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -30,6 +30,7 @@ import exchange.dydx.abacus.state.manager.SystemUtils
 import exchange.dydx.abacus.state.manager.pendingCctpWithdraw
 import exchange.dydx.abacus.state.model.TradingStateMachine
 import exchange.dydx.abacus.state.model.TransferInputField
+import exchange.dydx.abacus.state.model.evmSwapVenues
 import exchange.dydx.abacus.state.model.routerChains
 import exchange.dydx.abacus.state.model.routerStatus
 import exchange.dydx.abacus.state.model.routerTokens
@@ -74,6 +75,10 @@ private val NEUTRON_SWAP_VENUE = mapOf(
     "chain_id" to "neutron-1",
 )
 
+private val SMART_SWAP_OPTIONS = mapOf(
+    "evm_swaps" to true,
+)
+
 private const val IBC_BRIDGE_ID = "IBC"
 private const val CCTP_BRIDGE_ID = "CCTP"
 private const val AXELAR_BRIDGE_ID = "AXELAR"
@@ -101,6 +106,7 @@ internal class OnboardingSupervisor(
                 retrieveSkipTransferChains()
             }
             retrieveSkipTransferTokens()
+            retrieveSkipEvmSwapVenues()
         } else {
             retrieveTransferAssets()
         }
@@ -131,11 +137,19 @@ internal class OnboardingSupervisor(
         }
     }
 
+    private fun retrieveSkipEvmSwapVenues() {
+        helper.get(helper.configs.skipV2Venues, null, null) { _, response, httpCode, _ ->
+            if (!helper.success(httpCode) || response == null) {
+                Logger.e { "retrieveSkipEVMSwapVenues error, code: $httpCode" }
+            } else {
+                stateMachine.evmSwapVenues(response)
+            }
+        }
+    }
+
     private fun retrieveSkipTransferTokens() {
         val oldState = stateMachine.state
         val tokensUrl = helper.configs.skipV1Assets()
-//            add API key injection for all skip methods
-//            val header = iMapOf("authorization" to skipAPIKey)
         helper.get(tokensUrl, null, null) { _, response, httpCode, _ ->
             if (helper.success(httpCode) && response != null) {
                 update(stateMachine.routerTokens(response), oldState)
@@ -285,6 +299,13 @@ internal class OnboardingSupervisor(
         val nativeChainUSDCDenom = helper.environment.tokens["usdc"]?.denom ?: return
         val fromAmountString = helper.parser.asString(fromAmount) ?: return
         val url = helper.configs.skipV2MsgsDirect()
+
+        val nonEvmSwapVenues = listOf(
+            OSMOSIS_SWAP_VENUE,
+            NEUTRON_SWAP_VENUE,
+        )
+        val evmSwapVenues = stateMachine.routerProcessor.evmSwapVenues
+        val swapVenues = evmSwapVenues + nonEvmSwapVenues
         if (fromAmount != null && fromAmount > 0) {
             val body: Map<String, Any> = mapOf(
                 "amount_in" to fromAmountString,
@@ -299,15 +320,14 @@ internal class OnboardingSupervisor(
                     neutronChainId to accountAddress.toNeutronAddress(),
                     chainId to accountAddress,
                 ),
-                "swap_venues" to listOf(
-                    OSMOSIS_SWAP_VENUE,
-                    NEUTRON_SWAP_VENUE,
-                ),
+                "swap_venues" to swapVenues,
                 "bridges" to listOf(
                     IBC_BRIDGE_ID,
                     AXELAR_BRIDGE_ID,
+                    CCTP_BRIDGE_ID,
                 ),
                 "slippage_tolerance_percent" to SLIPPAGE_PERCENT,
+                "smart_swap_options" to SMART_SWAP_OPTIONS,
             )
 
             val oldState = stateMachine.state

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
@@ -426,7 +426,7 @@ class SkipProcessorTests {
             payload = templateToMap(SkipVenuesMock.venues),
         )
 
-        val result = skipProcessor.evmSwapVenues
+        val result = internalState.evmSwapVenues
 
         val expected =
             listOf(

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
@@ -9,6 +9,7 @@ import exchange.dydx.abacus.tests.payloads.RpcMock
 import exchange.dydx.abacus.tests.payloads.SkipChainsMock
 import exchange.dydx.abacus.tests.payloads.SkipRouteMock
 import exchange.dydx.abacus.tests.payloads.SkipTokensMock
+import exchange.dydx.abacus.tests.payloads.SkipVenuesMock
 import exchange.dydx.abacus.utils.DEFAULT_GAS_LIMIT
 import exchange.dydx.abacus.utils.DEFAULT_GAS_PRICE
 import exchange.dydx.abacus.utils.Parser
@@ -415,6 +416,57 @@ class SkipProcessorTests {
             ),
             "is_testnet" to false,
         ).toJsonObject()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun receivedEvmSwapVenues() {
+        skipProcessor.receivedEvmSwapVenues(
+            existing = mapOf(),
+            payload = templateToMap(SkipVenuesMock.venues),
+        )
+
+        val result = skipProcessor.evmSwapVenues
+
+        val expected =
+            listOf(
+                mapOf(
+                    "name" to "ethereum-uniswap",
+                    "chain_id" to "1",
+                ),
+                mapOf(
+                    "name" to "binance-uniswap",
+                    "chain_id" to "56",
+                ),
+                mapOf(
+                    "name" to "polygon-uniswap",
+                    "chain_id" to "137",
+                ),
+                mapOf(
+                    "name" to "optimism-uniswap",
+                    "chain_id" to "10",
+                ),
+                mapOf(
+                    "name" to "arbitrum-uniswap",
+                    "chain_id" to "42161",
+                ),
+                mapOf(
+                    "name" to "base-uniswap",
+                    "chain_id" to "8453",
+                ),
+                mapOf(
+                    "name" to "celo-uniswap",
+                    "chain_id" to "42220",
+                ),
+                mapOf(
+                    "name" to "avalanche-uniswap",
+                    "chain_id" to "43114",
+                ),
+                mapOf(
+                    "name" to "blast-uniswap",
+                    "chain_id" to "81457",
+                ),
+            )
         assertEquals(expected, result)
     }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipVenuesMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/SkipVenuesMock.kt
@@ -1,0 +1,125 @@
+package exchange.dydx.abacus.tests.payloads
+
+object SkipVenuesMock {
+    internal val venues = """
+        {
+            "venues": [
+                {
+                    "name": "archway-astrovault",
+                    "chain_id": "archway-1",
+                    "logo_uri": "https://raw.githubusercontent.com/coinhall/yacar/main/_dex/astrovault/logo.svg"
+                },
+                {
+                    "name": "persistence-dexter",
+                    "chain_id": "core-1",
+                    "logo_uri": "https://raw.githubusercontent.com/skip-mev/skip-go-registry/main/swap-venues/dexter/logo.png"
+                },
+                {
+                    "name": "oraichain-oraidex",
+                    "chain_id": "Oraichain",
+                    "logo_uri": "https://raw.githubusercontent.com/coinhall/yacar/main/_dex/oraidex/logo.svg"
+                },
+                {
+                    "name": "neutron-lido-satellite",
+                    "chain_id": "neutron-1",
+                    "logo_uri": "https://raw.githubusercontent.com/skip-mev/skip-go-registry/main/swap-venues/lido-satellite/logo.png"
+                },
+                {
+                    "name": "osmosis-poolmanager",
+                    "chain_id": "osmosis-1",
+                    "logo_uri": "https://raw.githubusercontent.com/skip-mev/skip-go-registry/main/swap-venues/osmosis/logo.png"
+                },
+                {
+                    "name": "injective-white-whale",
+                    "chain_id": "injective-1",
+                    "logo_uri": "https://raw.githubusercontent.com/coinhall/yacar/main/_dex/whitewhale/logo.svg"
+                },
+                {
+                    "name": "sei-white-whale",
+                    "chain_id": "pacific-1",
+                    "logo_uri": "https://raw.githubusercontent.com/coinhall/yacar/main/_dex/whitewhale/logo.svg"
+                },
+                {
+                    "name": "injective-dojoswap",
+                    "chain_id": "injective-1",
+                    "logo_uri": "https://raw.githubusercontent.com/coinhall/yacar/main/_dex/dojoswap/logo.svg"
+                },
+                {
+                    "name": "injective-helix",
+                    "chain_id": "injective-1",
+                    "logo_uri": "https://raw.githubusercontent.com/coinhall/yacar/main/_dex/helix/logo.svg"
+                },
+                {
+                    "name": "sei-astroport",
+                    "chain_id": "pacific-1",
+                    "logo_uri": "https://raw.githubusercontent.com/skip-mev/skip-go-registry/main/swap-venues/astroport/logo.png"
+                },
+                {
+                    "name": "neutron-astroport",
+                    "chain_id": "neutron-1",
+                    "logo_uri": "https://raw.githubusercontent.com/coinhall/yacar/main/_dex/astroport/logo.svg"
+                },
+                {
+                    "name": "migaloo-white-whale",
+                    "chain_id": "migaloo-1",
+                    "logo_uri": "https://raw.githubusercontent.com/coinhall/yacar/main/_dex/whitewhale/logo.svg"
+                },
+                {
+                    "name": "chihuahua-white-whale",
+                    "chain_id": "chihuahua-1",
+                    "logo_uri": "https://raw.githubusercontent.com/skip-mev/skip-go-registry/main/swap-venues/white-whale/logo.png"
+                },
+                {
+                    "name": "injective-astroport",
+                    "chain_id": "injective-1",
+                    "logo_uri": "https://raw.githubusercontent.com/coinhall/yacar/main/_dex/astroport/logo.svg"
+                },
+                {
+                    "name": "ethereum-uniswap",
+                    "chain_id": "1",
+                    "logo_uri": "https://raw.githubusercontent.com/Uniswap/brand-assets/main/Uniswap%20Brand%20Assets/Uniswap_icon_pink.svg"
+                },
+                {
+                    "name": "binance-uniswap",
+                    "chain_id": "56",
+                    "logo_uri": "https://raw.githubusercontent.com/Uniswap/brand-assets/main/Uniswap%20Brand%20Assets/Uniswap_icon_pink.svg"
+                },
+                {
+                    "name": "polygon-uniswap",
+                    "chain_id": "137",
+                    "logo_uri": "https://raw.githubusercontent.com/Uniswap/brand-assets/main/Uniswap%20Brand%20Assets/Uniswap_icon_pink.svg"
+                },
+                {
+                    "name": "optimism-uniswap",
+                    "chain_id": "10",
+                    "logo_uri": "https://raw.githubusercontent.com/Uniswap/brand-assets/main/Uniswap%20Brand%20Assets/Uniswap_icon_pink.svg"
+                },
+                {
+                    "name": "arbitrum-uniswap",
+                    "chain_id": "42161",
+                    "logo_uri": "https://raw.githubusercontent.com/Uniswap/brand-assets/main/Uniswap%20Brand%20Assets/Uniswap_icon_pink.svg"
+                },
+                {
+                    "name": "base-uniswap",
+                    "chain_id": "8453",
+                    "logo_uri": "https://raw.githubusercontent.com/Uniswap/brand-assets/main/Uniswap%20Brand%20Assets/Uniswap_icon_pink.svg"
+                },
+                {
+                    "name": "celo-uniswap",
+                    "chain_id": "42220",
+                    "logo_uri": "https://raw.githubusercontent.com/Uniswap/brand-assets/main/Uniswap%20Brand%20Assets/Uniswap_icon_pink.svg"
+                },
+                {
+                    "name": "avalanche-uniswap",
+                    "chain_id": "43114",
+                    "logo_uri": "https://raw.githubusercontent.com/Uniswap/brand-assets/main/Uniswap%20Brand%20Assets/Uniswap_icon_pink.svg"
+                },
+                {
+                    "name": "blast-uniswap",
+                    "chain_id": "81457",
+                    "logo_uri": "https://raw.githubusercontent.com/Uniswap/brand-assets/main/Uniswap%20Brand%20Assets/Uniswap_icon_pink.svg"
+                }
+            ]
+        }
+    """.trimIndent()
+}


### PR DESCRIPTION
enables evm swaps by:
- calling the swap venues endpoint and storing the uniswap venues internally in the class. i opted to keep the list as a class variable instead of throwing it into state for the following reasons:
  - it doesn't need to be updated 
  - it doesn't need to be exposed to the clients
  - considering the previous two, feels like a whole lot of boilerplate/overhead for no material gain
  - it should only be referenced specifically for calling skip endpoints and not be available to parts of the code that do not directly work skip endpoints
  - when @ruixhuang 's work to migrate everything to `internalState` is done, we can really easily move it into that state.
- adding the `swap_venues` list to the nonCCTP deposit payload (this enables the request to to include evm swap venues)
- adding `CCTP` to the list of enabled bridges for nonCCTP deposits
  - evm swaps often rely on `CCTP` bridges
  - this means that CCTP enabled chains will route via CCTP even if we don't explicitly mark them as such. fortunately there's no chains that fit this criteria and we're exploring refactorings as a direct follow up to this PR to make sure this doesn't happen (or to unify the 2 paths, if there's no reason to keep the 2 paths separate anymore)