### PR TITLE
chore: update unrealized pnl percent to be based on leverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.91"
+version = "1.8.92"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/SubaccountCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/SubaccountCalculator.kt
@@ -5,6 +5,7 @@ import exchange.dydx.abacus.protocols.ParserProtocol
 import exchange.dydx.abacus.utils.Numeric
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
+import kotlin.math.max
 
 internal enum class CalculationPeriod(val rawValue: String) {
     current("current"),
@@ -158,13 +159,15 @@ internal class SubaccountCalculator(val parser: ParserProtocol) {
                             set(maxLeverage, modified, "maxLeverage", period)
 
                             if (entryPrice != null) {
+                                val leverage = parser.asDouble(value(position, "leverage", period))
+                                val scaledLeverage = max(leverage?.abs() ?: 1.0, 1.0)
                                 val entryValue = size * entryPrice
                                 val currentValue = size * oraclePrice
                                 val unrealizedPnl = currentValue - entryValue
-                                val unrealizedPnlPercent =
-                                    if (entryValue != Numeric.double.ZERO) unrealizedPnl / entryValue.abs() else null
+                                val scaledUnrealizedPnlPercent =
+                                    if (entryValue != Numeric.double.ZERO) unrealizedPnl / entryValue.abs() * scaledLeverage else null
                                 set(unrealizedPnl, modified, "unrealizedPnl", period)
-                                set(unrealizedPnlPercent, modified, "unrealizedPnlPercent", period)
+                                set(scaledUnrealizedPnlPercent, modified, "unrealizedPnlPercent", period)
                             }
 
                             val marginMode = parser.asString(parser.value(position, "marginMode"))

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/SubaccountCalculatorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/SubaccountCalculatorV2.kt
@@ -15,6 +15,7 @@ import exchange.dydx.abacus.state.internalstate.InternalSubaccountCalculated
 import exchange.dydx.abacus.state.internalstate.InternalSubaccountState
 import exchange.dydx.abacus.utils.Numeric
 import indexer.codegen.IndexerPerpetualPositionStatus
+import kotlin.math.max
 
 internal class SubaccountCalculatorV2(
     val parser: ParserProtocol
@@ -395,13 +396,15 @@ internal class SubaccountCalculatorV2(
                             calculated.maxLeverage = maxLeverage
 
                             if (entryPrice != null) {
+                                val leverage = position.calculated[period]?.leverage
+                                val scaledLeverage = max(leverage?.abs() ?: 1.0, 1.0)
                                 val entryValue = size * entryPrice
                                 val currentValue = size * oraclePrice
                                 val unrealizedPnl = currentValue - entryValue
-                                val unrealizedPnlPercent =
-                                    if (entryValue != Numeric.double.ZERO) unrealizedPnl / entryValue.abs() else null
+                                val scaledUnrealizedPnlPercent =
+                                    if (entryValue != Numeric.double.ZERO) unrealizedPnl / entryValue.abs() * scaledLeverage else null
                                 calculated.unrealizedPnl = unrealizedPnl
-                                calculated.unrealizedPnlPercent = unrealizedPnlPercent
+                                calculated.unrealizedPnlPercent = scaledUnrealizedPnlPercent
                             }
 
                             val marginMode = position.marginMode

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4AccountTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4AccountTests.kt
@@ -628,7 +628,7 @@ class V4AccountTests : V4BaseTests() {
                                             "resources": {
                                             },
                                             "unrealizedPnlPercent": {
-                                                "current": 0.4066
+                                                "current": 0.7995
                                             },
                                             "valueTotal": {
                                                 "current": -43112.854562506596
@@ -670,7 +670,7 @@ class V4AccountTests : V4BaseTests() {
                                                 "current": -7.640711804814775E-4
                                             },
                                             "unrealizedPnlPercent": {
-                                                "current": -0.3848
+                                                "current": -0.587
                                             },
                                             "valueTotal": {
                                                 "current": -186164.40898202002

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.91'
+    spec.version = '1.8.92'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
update unrealized pnl percent calculation to match SLTP: multiple percent by scaled leverage

"currently the p&l on positions table doesnt factor the leverage you're using. if you're 10x levered and ETH moves 10%, your P&L should be 100% not 10%. (SL/TP already accounts for leverage)"