### PR TITLE
fix: fix incorrect size calculation on leverage trade size inputs for cross margin orders

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.86"
+version = "1.8.87"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -60,7 +60,7 @@ internal class TradeInputCalculator(
     ): Map<String, Any> {
         val account = parser.asNativeMap(state["account"])
 
-        val crossMarginSubaccount = parser.asMap(parser.value(account, "subaccounts.$subaccountNumber"))
+        val crossMarginSubaccount = parser.asNativeMap(parser.value(account, "subaccounts.$subaccountNumber"))
         val subaccount = parser.asMap(parser.value(account, "groupedSubaccounts.$subaccountNumber"))
             ?: crossMarginSubaccount
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -74,7 +74,7 @@ internal class TradeInputCalculator(
             subaccountNumber,
         )
 
-        val marginMode = parser.asString(parser.value(trade, "marginMode"))
+        val marginMode = parser.asString(parser.value(trade, "marginMode"))?.let { MarginMode.invoke(it) }
 
         val marketId = parser.asString(trade?.get("marketId"))
         val type = parser.asString(trade?.get("type"))
@@ -90,7 +90,7 @@ internal class TradeInputCalculator(
                         calculateMarketOrderTrade(
                             trade,
                             market,
-                            if (marginMode === "ISOLATED") {
+                            if (marginMode == MarginMode.Isolated) {
                                 subaccount
                             } else {
                                 crossMarginSubaccount

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -59,16 +59,10 @@ internal class TradeInputCalculator(
         input: String?,
     ): Map<String, Any> {
         val account = parser.asNativeMap(state["account"])
-        val fallbackSubaccount = parser.asNativeMap(
-            parser.value(
-                account,
-                "subaccounts.$subaccountNumber",
-            ),
-        )
-        val subaccount = parser.asMap(parser.value(account, "groupedSubaccounts.$subaccountNumber"))
-            ?: fallbackSubaccount
+
         val crossMarginSubaccount = parser.asMap(parser.value(account, "subaccounts.$subaccountNumber"))
-            ?: fallbackSubaccount
+        val subaccount = parser.asMap(parser.value(account, "groupedSubaccounts.$subaccountNumber"))
+            ?: crossMarginSubaccount
 
         val user = parser.asNativeMap(state["user"]) ?: mapOf()
         val markets = parser.asNativeMap(state["markets"])

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.86'
+    spec.version = '1.8.87'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
fix: we were passing in merged subaccount equity which caused significantly incorrect leverage calculations when a user had non trivial margin in isolated positions.

after the fix, it's still not _great_. Our calculation for `position.leverage.post` still doesn't exactly match with our leverage calculations for market trade because:
- the market trade calculation goes through the orderbook and gives a best estimate based on available market prices and order sizes (rather than looking only at oracle price like `position.leverage.post`)
- the market trade calculation also takes into consideration feeRate which `position.leverage.post` does not

in other words, the receipt summary at the bottom of the trade form assumes that account equity does not change with a proposed trade (because it's always reading oraclePrice + no fees) whereas the leverage toggle does. It's pretty non trivial to match up these two calculations in abacus (`position.leverage.post` is calculated  in `SubaccountCalculator` which is missing a lot of the trade data necessary to match the calculations done in `TradeInputCalculator`) so I've left it as is. Will chat with Se more about how we want to proceed here; I sort of feel like just updating the frontend to render `trade.input.size.leverage` into the receipt (instead of `position.leverage.post`) is the easiest thing to do here 🤔 

Honestly, our calculated trades off `usdcSize`/`size` inputs also aren't perfect (leverage is slightly off after the trade is made) for similar reasons.

Also left a TODO to do this properly for isolated margin trades since we're rehauling to remove the concept of leverage per trade, and update it to leverage per position on the isolated market.

