### PR TITLE
Save remote localization files to cache

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/app/helper/DynamicLocalizer.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/app/helper/DynamicLocalizer.kt
@@ -183,6 +183,7 @@ class DynamicLocalizer(
             ioImplementations.rest?.get(url, null) { response, code, _ ->
                 ioImplementations.threading?.async(ThreadingType.main) {
                     if (code in 200..299 && response != null) {
+                        ioImplementations.fileSystem?.writeTextFile("$path/$file", response)
                         val data = parser.decodeJsonObject(response)
                         if (data != null && data.size != 0) {
                             mergeLanguageData(data, file, language)


### PR DESCRIPTION
Update DynamicLocalizer to save remote localization files to cache, so that the client gets the latest remote update on the next launch.

Tested on iOS and Android.