### PR TITLE
ignore meeeee: attempt batch cancel support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.9.3"
+version = "1.9.8"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
@@ -147,6 +147,7 @@ enum class QueryType(val rawValue: String) {
 enum class TransactionType(val rawValue: String) {
     PlaceOrder("placeOrder"),
     CancelOrder("cancelOrder"),
+    BatchCancel("batchCancel"),
     Deposit("deposit"),
     Withdraw("withdraw"),
     SubaccountTransfer("subaccountTransfer"),

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
@@ -63,6 +63,7 @@ interface AsyncAbacusStateManagerProtocol {
     fun closePositionPayload(): HumanReadablePlaceOrderPayload?
     fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload?
     fun cancelOrderPayload(orderId: String): HumanReadableCancelOrderPayload?
+    fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload?
     fun depositPayload(): HumanReadableDepositPayload?
     fun withdrawPayload(): HumanReadableWithdrawPayload?
     fun subaccountTransferPayload(): HumanReadableSubaccountTransferPayload?
@@ -80,7 +81,7 @@ interface AsyncAbacusStateManagerProtocol {
     // Commit changes with params
     fun faucet(amount: Double, callback: TransactionCallback)
     fun cancelOrder(orderId: String, callback: TransactionCallback)
-    fun cancelOrders(orderIds: IList<String>, callback: TransactionCallback)
+    fun cancelOrders(marketId: String?, callback: TransactionCallback)
 
     // Bridge functions.
     // If client is not using cancelOrder function, it should call orderCanceled function with

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
@@ -80,6 +80,7 @@ interface AsyncAbacusStateManagerProtocol {
     // Commit changes with params
     fun faucet(amount: Double, callback: TransactionCallback)
     fun cancelOrder(orderId: String, callback: TransactionCallback)
+    fun cancelOrders(orderIds: IList<String>, callback: TransactionCallback)
 
     // Bridge functions.
     // If client is not using cancelOrder function, it should call orderCanceled function with

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
@@ -29,7 +29,7 @@ data class CancelOrderRecord(
     val subaccountNumber: Int,
     val clientId: Int,
     val timestampInMilliseconds: Double,
-    val fromSlTpDialog: Boolean,
+    val fromSlTpDialog: Boolean = false,
 )
 
 data class IsolatedPlaceOrderRecord(
@@ -86,6 +86,7 @@ data class HumanReadableCancelOrderPayload(
 @JsExport
 @Serializable
 data class HumanReadableCancelMultipleOrdersPayload(
+    val orderIds: IList<String>,
     val shortTermCancelPayloads: IList<HumanReadableBatchCancelPayload>,
     val statefulCancelPayloads: IList<HumanReadableCancelOrderPayload>,
 )

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
@@ -85,6 +85,28 @@ data class HumanReadableCancelOrderPayload(
 
 @JsExport
 @Serializable
+data class HumanReadableCancelMultipleOrdersPayload(
+    val shortTermCancelPayloads: IList<HumanReadableBatchCancelPayload>,
+    val statefulCancelPayloads: IList<HumanReadableCancelOrderPayload>,
+)
+
+@JsExport
+@Serializable
+data class HumanReadableOrderBatchPayload(
+    val clobPairId: Int,
+    val clientIds: IList<Int>,
+)
+
+@JsExport
+@Serializable
+data class HumanReadableBatchCancelPayload(
+    val subaccountNumber: Int,
+    val shortTermOrders: IList<HumanReadableOrderBatchPayload>,
+    val goodTilBlock: Int,
+)
+
+@JsExport
+@Serializable
 data class HumanReadableTriggerOrdersPayload(
     val marketId: String,
     val positionSize: Double?,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
@@ -23,6 +23,7 @@ import exchange.dydx.abacus.state.manager.ConfigFile
 import exchange.dydx.abacus.state.manager.GasToken
 import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
+import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -503,6 +504,10 @@ class AsyncAbacusStateManagerV2(
         return adaptor?.cancelOrderPayload(orderId)
     }
 
+    override fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload? {
+        return adaptor?.cancelOrdersPayload(marketId)
+    }
+
     override fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload? {
         return adaptor?.triggerOrdersPayload()
     }
@@ -603,9 +608,9 @@ class AsyncAbacusStateManagerV2(
         }
     }
 
-    override fun cancelOrders(orderIds: IList<String>, callback: TransactionCallback) {
+    override fun cancelOrders(marketId: String?, callback: TransactionCallback) {
         try {
-            adaptor?.cancelOrders(orderIds, callback)
+            adaptor?.cancelOrders(marketId, callback)
         } catch (e: Exception) {
             val error = V4TransactionErrors.error(null, e.toString())
             callback(false, error, null)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
@@ -603,6 +603,15 @@ class AsyncAbacusStateManagerV2(
         }
     }
 
+    override fun cancelOrders(orderIds: IList<String>, callback: TransactionCallback) {
+        try {
+            adaptor?.cancelOrders(orderIds, callback)
+        } catch (e: Exception) {
+            val error = V4TransactionErrors.error(null, e.toString())
+            callback(false, error, null)
+        }
+    }
+
     override fun triggerCompliance(action: ComplianceAction, callback: TransactionCallback) {
         try {
             adaptor?.triggerCompliance(action, callback)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
@@ -58,6 +58,7 @@ import exchange.dydx.abacus.state.v2.supervisor.adjustIsolatedMargin
 import exchange.dydx.abacus.state.v2.supervisor.adjustIsolatedMarginPayload
 import exchange.dydx.abacus.state.v2.supervisor.cancelOrder
 import exchange.dydx.abacus.state.v2.supervisor.cancelOrderPayload
+import exchange.dydx.abacus.state.v2.supervisor.cancelOrders
 import exchange.dydx.abacus.state.v2.supervisor.closePosition
 import exchange.dydx.abacus.state.v2.supervisor.closePositionPayload
 import exchange.dydx.abacus.state.v2.supervisor.commitAdjustIsolatedMargin
@@ -593,6 +594,10 @@ internal class StateManagerAdaptorV2(
 
     internal fun cancelOrder(orderId: String, callback: TransactionCallback) {
         accounts.cancelOrder(orderId, callback)
+    }
+
+    internal fun cancelOrders(orderIds: List<String>, callback: TransactionCallback) {
+        accounts.cancelOrders(orderIds, currentHeight = currentHeight, callback)
     }
 
     internal fun orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
@@ -26,6 +26,7 @@ import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.GasToken
 import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
+import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -59,6 +60,7 @@ import exchange.dydx.abacus.state.v2.supervisor.adjustIsolatedMarginPayload
 import exchange.dydx.abacus.state.v2.supervisor.cancelOrder
 import exchange.dydx.abacus.state.v2.supervisor.cancelOrderPayload
 import exchange.dydx.abacus.state.v2.supervisor.cancelOrders
+import exchange.dydx.abacus.state.v2.supervisor.cancelOrdersPayload
 import exchange.dydx.abacus.state.v2.supervisor.closePosition
 import exchange.dydx.abacus.state.v2.supervisor.closePositionPayload
 import exchange.dydx.abacus.state.v2.supervisor.commitAdjustIsolatedMargin
@@ -538,6 +540,10 @@ internal class StateManagerAdaptorV2(
         return accounts.cancelOrderPayload(orderId)
     }
 
+    internal fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload? {
+        return accounts.cancelOrdersPayload(marketId, currentHeight)
+    }
+
     internal fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload? {
         return accounts.triggerOrdersPayload(currentHeight)
     }
@@ -596,8 +602,8 @@ internal class StateManagerAdaptorV2(
         accounts.cancelOrder(orderId, callback)
     }
 
-    internal fun cancelOrders(orderIds: List<String>, callback: TransactionCallback) {
-        accounts.cancelOrders(orderIds, currentHeight = currentHeight, callback)
+    internal fun cancelOrders(marketId: String?, callback: TransactionCallback) {
+        accounts.cancelOrders(marketId, currentHeight = currentHeight, callback)
     }
 
     internal fun orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -21,6 +21,7 @@ import exchange.dydx.abacus.state.changes.StateChanges
 import exchange.dydx.abacus.state.manager.ApiData
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
+import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -1180,6 +1181,13 @@ internal fun AccountSupervisor.cancelOrderPayload(
     return subaccount?.cancelOrderPayload(orderId)
 }
 
+internal fun AccountSupervisor.cancelOrdersPayload(
+    marketId: String?,
+    currentHeight: Int?
+): HumanReadableCancelMultipleOrdersPayload? {
+    return subaccount?.cancelOrdersPayload(marketId, currentHeight)
+}
+
 internal fun AccountSupervisor.depositPayload(): HumanReadableDepositPayload? {
     return subaccount?.depositPayload()
 }
@@ -1231,8 +1239,8 @@ internal fun AccountSupervisor.cancelOrder(orderId: String, callback: Transactio
     subaccount?.cancelOrder(orderId = orderId, callback = callback)
 }
 
-internal fun AccountSupervisor.cancelOrders(orderIds: List<String>, currentHeight: Int?, callback: TransactionCallback) {
-    subaccount?.cancelOrders(orderIds, currentHeight, callback)
+internal fun AccountSupervisor.cancelOrders(marketId: String?, currentHeight: Int?, callback: TransactionCallback) {
+    subaccount?.cancelOrders(marketId, currentHeight, callback)
 }
 
 internal fun AccountSupervisor.orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -1231,6 +1231,10 @@ internal fun AccountSupervisor.cancelOrder(orderId: String, callback: Transactio
     subaccount?.cancelOrder(orderId = orderId, callback = callback)
 }
 
+internal fun AccountSupervisor.cancelOrders(orderIds: List<String>, currentHeight: Int?, callback: TransactionCallback) {
+    subaccount?.cancelOrders(orderIds, currentHeight, callback)
+}
+
 internal fun AccountSupervisor.orderCanceled(orderId: String) {
     subaccount?.orderCanceled(orderId)
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
@@ -15,6 +15,7 @@ import exchange.dydx.abacus.state.manager.ApiData
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
+import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -275,6 +276,10 @@ internal fun AccountsSupervisor.cancelOrderPayload(orderId: String): HumanReadab
     return account?.cancelOrderPayload(orderId)
 }
 
+internal fun AccountsSupervisor.cancelOrdersPayload(marketId: String?, currentHeight: Int?): HumanReadableCancelMultipleOrdersPayload? {
+    return account?.cancelOrdersPayload(marketId, currentHeight)
+}
+
 internal fun AccountsSupervisor.depositPayload(): HumanReadableDepositPayload? {
     return account?.depositPayload()
 }
@@ -337,8 +342,8 @@ internal fun AccountsSupervisor.cancelOrder(orderId: String, callback: Transacti
     account?.cancelOrder(orderId, callback)
 }
 
-internal fun AccountsSupervisor.cancelOrders(orderIds: List<String>, currentHeight: Int?, callback: TransactionCallback) {
-    account?.cancelOrders(orderIds, currentHeight, callback)
+internal fun AccountsSupervisor.cancelOrders(marketId: String?, currentHeight: Int?, callback: TransactionCallback) {
+    account?.cancelOrders(marketId, currentHeight, callback)
 }
 
 internal fun AccountsSupervisor.orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
@@ -337,6 +337,10 @@ internal fun AccountsSupervisor.cancelOrder(orderId: String, callback: Transacti
     account?.cancelOrder(orderId, callback)
 }
 
+internal fun AccountsSupervisor.cancelOrders(orderIds: List<String>, currentHeight: Int?, callback: TransactionCallback) {
+    account?.cancelOrders(orderIds, currentHeight, callback)
+}
+
 internal fun AccountsSupervisor.orderCanceled(orderId: String) {
     account?.orderCanceled(orderId)
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -14,6 +14,7 @@ import exchange.dydx.abacus.state.changes.StateChanges
 import exchange.dydx.abacus.state.manager.ApiData
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.FaucetRecord
+import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadableFaucetPayload
@@ -423,6 +424,10 @@ internal class SubaccountSupervisor(
 
     internal fun cancelOrder(orderId: String, isOrphanedTriggerOrder: Boolean = false, callback: TransactionCallback): HumanReadableCancelOrderPayload {
         return transactionSupervisor.cancelOrder(orderId, isOrphanedTriggerOrder, callback)
+    }
+
+    internal fun cancelOrders(orderIds: List<String>, currentHeight: Int?, callback: TransactionCallback): HumanReadableCancelMultipleOrdersPayload? {
+        return transactionSupervisor.cancelOrders(orderIds, currentHeight, callback)
     }
 
     internal fun commitTriggerOrders(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -329,6 +329,10 @@ internal class SubaccountSupervisor(
         return payloadProvider.cancelOrderPayload(orderId)
     }
 
+    internal fun cancelOrdersPayload(marketId: String?, currentHeight: Int?): HumanReadableCancelMultipleOrdersPayload? {
+        return payloadProvider.cancelOrdersPayload(marketId, currentHeight)
+    }
+
     fun trade(
         data: String?,
         type: TradeInputField?,
@@ -426,8 +430,8 @@ internal class SubaccountSupervisor(
         return transactionSupervisor.cancelOrder(orderId, isOrphanedTriggerOrder, callback)
     }
 
-    internal fun cancelOrders(orderIds: List<String>, currentHeight: Int?, callback: TransactionCallback): HumanReadableCancelMultipleOrdersPayload? {
-        return transactionSupervisor.cancelOrders(orderIds, currentHeight, callback)
+    internal fun cancelOrders(marketId: String?, currentHeight: Int?, callback: TransactionCallback): HumanReadableCancelMultipleOrdersPayload? {
+        return transactionSupervisor.cancelOrders(marketId, currentHeight, callback)
     }
 
     internal fun commitTriggerOrders(

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/TestFactory.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/TestFactory.kt
@@ -311,6 +311,7 @@ class TestChain : DYDXChainTransactionsProtocol {
     var heightResponse: String? = null
     var placeOrderResponse: String? = null
     var cancelOrderResponse: String? = null
+    var batchCancelResponse: String? = null
     var transferResponse: String? = null
     var depositResponse: String? = null
     var withdrawResponse: String? = null
@@ -320,6 +321,7 @@ class TestChain : DYDXChainTransactionsProtocol {
 
     var placeOrderPayloads = mutableListOf<String>()
     var canceldOrderPayloads = mutableListOf<String>()
+    var batchCancelPayloads = mutableListOf<String>()
     var transferPayloads = mutableListOf<String>()
 
     var requests = mutableListOf<QueryType>()
@@ -375,6 +377,10 @@ class TestChain : DYDXChainTransactionsProtocol {
                 cancelOrder(paramsInJson!!, callback)
             }
 
+            TransactionType.BatchCancel -> {
+                batchCancel(paramsInJson!!, callback)
+            }
+
             TransactionType.SubaccountTransfer -> {
                 transfer(paramsInJson!!, callback)
             }
@@ -424,6 +430,15 @@ class TestChain : DYDXChainTransactionsProtocol {
         canceldOrderPayloads.add(json)
         if (cancelOrderResponse != null) {
             callback(cancelOrderResponse)
+        } else {
+            this.transactionCallback = callback
+        }
+    }
+
+    fun batchCancel(json: String, callback: (response: String?) -> Unit) {
+        batchCancelPayloads.add(json)
+        if (batchCancelResponse != null) {
+            callback(batchCancelResponse)
         } else {
             this.transactionCallback = callback
         }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -217,26 +217,26 @@ class V4TransactionTests : NetworkTests() {
         val callback: TransactionCallback = { _, _, data -> statefulCancelCalledCount++ }
         val batchCancelPayloads = testChain!!.batchCancelPayloads
 
-        val shortTermOrderId1 = "770933a5-0293-5aca-8a01-d9c4030d776d"
-        val shortTermOrderId2 = "734617f4-29ba-50fe-878d-391ad4e4fbae"
-        val statefulOrderId1 = "31d7d484-8685-570c-aa62-c2589cb6c8d8"
-        val statefulOrderId2 = "0ae98da9-4fdc-5f08-b880-2449464b6b45"
-
-        val orderIds = listOf(shortTermOrderId1, shortTermOrderId2, statefulOrderId1, statefulOrderId2)
-
-        subaccountSupervisor?.cancelOrders(orderIds, 0, callback)
-        // there are 2 short term orders and 2 stateful orders
-        // hence 1 stateful orders should be queued
-        assertEquals(1, subaccountSupervisor?.transactionQueue?.size)
-        testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
-        testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
+        subaccountSupervisor?.cancelOrders("ETH-USD", 0, callback)
+        // there are 1 short term orders and 3 stateful orders in "ETH"
+        // hence 2 stateful orders should be queued
+        assertEquals(2, subaccountSupervisor?.transactionQueue?.size)
+        repeat(3) {
+            testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
+        }
         assertTransactionQueueEmpty()
-        assertEquals(2, statefulCancelCalledCount)
+        assertEquals(3, statefulCancelCalledCount)
 
         // verifying batch cancel contents
         assertEquals(1, batchCancelPayloads.size) // 1 batch because 1 subaccount
         val batchCancelPayload = parser.asNativeMap(Json.parseToJsonElement(batchCancelPayloads.first()))
-        assertEquals(2, parser.asList(batchCancelPayload?.get("shortTermOrders"))?.size) // 2 short term orders from different markets
+        assertEquals(1, parser.asList(batchCancelPayload?.get("shortTermOrders"))?.size)
+
+        // cancel all orders
+        subaccountSupervisor?.cancelOrders(null, 0, callback)
+        assertEquals(2, batchCancelPayloads.size) // added 1 more batch
+        val batchCancelPayload2 = parser.asNativeMap(Json.parseToJsonElement(batchCancelPayloads.last()))
+        assertEquals(2, parser.asList(batchCancelPayload2?.get("shortTermOrders"))?.size) // 2 short term orders from different markets
     }
 
     @Test

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AccountsChannelMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AccountsChannelMock.kt
@@ -1952,6 +1952,28 @@ internal class AccountsChannelMock {
                     "goodTilBlock": "8864635",
                     "ticker": "ETH-USD",
                     "clientMetadata": "1"
+                },
+                {
+                    "id": "734617f4-29ba-50fe-878d-391ad4e4fbae",
+                    "subaccountId": "e470a747-3aa0-543e-aafa-0bd27d568901",
+                    "clientId": "1597910999",
+                    "clobPairId": "0",
+                    "side": "BUY",
+                    "size": "0.1",
+                    "totalFilled": "0",
+                    "price": "42000",
+                    "type": "LIMIT",
+                    "status": "OPEN",
+                    "timeInForce": "IOC",
+                    "reduceOnly": true,
+                    "orderFlags": "0",
+                    "goodTilBlockTime": "2024-04-02T15:57:16.000Z",
+                    "createdAtHeight": "8489771",
+                    "clientMetadata": "0",
+                    "updatedAt": "2024-03-15T06:37:01.731Z",
+                    "updatedAtHeight": "8489771",
+                    "postOnly": false,
+                    "ticker": "BTC-USD"
                 }
               ],
               "fills":[

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AccountsChannelMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AccountsChannelMock.kt
@@ -1852,7 +1852,7 @@ internal class AccountsChannelMock {
                  {
                     "id":"b812bea8-29d3-5841-9549-caa072f6f8a8",
                     "market": "ETH-USD",
-                             "ticker":"ETH-USD",
+                    "ticker":"ETH-USD",
                     "subaccountId":"660efb4c-5472-5119-8c17-65cf702ccaea",
                     "clientId":"2194126268",
                     "clobPairId":"1",
@@ -1936,7 +1936,7 @@ internal class AccountsChannelMock {
                 },
                 {
                     "id": "770933a5-0293-5aca-8a01-d9c4030d776d",
-                             "ticker":"ETH-USD",
+                    "ticker":"ETH-USD",
                     "subaccountId": "e470a747-3aa0-543e-aafa-0bd27d568901",
                     "clientId": "852785216",
                     "clobPairId": "1",

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.9.3'
+    spec.version = '1.9.8'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
to support cancel all orders feature, adding a `cancelOrders` function in abacus which does the following:
- filter these orders to ensure they're cancelable (i.e. orders are open)
- group by short term vs. stateful
- for short term, group them by order's subaccount number, and cancel them in batches, using the new `TransactionType.BatchCancel`, which should be implemented on web/mobile with TS composite client's `batchCancelShortTermOrdersWithClobPairId` (added [here](https://github.com/dydxprotocol/v4-clients/pull/228/)). 
- for stateful, just cancel them using the normal cancel order operation one by one via transaction queue
- the callback should look at the payload and handle batch cancel vs. normal cancel slightly differently -- batch cancel can have one failed order and rest successful


TODO:
- implement analytics / tracking in a followup PR to not make this any bigger. will need to run orderCanceled / cancelOrderRecords on the canceled orders after digging into the error response to determine which orders failed vs. succeeded in a batch
- test on FE integration