### PR TITLE
fix showing one sided liquidity error when it should not

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.100"
+version = "1.8.102"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.9.4"
+version = "1.9.5"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeMarketOrderInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeMarketOrderInputValidator.kt
@@ -141,7 +141,8 @@ internal class TradeMarketOrderInputValidator(
             )
         }
 
-        val summary = parser.asNativeMap(trade["summary"]) ?: return null
+        // summary can be empty even though there's input e.g. leverage input is set to the same as current position leverage
+        val summary = parser.asNativeMap(trade["summary"])?.takeIf { it.isNotEmpty() } ?: return null
         // if there's liquidity for market order to be filled but is missing orderbook slippage (mid price)
         // it is a one sided liquidity situation and should place limit order instead
         parser.asDouble(summary["slippage"])

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.9.4'
+    spec.version = '1.9.5'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.100'
+    spec.version = '1.8.102'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
it depends on summary.slippage. but summary can be a non-null empty object.

<img width="407" alt="image" src="https://github.com/user-attachments/assets/df56effa-2232-4829-a5c3-868cd373f3aa">

<img width="403" alt="image" src="https://github.com/user-attachments/assets/784fab0e-60c9-48cd-b057-c9c028164ce8">

