### PR TITLE
Default close position input to use full close (percent input as 1)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.95"
+version = "1.8.96"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
@@ -84,7 +84,7 @@ fun TradingStateMachine.closePosition(
                 trade["targetLeverage"] = if (currentPositionLeverage != null && currentPositionLeverage > 0) currentPositionLeverage else 1.0
 
                 // default full close
-                trade.safeSet("size.percent", 1)
+                trade.safeSet("size.percent", 1.0)
                 trade.safeSet("size.input", "size.percent")
 
                 changes = StateChanges(
@@ -162,7 +162,7 @@ private fun TradingStateMachine.initiateClosePosition(
     trade["side"] = "BUY"
     trade["marketId"] = marketId ?: "ETH-USD"
     // default full close
-    trade.safeSet("size.percent", 1)
+    trade.safeSet("size.percent", 1.0)
     trade.safeSet("size.input", "size.percent")
 
     val calculator = TradeInputCalculator(parser, TradeCalculation.closePosition)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
@@ -157,6 +157,9 @@ private fun TradingStateMachine.initiateClosePosition(
     trade["type"] = "MARKET"
     trade["side"] = "BUY"
     trade["marketId"] = marketId ?: "ETH-USD"
+    // default full close
+    trade.safeSet("size.percent", 1)
+    trade.safeSet("size.input", "size.percent")
 
     val calculator = TradeInputCalculator(parser, TradeCalculation.closePosition)
     val params = mutableMapOf<String, Any>()
@@ -167,7 +170,7 @@ private fun TradingStateMachine.initiateClosePosition(
     params.safeSet("rewardsParams", rewardsParams)
     params.safeSet("configs", configs)
 
-    val modified = calculator.calculate(params, subaccountNumber, null)
+    val modified = calculator.calculate(params, subaccountNumber, "size.percent")
 
     return parser.asMap(modified["trade"])?.mutable() ?: trade
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+ClosePositionInput.kt
@@ -83,6 +83,10 @@ fun TradingStateMachine.closePosition(
                 val currentPositionLeverage = parser.asDouble(parser.value(position, "leverage.current"))?.abs()
                 trade["targetLeverage"] = if (currentPositionLeverage != null && currentPositionLeverage > 0) currentPositionLeverage else 1.0
 
+                // default full close
+                trade.safeSet("size.percent", 1)
+                trade.safeSet("size.input", "size.percent")
+
                 changes = StateChanges(
                     iListOf(Changes.subaccount, Changes.input),
                     null,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
@@ -197,7 +197,6 @@ private fun TradingStateMachine.initiateTrade(
     trade["type"] = "LIMIT"
     trade["side"] = "BUY"
     trade["marketId"] = marketId ?: "ETH-USD"
-    marketId?.let { trade.safeSet("price.limitPrice", getMidMarketPrice(it)) }
 
     val marginMode = MarginCalculator.findExistingMarginModeDeprecated(parser, account, marketId, subaccountNumber)
         ?: MarginCalculator.findMarketMarginModeDeprecated(parser, parser.asNativeMap(parser.value(marketsSummary, "markets.$marketId")))
@@ -419,18 +418,5 @@ private fun TradingStateMachine.validTradeInput(trade: Map<String, Any>, typeTex
         }
     } else {
         true
-    }
-}
-
-fun TradingStateMachine.getMidMarketPrice(
-    marketId: String
-): Double? {
-    val markets = parser.asNativeMap(marketsSummary?.get("markets"))
-    return parser.asNativeMap(parser.asNativeMap(markets?.get(marketId))?.get("orderbook_consolidated"))?.let { orderbook ->
-        parser.asDouble(parser.value(orderbook, "asks.0.price"))?.let { firstAskPrice ->
-            parser.asDouble(parser.value(orderbook, "bids.0.price"))?.let { firstBidPrice ->
-                (firstAskPrice + firstBidPrice) / 2.0
-            }
-        }
     }
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
@@ -197,6 +197,7 @@ private fun TradingStateMachine.initiateTrade(
     trade["type"] = "LIMIT"
     trade["side"] = "BUY"
     trade["marketId"] = marketId ?: "ETH-USD"
+    marketId?.let { trade.safeSet("price.limitPrice", getMidMarketPrice(it)) }
 
     val marginMode = MarginCalculator.findExistingMarginModeDeprecated(parser, account, marketId, subaccountNumber)
         ?: MarginCalculator.findMarketMarginModeDeprecated(parser, parser.asNativeMap(parser.value(marketsSummary, "markets.$marketId")))
@@ -418,5 +419,18 @@ private fun TradingStateMachine.validTradeInput(trade: Map<String, Any>, typeTex
         }
     } else {
         true
+    }
+}
+
+fun TradingStateMachine.getMidMarketPrice(
+    marketId: String
+): Double? {
+    val markets = parser.asNativeMap(marketsSummary?.get("markets"))
+    return parser.asNativeMap(parser.asNativeMap(markets?.get(marketId))?.get("orderbook_consolidated"))?.let { orderbook ->
+        parser.asDouble(parser.value(orderbook, "asks.0.price"))?.let { firstAskPrice ->
+            parser.asDouble(parser.value(orderbook, "bids.0.price"))?.let { firstBidPrice ->
+                (firstAskPrice + firstBidPrice) / 2.0
+            }
+        }
     }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4ClosePositionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4ClosePositionTests.kt
@@ -43,6 +43,11 @@ class V4ClosePositionTests : V4BaseTests() {
                     "closePosition": {
                         "type": "MARKET",
                         "side": "SELL",
+                         "size": {
+                            "percent": 1,
+                            "input": "size.percent",
+                            "size": 10.771
+                        },
                         "reduceOnly": true
                     }
                 }
@@ -175,6 +180,11 @@ class V4ClosePositionTests : V4BaseTests() {
                     "closePosition": {
                         "type": "MARKET",
                         "side": "BUY",
+                         "size": {
+                            "percent": 1,
+                            "input": "size.percent",
+                            "size": 106.179
+                        },
                         "reduceOnly": true
                     }
                 }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.95'
+    spec.version = '1.8.96'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
we were previously setting this manually in web, but we can just move this into abacus
i have an upcoming PR that adds limit close functionality, which will also default to set mid market price as limit price around the same place