### PR TITLE
chore: add min validation for isolated limit orders

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.9.5"
+version = "1.9.6"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.9.3"
+version = "1.9.4"
 
 repositories {
     google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.9.4"
+version = "1.9.5"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Environment.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Environment.kt
@@ -81,6 +81,7 @@ data class EnvironmentLinks(
     val statusPage: String?,
     val withdrawalGateLearnMore: String?,
     val complianceSupportEmail: String?,
+    val equityTiersLearnMore: String?,
 ) {
     companion object {
         fun parse(
@@ -100,6 +101,7 @@ data class EnvironmentLinks(
             val statusPage = parser.asString(data["statusPage"])
             val withdrawalGateLearnMore = parser.asString(data["withdrawalGateLearnMore"])
             val complianceSupportEmail = parser.asString(data["complianceSupportEmail"])
+            val equityTiersLearnMore = parser.asString(data["equityTiersLearnMore"])
             return EnvironmentLinks(
                 tos,
                 privacy,
@@ -114,6 +116,7 @@ data class EnvironmentLinks(
                 statusPage,
                 withdrawalGateLearnMore,
                 complianceSupportEmail,
+                equityTiersLearnMore,
             )
         }
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/TradeInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/TradeInputValidator.kt
@@ -16,7 +16,7 @@ import exchange.dydx.abacus.validator.trade.TradeAccountStateValidator
 import exchange.dydx.abacus.validator.trade.TradeBracketOrdersValidator
 import exchange.dydx.abacus.validator.trade.TradeFieldsValidator
 import exchange.dydx.abacus.validator.trade.TradeInputDataValidator
-import exchange.dydx.abacus.validator.trade.TradeMarketOrderInputValidator
+import exchange.dydx.abacus.validator.trade.TradeOrderInputValidator
 import exchange.dydx.abacus.validator.trade.TradePositionStateValidator
 import exchange.dydx.abacus.validator.trade.TradeResctrictedValidator
 import exchange.dydx.abacus.validator.trade.TradeTriggerPriceValidator
@@ -30,7 +30,7 @@ internal class TradeInputValidator(
         TradeFieldsValidator(localizer, formatter, parser),
         TradeResctrictedValidator(localizer, formatter, parser),
         TradeInputDataValidator(localizer, formatter, parser),
-        TradeMarketOrderInputValidator(localizer, formatter, parser),
+        TradeOrderInputValidator(localizer, formatter, parser),
         TradeBracketOrdersValidator(localizer, formatter, parser),
         TradeTriggerPriceValidator(localizer, formatter, parser),
         TradePositionStateValidator(localizer, formatter, parser),

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
@@ -87,10 +87,6 @@ internal class TradeOrderInputValidator(
         }
     }
 
-    private fun accountRestricted(): Boolean {
-        return false
-    }
-
     private fun validateMarketOrder(
         trade: Map<String, Any>,
         restricted: Boolean
@@ -165,7 +161,7 @@ internal class TradeOrderInputValidator(
 
                 if (orderEquity < isolatedLimitOrderMinimumEquity) {
                     return createTradeBoxWarningOrError(
-                        errorLevel = if (accountRestricted()) ErrorType.warning else ErrorType.error,
+                        errorLevel = ErrorType.error,
                         errorCode = "ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM",
                         fields = listOf("size.size"),
                         actionStringKey = "APP.TRADE.MODIFY_SIZE_FIELD",
@@ -194,7 +190,7 @@ internal class TradeOrderInputValidator(
 
         if (filled == false) {
             return createTradeBoxWarningOrError(
-                errorLevel = if (accountRestricted()) ErrorType.warning else ErrorType.error,
+                errorLevel = ErrorType.error,
                 errorCode = "MARKET_ORDER_NOT_ENOUGH_LIQUIDITY",
                 fields = listOf("size.size"),
                 actionStringKey = "APP.TRADE.MODIFY_SIZE_FIELD",
@@ -206,7 +202,7 @@ internal class TradeOrderInputValidator(
         // it is a one sided liquidity situation and should place limit order instead
         if (summary != null && summary.slippage == null) {
             return createTradeBoxWarningOrError(
-                errorLevel = if (accountRestricted()) ErrorType.warning else ErrorType.error,
+                errorLevel = ErrorType.error,
                 errorCode = "MARKET_ORDER_ONE_SIDED_LIQUIDITY",
                 fields = listOf("size.size"),
                 actionStringKey = "APP.TRADE.MODIFY_SIZE_FIELD",

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
@@ -123,9 +123,6 @@ internal class TradeOrderInputValidator(
     }
 
     private fun isolatedMarginMinSize(subaccount: Map<String, Any>?, trade: Map<String, Any>, restricted: Boolean): Map<String, Any>? {
-        /*
-        TODO: make a new error type
-         */
         val marginMode = parser.asString(trade.get("marginMode"))?.let {
             MarginMode.invoke(it)
         }
@@ -139,7 +136,7 @@ internal class TradeOrderInputValidator(
                 if (orderEquity < isolatedLimitOrderMinimumEquity) {
                     return createTradeBoxWarningOrErrorDeprecated(
                         errorLevel = if (restricted) "WARNING" else "ERROR",
-                        errorCode = "MARKET_ORDER_NOT_ENOUGH_LIQUIDITY", // TODO: make a new error type
+                        errorCode = "ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM",
                         fields = listOf("size.size"),
                         actionStringKey = "APP.TRADE.MODIFY_SIZE_FIELD",
                     )
@@ -152,9 +149,6 @@ internal class TradeOrderInputValidator(
     }
 
     private fun validateIsolatedMarginMinSize(subaccount: InternalSubaccountState, trade: InternalTradeInputState): ValidationError? {
-        /*
-        TODO: make a new error type
-         */
         return when (trade.marginMode) {
             MarginMode.Isolated -> {
                 val currentFreeCollateral = subaccount.calculated.get(CalculationPeriod.current)?.freeCollateral ?: return null
@@ -164,7 +158,7 @@ internal class TradeOrderInputValidator(
                 if (orderEquity < isolatedLimitOrderMinimumEquity) {
                     return createTradeBoxWarningOrError(
                         errorLevel = if (accountRestricted()) ErrorType.warning else ErrorType.error,
-                        errorCode = "MARKET_ORDER_NOT_ENOUGH_LIQUIDITY", // TODO: make a new error type
+                        errorCode = "ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM",
                         fields = listOf("size.size"),
                         actionStringKey = "APP.TRADE.MODIFY_SIZE_FIELD",
                     )

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
@@ -14,6 +14,7 @@ import exchange.dydx.abacus.state.internalstate.InternalState
 import exchange.dydx.abacus.state.internalstate.InternalSubaccountState
 import exchange.dydx.abacus.state.internalstate.InternalTradeInputState
 import exchange.dydx.abacus.state.manager.V4Environment
+import exchange.dydx.abacus.utils.Numeric
 import exchange.dydx.abacus.validator.BaseInputValidator
 import exchange.dydx.abacus.validator.PositionChange
 import exchange.dydx.abacus.validator.TradeValidatorProtocol
@@ -130,7 +131,7 @@ internal class TradeOrderInputValidator(
                 val postFreeCollateral = parser.asDouble(parser.value(subaccount, "freeCollateral.postOrder")) ?: return null
                 val orderEquity = postFreeCollateral - currentFreeCollateral
 
-                if (orderEquity < isolatedLimitOrderMinimumEquity) {
+                if (postFreeCollateral >= Numeric.double.ZERO && orderEquity < isolatedLimitOrderMinimumEquity) {
                     return createTradeBoxWarningOrErrorDeprecated(
                         errorLevel = if (restricted) "WARNING" else "ERROR",
                         errorCode = "ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM",
@@ -159,7 +160,7 @@ internal class TradeOrderInputValidator(
                 val postFreeCollateral = subaccount.calculated.get(CalculationPeriod.post)?.freeCollateral ?: return null
                 val orderEquity = postFreeCollateral - currentFreeCollateral
 
-                if (orderEquity < isolatedLimitOrderMinimumEquity) {
+                if (postFreeCollateral >= Numeric.double.ZERO && orderEquity < isolatedLimitOrderMinimumEquity) {
                     return createTradeBoxWarningOrError(
                         errorLevel = ErrorType.error,
                         errorCode = "ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM",

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
@@ -25,7 +25,7 @@ internal class TradeOrderInputValidator(
 ) : BaseInputValidator(localizer, formatter, parser), TradeValidatorProtocol {
     private val marketOrderErrorSlippage = 0.1
     private val marketOrderWarningSlippage = 0.05
-    private val isolatedLimitOrderMinimumEquity = 20
+    private val isolatedLimitOrderMinimumEquity = 20.0
 
     override fun validateTrade(
         internalState: InternalState,
@@ -139,6 +139,12 @@ internal class TradeOrderInputValidator(
                         errorCode = "ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM",
                         fields = listOf("size.size"),
                         actionStringKey = "APP.TRADE.MODIFY_SIZE_FIELD",
+                        textParams = mapOf(
+                            "MIN_VALUE" to mapOf(
+                                "value" to isolatedLimitOrderMinimumEquity,
+                                "format" to "price",
+                            ),
+                        ),
                     )
                 } else {
                     return null
@@ -161,6 +167,12 @@ internal class TradeOrderInputValidator(
                         errorCode = "ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM",
                         fields = listOf("size.size"),
                         actionStringKey = "APP.TRADE.MODIFY_SIZE_FIELD",
+                        textParams = mapOf(
+                            "MIN_VALUE" to mapOf(
+                                "value" to isolatedLimitOrderMinimumEquity,
+                                "format" to "price",
+                            ),
+                        ),
                     )
                 }
                 return null
@@ -259,18 +271,25 @@ internal class TradeOrderInputValidator(
             minSlippageValue = indexSlippage
         }
 
+        val textParams = mapOf(
+            "SLIPPAGE" to mapOf(
+                "value" to minSlippageValue,
+                "format" to "percent",
+            ),
+        )
+
         return when {
             minSlippageValue >= marketOrderErrorSlippage -> createTradeBoxWarningOrError(
                 errorLevel = if (restricted) ErrorType.warning else ErrorType.error,
                 errorCode = "MARKET_ORDER_ERROR_${slippageType}_SLIPPAGE",
                 actionStringKey = "APP.TRADE.PLACE_LIMIT_ORDER",
-                slippagePercentValue = minSlippageValue,
+                textParams = textParams,
             )
             minSlippageValue >= marketOrderWarningSlippage -> createTradeBoxWarningOrError(
                 errorLevel = ErrorType.warning,
                 errorCode = "MARKET_ORDER_WARNING_${slippageType}_SLIPPAGE",
                 actionStringKey = "APP.TRADE.PLACE_LIMIT_ORDER",
-                slippagePercentValue = minSlippageValue,
+                textParams = textParams,
             )
             else -> null
         }
@@ -307,13 +326,23 @@ internal class TradeOrderInputValidator(
                 errorLevel = if (restricted) "WARNING" else "ERROR",
                 errorCode = "MARKET_ORDER_ERROR_${slippageType}_SLIPPAGE",
                 actionStringKey = "APP.TRADE.PLACE_LIMIT_ORDER",
-                slippagePercentValue = minSlippageValue,
+                textParams = mapOf(
+                    "SLIPPAGE" to mapOf(
+                        "value" to minSlippageValue,
+                        "format" to "percent",
+                    ),
+                ),
             )
             minSlippageValue >= marketOrderWarningSlippage -> createTradeBoxWarningOrErrorDeprecated(
                 errorLevel = "WARNING",
                 errorCode = "MARKET_ORDER_WARNING_${slippageType}_SLIPPAGE",
                 actionStringKey = "APP.TRADE.PLACE_LIMIT_ORDER",
-                slippagePercentValue = minSlippageValue,
+                textParams = mapOf(
+                    "SLIPPAGE" to mapOf(
+                        "value" to minSlippageValue,
+                        "format" to "percent",
+                    ),
+                ),
             )
             else -> null
         }
@@ -324,7 +353,7 @@ internal class TradeOrderInputValidator(
         errorCode: String,
         fields: List<String>? = null,
         actionStringKey: String? = null,
-        slippagePercentValue: Double? = null
+        textParams: Map<String, Any>? = null
     ): Map<String, Any> {
         return errorDeprecated(
             type = errorLevel,
@@ -333,14 +362,7 @@ internal class TradeOrderInputValidator(
             actionStringKey = actionStringKey,
             titleStringKey = "ERRORS.TRADE_BOX_TITLE.$errorCode",
             textStringKey = "ERRORS.TRADE_BOX.$errorCode",
-            textParams = slippagePercentValue?.let {
-                mapOf(
-                    "SLIPPAGE" to mapOf(
-                        "value" to it,
-                        "format" to "percent",
-                    ),
-                )
-            },
+            textParams = textParams,
         )
     }
 
@@ -349,7 +371,7 @@ internal class TradeOrderInputValidator(
         errorCode: String,
         fields: List<String>? = null,
         actionStringKey: String? = null,
-        slippagePercentValue: Double? = null
+        textParams: Map<String, Any>? = null
     ): ValidationError {
         return error(
             type = errorLevel,
@@ -358,14 +380,7 @@ internal class TradeOrderInputValidator(
             actionStringKey = actionStringKey,
             titleStringKey = "ERRORS.TRADE_BOX_TITLE.$errorCode",
             textStringKey = "ERRORS.TRADE_BOX.$errorCode",
-            textParams = slippagePercentValue?.let {
-                mapOf(
-                    "SLIPPAGE" to mapOf(
-                        "value" to it,
-                        "format" to "percent",
-                    ),
-                )
-            },
+            textParams = textParams,
         )
     }
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
@@ -129,7 +129,7 @@ internal class TradeOrderInputValidator(
             MarginMode.Isolated -> {
                 val currentFreeCollateral = parser.asDouble(parser.value(subaccount, "freeCollateral.current")) ?: return null
                 val postFreeCollateral = parser.asDouble(parser.value(subaccount, "freeCollateral.postOrder")) ?: return null
-                val orderEquity = postFreeCollateral - currentFreeCollateral
+                val orderEquity = currentFreeCollateral - postFreeCollateral
 
                 if (postFreeCollateral >= Numeric.double.ZERO && orderEquity < isolatedLimitOrderMinimumEquity) {
                     return createTradeBoxWarningOrErrorDeprecated(
@@ -158,7 +158,7 @@ internal class TradeOrderInputValidator(
             MarginMode.Isolated -> {
                 val currentFreeCollateral = subaccount.calculated.get(CalculationPeriod.current)?.freeCollateral ?: return null
                 val postFreeCollateral = subaccount.calculated.get(CalculationPeriod.post)?.freeCollateral ?: return null
-                val orderEquity = postFreeCollateral - currentFreeCollateral
+                val orderEquity = currentFreeCollateral - postFreeCollateral
 
                 if (postFreeCollateral >= Numeric.double.ZERO && orderEquity < isolatedLimitOrderMinimumEquity) {
                     return createTradeBoxWarningOrError(

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
@@ -484,7 +484,14 @@ open class V4TradeInputTests : V4BaseTests() {
                                     "stringKey": "ERRORS.TRADE_BOX_TITLE.ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM"
                                 },
                                 "text": {
-                                    "stringKey": "ERRORS.TRADE_BOX.ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM"
+                                    "stringKey": "ERRORS.TRADE_BOX.ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM",
+                                    "params": [
+                                        {
+                                            "value": 20.0,
+                                            "format": "price",
+                                            "key": "MIN_VALUE"
+                                        }
+                                    ]
                                 },
                                 "action": {
                                     "stringKey": "APP.TRADE.MODIFY_SIZE_FIELD"

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
@@ -49,12 +49,18 @@ open class V4TradeInputTests : V4BaseTests() {
     }
 
     private fun testOnce() {
+        testIsolatedLimitTradeInputOnce()
+
         testMarketTradeInputOnce()
         testLimitTradeInputOnce()
         testUpdates()
     }
 
     private fun testLimitTradeInputOnce() {
+        test({
+            perp.trade("CROSS", TradeInputField.marginMode, 0)
+        }, null)
+
         test(
             {
                 perp.tradeInMarket("ETH-USD", 0)
@@ -225,10 +231,6 @@ open class V4TradeInputTests : V4BaseTests() {
             """.trimIndent(),
         )
 
-//        test({
-//            perp.trade(null, TradeInputField.limitPrice)
-//        }, null)
-
         test({
             perp.trade("1500", TradeInputField.limitPrice, 0)
         }, null)
@@ -293,6 +295,10 @@ open class V4TradeInputTests : V4BaseTests() {
     }
 
     private fun testMarketTradeInputOnce() {
+        test({
+            perp.trade("CROSS", TradeInputField.marginMode, 0)
+        }, null)
+
         test({
             perp.trade("MARKET", TradeInputField.type, 0)
         }, null)
@@ -412,7 +418,116 @@ open class V4TradeInputTests : V4BaseTests() {
         )
     }
 
+    private fun testIsolatedLimitTradeInputOnce() {
+        test(
+            {
+                perp.tradeInMarket("BTC-USD", 0)
+            },
+            """
+            {
+                "input": {
+                    "trade": {
+                        "marketId": "BTC-USD"
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+        test({
+            perp.trade("ISOLATED", TradeInputField.marginMode, 0)
+        }, null)
+
+        test({
+            perp.trade("LIMIT", TradeInputField.type, 0)
+        }, null)
+
+        test({
+            perp.trade("BUY", TradeInputField.side, 0)
+        }, null)
+
+        test({
+            perp.trade("12", TradeInputField.goodTilDuration, 0)
+        }, null)
+
+        test({
+            perp.trade("0.01", TradeInputField.size, 0)
+        }, null)
+
+        // TODO update with new error
+        test(
+            {
+                perp.trade("1500", TradeInputField.limitPrice, 0)
+            },
+            """
+            {
+                "wallet": {
+                    "account": {
+                        "subaccounts": {
+                            "0": {
+                                "freeCollateral": {
+                                    "current": 100000.0,
+                                    "postOrder": 99985.0
+                                }
+                            }
+                        }
+                    }
+                },
+                "input": {
+                    "errors": [
+                        {
+                            "type": "ERROR",
+                            "code": "MARKET_ORDER_NOT_ENOUGH_LIQUIDITY",
+                            "fields": [
+                                "size.size"
+                            ],
+                            "resources": {
+                                "title": {
+                                    "stringKey": "ERRORS.TRADE_BOX_TITLE.MARKET_ORDER_NOT_ENOUGH_LIQUIDITY"
+                                },
+                                "text": {
+                                    "stringKey": "ERRORS.TRADE_BOX.MARKET_ORDER_NOT_ENOUGH_LIQUIDITY"
+                                },
+                                "action": {
+                                    "stringKey": "APP.TRADE.MODIFY_SIZE_FIELD"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+            """.trimIndent(),
+        )
+
+        test(
+            {
+                perp.trade("0", TradeInputField.size, 0)
+            },
+            """
+            {
+                "wallet": {
+                    "account": {
+                        "subaccounts": {
+                            "0": {
+                                "equity": {
+                                    "current": 100000.0,
+                                    "postOrder": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "input": {
+                    "errors": []
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
     private fun testUpdates() {
+        test({
+            perp.trade("CROSS", TradeInputField.marginMode, 0)
+        }, null)
         test(
             {
                 perp.socket(testWsUrl, mock.accountsChannel.v4_subaccounts_update_1, 0, null)
@@ -677,6 +792,10 @@ open class V4TradeInputTests : V4BaseTests() {
     }
 
     private fun testAdjustedMarginFraction() {
+        test({
+            perp.trade("CROSS", TradeInputField.marginMode, 0)
+        }, null)
+
         test(
             {
                 perp.socket(
@@ -733,6 +852,10 @@ open class V4TradeInputTests : V4BaseTests() {
     fun testConditional() {
         test({
             perp.trade("STOP_LIMIT", TradeInputField.type, 0)
+        }, null)
+
+        test({
+            perp.trade("CROSS", TradeInputField.marginMode, 0)
         }, null)
 
         test({
@@ -848,6 +971,10 @@ open class V4TradeInputTests : V4BaseTests() {
     }
 
     fun testReduceOnly() {
+        test({
+            perp.trade("CROSS", TradeInputField.marginMode, 0)
+        }, null)
+
         test(
             {
                 perp.trade("MARKET", TradeInputField.type, 0)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
@@ -479,6 +479,8 @@ open class V4TradeInputTests : V4BaseTests() {
                             "fields": [
                                 "size.size"
                             ],
+                            "linkText": "APP.GENERAL.LEARN_MORE_ARROW",
+                            "link": "https://help.dydx.trade/en/articles/171918-equity-tiers-and-rate-limits",
                             "resources": {
                                 "title": {
                                     "stringKey": "ERRORS.TRADE_BOX_TITLE.ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM"

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
@@ -508,6 +508,31 @@ open class V4TradeInputTests : V4BaseTests() {
 
         test(
             {
+                perp.trade("0.1", TradeInputField.size, 0)
+            },
+            """
+            {
+                "wallet": {
+                    "account": {
+                        "subaccounts": {
+                            "0": {
+                                "equity": {
+                                    "current": 100000.0,
+                                    "postOrder": 99850.0
+                                }
+                            }
+                        }
+                    }
+                },
+                "input": {
+                    "errors": null
+                }
+            }
+            """.trimIndent(),
+        )
+
+        test(
+            {
                 perp.trade("0", TradeInputField.size, 0)
             },
             """
@@ -525,7 +550,20 @@ open class V4TradeInputTests : V4BaseTests() {
                     }
                 },
                 "input": {
-                    "errors": []
+                    "errors": [
+                        {
+                            "type": "REQUIRED",
+                            "code": "REQUIRED_SIZE",
+                            "fields": [
+                                "size.size"
+                            ],
+                            "resources": {
+                                "action": {
+                                    "stringKey": "APP.TRADE.ENTER_AMOUNT"
+                                }
+                            }
+                        }
+                    ]
                 }
             }
             """.trimIndent(),

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
@@ -453,7 +453,6 @@ open class V4TradeInputTests : V4BaseTests() {
             perp.trade("0.01", TradeInputField.size, 0)
         }, null)
 
-        // TODO update with new error
         test(
             {
                 perp.trade("1500", TradeInputField.limitPrice, 0)
@@ -476,16 +475,16 @@ open class V4TradeInputTests : V4BaseTests() {
                     "errors": [
                         {
                             "type": "ERROR",
-                            "code": "MARKET_ORDER_NOT_ENOUGH_LIQUIDITY",
+                            "code": "ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM",
                             "fields": [
                                 "size.size"
                             ],
                             "resources": {
                                 "title": {
-                                    "stringKey": "ERRORS.TRADE_BOX_TITLE.MARKET_ORDER_NOT_ENOUGH_LIQUIDITY"
+                                    "stringKey": "ERRORS.TRADE_BOX_TITLE.ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM"
                                 },
                                 "text": {
-                                    "stringKey": "ERRORS.TRADE_BOX.MARKET_ORDER_NOT_ENOUGH_LIQUIDITY"
+                                    "stringKey": "ERRORS.TRADE_BOX.ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM"
                                 },
                                 "action": {
                                     "stringKey": "APP.TRADE.MODIFY_SIZE_FIELD"

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AbacusMockData.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AbacusMockData.kt
@@ -3,6 +3,7 @@ package exchange.dydx.abacus.tests.payloads
 import exchange.dydx.abacus.state.app.adaptors.AbUrl
 import exchange.dydx.abacus.state.manager.EnvironmentEndpoints
 import exchange.dydx.abacus.state.manager.EnvironmentFeatureFlags
+import exchange.dydx.abacus.state.manager.EnvironmentLinks
 import exchange.dydx.abacus.state.manager.TokenInfo
 import exchange.dydx.abacus.state.manager.V4Environment
 import exchange.dydx.abacus.state.manager.WalletConnect
@@ -69,7 +70,22 @@ class AbacusMockData {
             nobleValidator = null,
             geo = null,
         ),
-        null,
+        EnvironmentLinks(
+            tos = "https://dydx.exchange/v4-terms",
+            privacy = "https://dydx.exchange/privacy",
+            mintscan = "https://testnet.mintscan.io/dydx-testnet/txs/{tx_hash}",
+            mintscanBase = "https://testnet.mintscan.io/dydx-testnet",
+            documentation = "https://v4-teacher.vercel.app/",
+            community = "https://discord.com/invite/dydx",
+            feedback = "https://docs.google.com/forms/d/e/1FAIpQLSezLsWCKvAYDEb7L-2O4wOON1T56xxro9A2Azvl6IxXHP_15Q/viewform",
+            blogs = "https://www.dydx.foundation/blog",
+            help = "https://help.dydx.exchange/",
+            launchIncentive = "https://dydx.exchange/v4-launch-incentive",
+            statusPage = "https://status.v4testnet.dydx.exchange/",
+            withdrawalGateLearnMore = "https://help.dydx.exchange/en/articles/8981384-withdrawals-on-dydx-chain#h_23e97bc665",
+            complianceSupportEmail = "someemail@gmail.com",
+            equityTiersLearnMore = "https://help.dydx.trade/en/articles/171918-equity-tiers-and-rate-limits",
+        ),
         WalletConnection(
             WalletConnect(
                 WalletConnectClient(

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/EnvironmentsMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/EnvironmentsMock.kt
@@ -43,7 +43,8 @@ class EnvironmentsMock {
                     "community":"https://discord.com/invite/dydx",
                     "feedback":"https://docs.google.com/forms/d/e/1FAIpQLSezLsWCKvAYDEb7L-2O4wOON1T56xxro9A2Azvl6IxXHP_15Q/viewform",
                     "launchIncentive":"https://dydx.exchange/v4-launch-incentive",
-                    "complianceSupportEmail":"someemail@gmail.com"
+                    "complianceSupportEmail":"someemail@gmail.com",
+                    "equityTiersLearnMore":"https://help.dydx.trade/en/articles/171918-equity-tiers-and-rate-limits"
                }
            },
            "wallets": {

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.9.4'
+    spec.version = '1.9.5'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.9.5'
+    spec.version = '1.9.6'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.9.3'
+    spec.version = '1.9.4'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Add validation for isolated margin limit orders so that traders can't place orders <$20 total equity.

Renamed `TradeMarketOrderInputValidator` -> `TradeOrderInputValidator`
- Added `const isolatedLimitOrderMinimumEquity = 20`
- Added logic for validating that isolated margin limit orders (and stop limit and take profit limit) are using at least 20 dollars of equity by comparing post freeCollateral with current freeCollateral
  - Wrote 2 versions (one is statically typed, one isn't)
  - Error: `ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM` - https://github.com/dydxprotocol/v4-localization/pull/670

Added tests in `V4TradeInputTests`

I don't think our FE is reading in the link stuff rn, but willl dig in more. Here is proof of concept of it working:


https://github.com/user-attachments/assets/a53ba2b4-f67a-44af-ac7c-ec67151dc2ae


