### PR TITLE
feat: Add tracking for TradeInputValidator.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.9.7"
+version = "1.9.8"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
@@ -195,41 +195,44 @@ interface DYDXChainTransactionsProtocol {
 }
 
 @JsExport
-enum class AnalyticsEvent(val rawValue: String) {
+enum class AnalyticsEvent {
     // App
-    NetworkStatus("NetworkStatus"),
+    NetworkStatus,
 
     // Trade
-    TradePlaceOrderClick("TradePlaceOrderClick"),
-    TradeCancelOrderClick("TradeCancelOrderClick"),
-    TradePlaceOrder("TradePlaceOrder"),
-    TradeCancelOrder("TradeCancelOrder"),
-    TradePlaceOrderSubmissionConfirmed("TradePlaceOrderSubmissionConfirmed"),
-    TradeCancelOrderSubmissionConfirmed("TradeCancelOrderSubmissionConfirmed"),
-    TradePlaceOrderSubmissionFailed("TradePlaceOrderSubmissionFailed"),
-    TradeCancelOrderSubmissionFailed("TradeCancelOrderSubmissionFailed"),
-    TradeCancelOrderConfirmed("TradeCancelOrderConfirmed"),
-    TradePlaceOrderConfirmed("TradePlaceOrderConfirmed"),
+    TradePlaceOrderClick,
+    TradeCancelOrderClick,
+    TradePlaceOrder,
+    TradeCancelOrder,
+    TradePlaceOrderSubmissionConfirmed,
+    TradeCancelOrderSubmissionConfirmed,
+    TradePlaceOrderSubmissionFailed,
+    TradeCancelOrderSubmissionFailed,
+    TradeCancelOrderConfirmed,
+    TradePlaceOrderConfirmed,
 
     // Order status change
-    TradePlaceOrderStatusCanceled("TradePlaceOrderStatusCanceled"),
-    TradePlaceOrderStatusCanceling("TradePlaceOrderStatusCanceling"),
-    TradePlaceOrderStatusFilled("TradePlaceOrderStatusFilled"),
-    TradePlaceOrderStatusOpen("TradePlaceOrderStatusOpen"),
-    TradePlaceOrderStatusPending("TradePlaceOrderStatusPending"),
-    TradePlaceOrderStatusUntriggered("TradePlaceOrderStatusUntriggered"),
-    TradePlaceOrderStatusPartiallyFilled("TradePlaceOrderStatusPartiallyFilled"),
-    TradePlaceOrderStatusPartiallyCanceled("TradePlaceOrderStatusPartiallyCanceled"),
+    TradePlaceOrderStatusCanceled,
+    TradePlaceOrderStatusCanceling,
+    TradePlaceOrderStatusFilled,
+    TradePlaceOrderStatusOpen,
+    TradePlaceOrderStatusPending,
+    TradePlaceOrderStatusUntriggered,
+    TradePlaceOrderStatusPartiallyFilled,
+    TradePlaceOrderStatusPartiallyCanceled,
 
     // Trigger Order
-    TriggerOrderClick("TriggerOrderClick"),
+    TriggerOrderClick,
+
+    // Validation Error
+    TradeValidation,
 
     // Transfers
-    TransferFaucetConfirmed("TransferFaucetConfirmed");
+    TransferFaucetConfirmed;
 
     companion object {
         operator fun invoke(rawValue: String) =
-            AnalyticsEvent.values().firstOrNull { it.rawValue == rawValue }
+            entries.firstOrNull { it.name == rawValue }
     }
 }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/PerpTradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/PerpTradingStateMachine.kt
@@ -1,6 +1,7 @@
 package exchange.dydx.abacus.state.model
 
 import exchange.dydx.abacus.protocols.LocalizerProtocol
+import exchange.dydx.abacus.protocols.TrackingProtocol
 import exchange.dydx.abacus.state.app.helper.Formatter
 import exchange.dydx.abacus.state.manager.V4Environment
 
@@ -11,8 +12,9 @@ class PerpTradingStateMachine(
     maxSubaccountNumber: Int,
     useParentSubaccount: Boolean,
     staticTyping: Boolean = false,
+    trackingProtocol: TrackingProtocol?,
 ) :
-    TradingStateMachine(environment, localizer, formatter, maxSubaccountNumber, useParentSubaccount, staticTyping) {
+    TradingStateMachine(environment, localizer, formatter, maxSubaccountNumber, useParentSubaccount, staticTyping, trackingProtocol) {
     /*
     Placeholder for now. Eventually, the code specifically for Perpetual will be in this class
      */

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
@@ -49,6 +49,7 @@ import exchange.dydx.abacus.processor.router.squid.SquidProcessor
 import exchange.dydx.abacus.processor.wallet.WalletProcessor
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.protocols.TrackingProtocol
 import exchange.dydx.abacus.protocols.asTypedStringMap
 import exchange.dydx.abacus.responses.ParsingError
 import exchange.dydx.abacus.responses.ParsingErrorType
@@ -71,6 +72,7 @@ import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
 import exchange.dydx.abacus.utils.Parser
 import exchange.dydx.abacus.utils.ServerTime
+import exchange.dydx.abacus.utils.TradeValidationTracker
 import exchange.dydx.abacus.utils.iMapOf
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.mutableMapOf
@@ -101,6 +103,7 @@ open class TradingStateMachine(
     private val maxSubaccountNumber: Int,
     private val useParentSubaccount: Boolean,
     val staticTyping: Boolean = false,
+    private val trackingProtocol: TrackingProtocol?,
 ) {
     internal var internalState: InternalState = InternalState()
 
@@ -138,7 +141,9 @@ open class TradingStateMachine(
 
     private val receiptCalculator = ReceiptCalculator()
 
-    internal val inputValidator = InputValidator(localizer, formatter, parser)
+    private val tradeValidationTracker = TradeValidationTracker(trackingProtocol)
+
+    internal val inputValidator = InputValidator(localizer, formatter, parser, tradeValidationTracker)
 
     internal var data: Map<String, Any>? = null
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
@@ -113,6 +113,7 @@ internal class StateManagerAdaptorV2(
         maxSubaccountNumber = 127,
         useParentSubaccount = appConfigs.accountConfigs.subaccountConfigs.useParentSubaccount,
         staticTyping = appConfigs.staticTyping,
+        trackingProtocol = ioImplementations.tracking,
     )
 
     internal val jsonEncoder = JsonEncoder()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionStats.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionStats.kt
@@ -262,7 +262,7 @@ internal class ConnectionStats(
 
     private fun trackApiStateIfNeeded(apiState: ApiState?, oldValue: ApiState?) {
         if (apiState?.abnormalState() == true || oldValue?.abnormalState() == true) {
-            tracking(AnalyticsEvent.NetworkStatus.rawValue)
+            tracking(AnalyticsEvent.NetworkStatus.name)
         }
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountTransactionSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountTransactionSupervisor.kt
@@ -286,7 +286,7 @@ internal class SubaccountTransactionSupervisor(
                         // when order is first indexed
                         if (placeOrderRecord.lastOrderStatus == null) {
                             transactionTracker.tracking(
-                                AnalyticsEvent.TradePlaceOrderConfirmed.rawValue,
+                                AnalyticsEvent.TradePlaceOrderConfirmed.name,
                                 analyticsPayload,
                             )
                         }
@@ -302,7 +302,7 @@ internal class SubaccountTransactionSupervisor(
                             OrderStatus.PartiallyCanceled -> AnalyticsEvent.TradePlaceOrderStatusPartiallyCanceled
                         }
 
-                        transactionTracker.tracking(orderStatusChangeEvent.rawValue, analyticsPayload)
+                        transactionTracker.tracking(orderStatusChangeEvent.name, analyticsPayload)
 
                         when (order.status) {
                             // order reaches final state, can remove / skip further tracking
@@ -326,7 +326,7 @@ internal class SubaccountTransactionSupervisor(
                         fromSlTpDialogParams(cancelOrderRecord.fromSlTpDialog),
                     )
                     transactionTracker.tracking(
-                        AnalyticsEvent.TradeCancelOrderConfirmed.rawValue,
+                        AnalyticsEvent.TradeCancelOrderConfirmed.name,
                         ParsingHelper.merge(
                             extraParams,
                             orderAnalyticsPayload,
@@ -451,7 +451,7 @@ internal class SubaccountTransactionSupervisor(
                                 val interval = Clock.System.now().toEpochMilliseconds()
                                     .toDouble() - faucet.timestampInMilliseconds
                                 transactionTracker.tracking(
-                                    AnalyticsEvent.TransferFaucetConfirmed.rawValue,
+                                    AnalyticsEvent.TransferFaucetConfirmed.name,
                                     transactionTracker.trackingParams(interval),
                                 )
                                 faucetRecords.remove(faucet)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountTransactionTracker.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountTransactionTracker.kt
@@ -63,7 +63,7 @@ internal class SubaccountTransactionTracker(
     ): Double {
         val uiClickTimeMs = Clock.System.now().toEpochMilliseconds().toDouble()
         tracking(
-            analyticsEvent.rawValue,
+            analyticsEvent.name,
             analyticsPayload,
         )
         return uiClickTimeMs
@@ -78,7 +78,7 @@ internal class SubaccountTransactionTracker(
         val uiDelayTimeMs = submitTimeMs - uiClickTimeMs
 
         tracking(
-            if (isCancel) AnalyticsEvent.TradeCancelOrder.rawValue else AnalyticsEvent.TradePlaceOrder.rawValue,
+            if (isCancel) AnalyticsEvent.TradeCancelOrder.name else AnalyticsEvent.TradePlaceOrder.name,
             ParsingHelper.merge(uiTrackingParams(uiDelayTimeMs), analyticsPayload)?.toIMap(),
         )
 
@@ -92,12 +92,12 @@ internal class SubaccountTransactionTracker(
     ) {
         if (error != null) {
             tracking(
-                if (isCancel) AnalyticsEvent.TradeCancelOrderSubmissionFailed.rawValue else AnalyticsEvent.TradePlaceOrderSubmissionFailed.rawValue,
+                if (isCancel) AnalyticsEvent.TradeCancelOrderSubmissionFailed.name else AnalyticsEvent.TradePlaceOrderSubmissionFailed.name,
                 ParsingHelper.merge(errorTrackingParams(error), analyticsPayload)?.toIMap(),
             )
         } else {
             tracking(
-                if (isCancel) AnalyticsEvent.TradeCancelOrderSubmissionConfirmed.rawValue else AnalyticsEvent.TradePlaceOrderSubmissionConfirmed.rawValue,
+                if (isCancel) AnalyticsEvent.TradeCancelOrderSubmissionConfirmed.name else AnalyticsEvent.TradePlaceOrderSubmissionConfirmed.name,
                 analyticsPayload,
             )
         }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/TradeValidationTracker.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/TradeValidationTracker.kt
@@ -1,0 +1,38 @@
+package exchange.dydx.abacus.utils
+
+import exchange.dydx.abacus.protocols.AnalyticsEvent
+import exchange.dydx.abacus.protocols.TrackingProtocol
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+class TradeValidationTracker(
+    private val trackingProtocol: TrackingProtocol?
+) {
+
+    private var lastSeen: TradeValidationPayload? = null
+
+    fun logValidationResult(payload: TradeValidationPayload) {
+        if (payload == lastSeen) return
+
+        trackingProtocol?.log(AnalyticsEvent.TradeValidation.name, TrackingJson.encodeToString(TradeValidationPayload.serializer(), payload))
+        lastSeen = payload
+    }
+}
+
+private val TrackingJson = Json {
+    prettyPrint = true
+    encodeDefaults = true
+}
+
+@Serializable
+data class TradeValidationPayload(
+    val errors: List<String> = emptyList(),
+    val marketId: String,
+    val size: Double? = null,
+    val notionalSize: Double? = null,
+) {
+    // Fields declared in class body are still serialized, but are not used for data class equality.
+    // Basically, don't want to emit more events if only slippage has changed (via orderbook)
+    var indexSlippage: Double? = null
+    var orderbookSlippage: Double? = null
+}

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/InputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/InputValidator.kt
@@ -9,12 +9,14 @@ import exchange.dydx.abacus.state.internalstate.InternalState
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.V4Environment
 import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
+import exchange.dydx.abacus.utils.TradeValidationTracker
 import exchange.dydx.abacus.utils.modify
 
 internal class InputValidator(
-    val localizer: LocalizerProtocol?,
-    val formatter: Formatter?,
-    val parser: ParserProtocol,
+    localizer: LocalizerProtocol?,
+    formatter: Formatter?,
+    private val parser: ParserProtocol,
+    tradeValidationTracker: TradeValidationTracker,
 ) {
     private val errorTypeLookup = mapOf<String, Int>(
         "REQUIRED" to 0,
@@ -70,13 +72,13 @@ internal class InputValidator(
     private val tradeValidators = listOf<ValidatorProtocol>(
         AccountInputValidator(localizer, formatter, parser),
         FieldsInputValidator(localizer, formatter, parser),
-        TradeInputValidator(localizer, formatter, parser),
+        TradeInputValidator(localizer, formatter, parser, tradeValidationTracker),
     )
 
     private val closePositionValidators = listOf<ValidatorProtocol>(
         AccountInputValidator(localizer, formatter, parser),
         FieldsInputValidator(localizer, formatter, parser),
-        TradeInputValidator(localizer, formatter, parser),
+        TradeInputValidator(localizer, formatter, parser, tradeValidationTracker),
     )
 
     private val transferValidators = listOf<ValidatorProtocol>(

--- a/src/commonTest/kotlin/exchange.dydx.abacus/fakes/FakeTrackingProtocol.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/fakes/FakeTrackingProtocol.kt
@@ -1,0 +1,13 @@
+package exchange.dydx.abacus.fakes
+
+import exchange.dydx.abacus.protocols.TrackingProtocol
+
+internal class FakeTrackingProtocol : TrackingProtocol {
+    var lastEvent: String? = null
+    var lastData: String? = null
+
+    override fun log(event: String, data: String?) {
+        lastData = data
+        lastEvent = event
+    }
+}

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/BaseTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/BaseTests.kt
@@ -7,6 +7,7 @@ import exchange.dydx.abacus.app.manager.TestThreading
 import exchange.dydx.abacus.app.manager.TestTimer
 import exchange.dydx.abacus.app.manager.TestWebSocket
 import exchange.dydx.abacus.calculator.CalculationPeriod
+import exchange.dydx.abacus.fakes.FakeTrackingProtocol
 import exchange.dydx.abacus.output.Asset
 import exchange.dydx.abacus.output.Configs
 import exchange.dydx.abacus.output.FeeDiscount
@@ -101,6 +102,7 @@ open class BaseTests(
     internal val doesntMatchText = "doesn't match"
     internal val parser = Parser()
     internal val mock = AbacusMockData()
+    internal val trackingProtocol = FakeTrackingProtocol()
     internal var perp = createState(
         useParentSubaccount = useParentSubaccount,
         staticTyping = staticTyping,
@@ -146,6 +148,7 @@ open class BaseTests(
             maxSubaccountNumber = maxSubaccountNumber,
             useParentSubaccount = useParentSubaccount,
             staticTyping = staticTyping,
+            trackingProtocol = trackingProtocol,
         )
     }
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4BaseTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4BaseTests.kt
@@ -41,6 +41,7 @@ open class V4BaseTests(useParentSubaccount: Boolean = false) : BaseTests(127, us
             maxSubaccountNumber = 127,
             useParentSubaccount = useParentSubaccount,
             staticTyping = staticTyping,
+            trackingProtocol = trackingProtocol,
         )
     }
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/state/model/TradingStateMachineTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/state/model/TradingStateMachineTests.kt
@@ -15,6 +15,7 @@ class TradingStateMachineTests {
             formatter = null,
             maxSubaccountNumber = 1,
             useParentSubaccount = false,
+            trackingProtocol = null,
         )
         StatsigConfig.useSkip = true
         assertTrue(tradingStateMachine.routerProcessor is SkipProcessor)
@@ -28,6 +29,7 @@ class TradingStateMachineTests {
             formatter = null,
             maxSubaccountNumber = 1,
             useParentSubaccount = false,
+            trackingProtocol = null,
         )
         StatsigConfig.useSkip = false
         assertTrue(tradingStateMachine.routerProcessor is SquidProcessor)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/validation/TradeMarketOrderTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/validation/TradeMarketOrderTests.kt
@@ -101,6 +101,23 @@ class TradeMarketOrderTests : ValidationsTests() {
             assertEquals(orderbook[1].price, 1000.5)
             assertEquals(orderbook[2].size, 0.4)
             assertEquals(orderbook[2].price, 1060.0)
+
+            assertEquals(trackingProtocol.lastEvent, "TradeValidation")
+            assertEquals(
+                trackingProtocol.lastData,
+                """
+                    {
+                        "errors": [
+                            "MARKET_ORDER_WARNING_ORDERBOOK_SLIPPAGE"
+                        ],
+                        "marketId": "ETH-USD",
+                        "size": 1.0,
+                        "notionalSize": 1024.26,
+                        "indexSlippage": 0.06,
+                        "orderbookSlippage": 0.06
+                    }
+                """.trimIndent(),
+            )
         } else {
             test(
                 {
@@ -147,6 +164,23 @@ class TradeMarketOrderTests : ValidationsTests() {
                         }
                     }
                 }
+                """.trimIndent(),
+            )
+
+            assertEquals(trackingProtocol.lastEvent, "TradeValidation")
+            assertEquals(
+                trackingProtocol.lastData,
+                """
+                    {
+                        "errors": [
+                            "MARKET_ORDER_WARNING_ORDERBOOK_SLIPPAGE"
+                        ],
+                        "marketId": "ETH-USD",
+                        "size": 1.0,
+                        "notionalSize": 1024.26,
+                        "indexSlippage": 0.06,
+                        "orderbookSlippage": 0.06
+                    }
                 """.trimIndent(),
             )
         }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.9.7'
+    spec.version = '1.9.8'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
- Cleans up AnalyticsEvent a bit, the `rawValue` is not needed. We can just use the enum name directly.
- Adds a new class `TradeValidationTracker` which logs validation results and does some quick and dirty de-duping, since the validators are run quite often.
- Wires up TradeValidationTracker in TradeInputValidator and pipes through needed dependencies.

context: https://dydx-team.slack.com/archives/C06EMK1746T/p1722891345373099