### PR TITLE
fix(isolatedMargin): update isolated margin addition of margin to leave behind buffer for collateralization checks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.9.0"
+version = "1.9.1"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AdjustIsolatedMarginInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/AdjustIsolatedMarginInputCalculator.kt
@@ -3,10 +3,13 @@ package exchange.dydx.abacus.calculator
 import exchange.dydx.abacus.output.input.IsolatedMarginAdjustmentType
 import exchange.dydx.abacus.output.input.IsolatedMarginInputType
 import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.utils.MARGIN_COLLATERALIZATION_CHECK_BUFFER
 import exchange.dydx.abacus.utils.MAX_LEVERAGE_BUFFER_PERCENT
 import exchange.dydx.abacus.utils.Numeric
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
+import kotlin.math.max
+import kotlin.math.min
 
 @Suppress("UNCHECKED_CAST")
 internal class AdjustIsolatedMarginInputCalculator(val parser: ParserProtocol) {
@@ -125,7 +128,9 @@ internal class AdjustIsolatedMarginInputCalculator(val parser: ParserProtocol) {
                             IsolatedMarginAdjustmentType.Add -> {
                                 // The amount to add is a percentage of all add-able margin (your parent subaccount's free collateral)
                                 val amount = baseAmount * amountPercent
-                                modified.safeSet("Amount", amount.toString())
+                                // We leave behind MARGIN_COLLATERALIZATION_CHECK_BUFFER to pass collateralization checks
+                                val cappedAmount = min(max(baseAmount - MARGIN_COLLATERALIZATION_CHECK_BUFFER, 0.0), amount)
+                                modified.safeSet("Amount", cappedAmount.toString())
                             }
                             IsolatedMarginAdjustmentType.Remove -> {
                                 // The amount to remove is a percentage of all remov-able margin (100% puts you at the market's max leveage)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -13,6 +13,7 @@ internal const val SLIPPAGE_PERCENT = "1"
 
 // Isolated Margin Constants
 internal const val MAX_LEVERAGE_BUFFER_PERCENT = 0.98
+internal const val MARGIN_COLLATERALIZATION_CHECK_BUFFER = 0.01;
 
 // Order flags
 internal const val SHORT_TERM_ORDER_FLAGS = 0

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/AdjustIsolatedMarginInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/AdjustIsolatedMarginInputTests.kt
@@ -354,7 +354,7 @@ class AdjustIsolatedMarginInputTests : V4BaseTests(useParentSubaccount = true) {
                     "adjustIsolatedMargin": {
                         "Type": "Remove",
                         "AmountPercent": "1",
-                        "Amount": "1100.00",
+                        "Amount": "1099.77",
                         "AmountInput": "Percent"
                     }
                 }
@@ -384,7 +384,7 @@ class AdjustIsolatedMarginInputTests : V4BaseTests(useParentSubaccount = true) {
                     "adjustIsolatedMargin": {
                         "Type": "Remove",
                         "AmountPercent": "0.1",
-                        "Amount": "110.00",
+                        "Amount": "109.98",
                         "AmountInput": "Percent"
                     }
                 }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.9.0'
+    spec.version = '1.9.1'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
tested locally and found that 100% almost always fails 🫠 . Leaving behind 0.01 seems to almost always work, but this const can be easily adjusted. Basically only applies if we hit the 100% toggle button.