### PR TITLE
chore: datadog poc [OTE-719][1/n]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.99"
+version = "1.8.100"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
@@ -355,5 +355,7 @@ interface PresentationProtocol {
 interface LoggingProtocol {
     fun d(tag: String, message: String)
 
-    fun e(tag: String, message: String)
+    fun e(tag: String, message: String, context: Map<String, Any>?, error: Error?)
+
+    fun ddInfo(tag: String, message: String, context: Map<String, Any>?)
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -56,6 +56,7 @@ import exchange.dydx.abacus.utils.toNobleAddress
 import exchange.dydx.abacus.utils.toOsmosisAddress
 import io.ktor.util.encodeBase64
 import kollections.iListOf
+import kollections.toIMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -357,8 +358,10 @@ internal class OnboardingSupervisor(
             val header = iMapOf(
                 "Content-Type" to "application/json",
             )
+            Logger.ddInfo(body.toIMap(), { "retrieveSkipDepositRouteNonCCTP payload sending" })
             helper.post(url, header, body.toJsonPrettyPrint()) { _, response, code, headers ->
                 if (response != null) {
+                    Logger.ddInfo(helper.parser.decodeJsonObject(response), { "retrieveSkipDepositRouteCCTP payload received" })
                     val currentFromAmount = stateMachine.state?.input?.transfer?.size?.size
                     val oldFromAmount = oldState?.input?.transfer?.size?.size
                     if (currentFromAmount == oldFromAmount) {
@@ -415,8 +418,10 @@ internal class OnboardingSupervisor(
         val header = iMapOf(
             "Content-Type" to "application/json",
         )
+        Logger.ddInfo(body.toIMap(), { "retrieveSkipDepositRouteCCTP payload sending" })
         helper.post(url, header, body.toJsonPrettyPrint()) { _, response, code, headers ->
             if (response != null) {
+                Logger.ddInfo(helper.parser.decodeJsonObject(response), { "retrieveSkipDepositRouteCCTP payload received" })
                 val currentFromAmount = stateMachine.state?.input?.transfer?.size?.size
                 val oldFromAmount = oldState?.input?.transfer?.size?.size
                 if (currentFromAmount == oldFromAmount) {
@@ -1139,8 +1144,10 @@ internal class OnboardingSupervisor(
             "Content-Type" to "application/json",
         )
         val oldState = stateMachine.state
+        Logger.ddInfo(body.toIMap(), { "retrieveSkipWithdrawalRouteNonCCTP payload sending" })
         helper.post(url, header, body.toJsonPrettyPrint()) { _, response, code, headers ->
             if (response != null) {
+                Logger.ddInfo(helper.parser.decodeJsonObject(response), { "retrieveSkipWithdrawalRouteNonCCTP payload received" })
                 update(stateMachine.squidRoute(response, subaccountNumber ?: 0, null), oldState)
             } else {
                 Logger.e { "retrieveSkipWithdrawalRouteNonCCTP error, code: $code" }
@@ -1194,8 +1201,10 @@ internal class OnboardingSupervisor(
         val header = iMapOf(
             "Content-Type" to "application/json",
         )
+        Logger.ddInfo(body.toIMap(), { "retrieveSkipWithdrawalRouteCCTP payload sending" })
         helper.post(url, header, body.toJsonPrettyPrint()) { _, response, code, _ ->
             if (response != null) {
+                Logger.ddInfo(helper.parser.decodeJsonObject(response), { "retrieveSkipWithdrawalRouteCCTP payload received" })
                 val currentFromAmount = stateMachine.state?.input?.transfer?.size?.size
                 val oldFromAmount = oldState?.input?.transfer?.size?.size
                 if (currentFromAmount == oldFromAmount) {
@@ -1693,9 +1702,11 @@ internal class OnboardingSupervisor(
             val header = iMapOf(
                 "Content-Type" to "application/json",
             )
+            Logger.ddInfo(body.toIMap(), { "cctpToNobleSkip payload sending" })
             helper.post(url, header, body.toJsonPrettyPrint()) { _, response, code, _ ->
                 val json = helper.parser.decodeJsonObject(response)
                 if (json != null) {
+                    Logger.ddInfo(json, { "cctpToNobleSkip payload received" })
                     val skipRoutePayloadProcessor = SkipRoutePayloadProcessor(parser = helper.parser)
                     val processedPayload = skipRoutePayloadProcessor.received(existing = mapOf(), payload = json)
                     val ibcPayload = helper.parser.asString(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Logger.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Logger.kt
@@ -17,10 +17,18 @@ object Logger {
         }
     }
 
-    fun e(message: () -> String) {
+    fun e(context: Map<String, Any>? = null, error: Error? = null, message: () -> String) {
         clientLogger?.let {
-            it.e(TAG, message())
+            it.e(TAG, message(), context, error)
         } ?: platformErrorLog(message())
+    }
+
+    fun ddInfo(context: Map<String, Any>? = null, message: () -> String) {
+        if (isDebugEnabled) {
+            clientLogger?.let {
+                it.ddInfo(TAG, message(), context)
+            }
+        }
     }
 }
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.99'
+    spec.version = '1.8.100'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
This PR:
- updates Logger.kt's `e` function to accept a context (IMap so its json serializable), and error (i'm using Kotlin's default Error which is probably the wrong type, still investigating this one)
- adds `ddInfo` to Logger.kt. This behaves similarly to `Logger.d` except that it ships logs to datadog and accepts a context IMap