### PR TITLE
Test new bump version workflow

### DIFF
--- a/.github/workflows/bump_version_on_main.yml
+++ b/.github/workflows/bump_version_on_main.yml
@@ -1,0 +1,63 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - prashan-testing
+  
+jobs:
+  update_version:
+    #if: github.event.pull_request.merged == true
+    runs-on: macos-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          # Fetch full depth, otherwise the last step overwrites the last commit's parent, essentially removing the graph.
+          fetch-depth: 0
+          token: ${{ secrets.BOT_PAT }}
+          ref: ${{ github.head_ref }}
+
+      - name: Import bot's GPG key for signing commits
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Bump version
+        id: bump-version
+        run: |
+          # exit early if current commit was a version bump.
+          git show -s --format=%s | grep -q "^BUMP-VERSION" && exit 0
+          
+          # search for the first line that starts with "version" in build.gradle.kts
+          # get the value in the quotes
+          VERSION=$(grep "^version = " build.gradle.kts | sed -n 's/version = "\(.*\)"/\1/p')
+          
+          # increment the version number
+          NEW_VERSION=$(echo $VERSION | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
+          
+          #if NEW_VERSION is not empty, replace the version in build.gradle.kts and podspec
+          if [ -n "$NEW_VERSION" ]; then
+            sed -i '' "s/version = \"$VERSION\"/version = \"$NEW_VERSION\"/" build.gradle.kts
+            sed -i '' "s/spec.version *= *'[0-9.]*'/spec.version = '$NEW_VERSION'/" v4_abacus.podspec
+            # this condition gets added when kmp generates the pod, but it breaks our iOS dependency flow
+            sed -i '' "s/if \!Dir.exist?('build\/cocoapods\/framework\/Abacus.framework') || Dir.empty?('build\/cocoapods\/framework\/Abacus.framework')/if false/" v4_abacus.podspec
+            echo "Version bumped to $NEW_VERSION"
+          
+            git config --global user.email ${{ steps.import-gpg.outputs.name }}
+            git config --global user.name ${{ steps.import-gpg.outputs.email }}
+          
+            git add build.gradle.kts
+            git add v4_abacus.podspec
+            git commit -S -m "BUMP-VERSION: $NEW_VERSION"
+            git push 
+          fi
+        env:
+            GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+            GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
+            GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
+            GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
+            GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.8.101"
+version = "1.8.102"
 
 repositories {
     google()

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.8.101'
+    spec.version = '1.8.102'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
I've given @mobile-build-bot permission to bypass `main` branch protection.

TODO:
Once this merges, need to add a commit message filter on the `publish` workflow in Bitrise to only run on commits that start with `BUMP-VERSION`