### PR TITLE
add cancel orders with tx queue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.9.9"
+version = "1.9.10"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
@@ -202,6 +202,7 @@ enum class AnalyticsEvent {
     // Trade
     TradePlaceOrderClick,
     TradeCancelOrderClick,
+    TradeCancelAllOrdersClick,
     TradePlaceOrder,
     TradeCancelOrder,
     TradePlaceOrderSubmissionConfirmed,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
@@ -63,7 +63,7 @@ interface AsyncAbacusStateManagerProtocol {
     fun closePositionPayload(): HumanReadablePlaceOrderPayload?
     fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload?
     fun cancelOrderPayload(orderId: String): HumanReadableCancelOrderPayload?
-    fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload?
+    fun cancelAllOrdersPayload(marketId: String?): HumanReadableCancelAllOrdersPayload?
     fun depositPayload(): HumanReadableDepositPayload?
     fun withdrawPayload(): HumanReadableWithdrawPayload?
     fun subaccountTransferPayload(): HumanReadableSubaccountTransferPayload?
@@ -81,7 +81,7 @@ interface AsyncAbacusStateManagerProtocol {
     // Commit changes with params
     fun faucet(amount: Double, callback: TransactionCallback)
     fun cancelOrder(orderId: String, callback: TransactionCallback)
-    fun cancelOrders(marketId: String?, callback: TransactionCallback)
+    fun cancelAllOrders(marketId: String?, callback: TransactionCallback)
 
     // Bridge functions.
     // If client is not using cancelOrder function, it should call orderCanceled function with

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
@@ -63,6 +63,7 @@ interface AsyncAbacusStateManagerProtocol {
     fun closePositionPayload(): HumanReadablePlaceOrderPayload?
     fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload?
     fun cancelOrderPayload(orderId: String): HumanReadableCancelOrderPayload?
+    fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload?
     fun depositPayload(): HumanReadableDepositPayload?
     fun withdrawPayload(): HumanReadableWithdrawPayload?
     fun subaccountTransferPayload(): HumanReadableSubaccountTransferPayload?
@@ -80,6 +81,7 @@ interface AsyncAbacusStateManagerProtocol {
     // Commit changes with params
     fun faucet(amount: Double, callback: TransactionCallback)
     fun cancelOrder(orderId: String, callback: TransactionCallback)
+    fun cancelOrders(marketId: String?, callback: TransactionCallback)
 
     // Bridge functions.
     // If client is not using cancelOrder function, it should call orderCanceled function with

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
@@ -85,6 +85,13 @@ data class HumanReadableCancelOrderPayload(
 
 @JsExport
 @Serializable
+data class HumanReadableCancelMultipleOrdersPayload(
+    val marketId: String?,
+    val payloads: IList<HumanReadableCancelOrderPayload>,
+)
+
+@JsExport
+@Serializable
 data class HumanReadableTriggerOrdersPayload(
     val marketId: String,
     val positionSize: Double?,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
@@ -85,7 +85,7 @@ data class HumanReadableCancelOrderPayload(
 
 @JsExport
 @Serializable
-data class HumanReadableCancelMultipleOrdersPayload(
+data class HumanReadableCancelAllOrdersPayload(
     val marketId: String?,
     val payloads: IList<HumanReadableCancelOrderPayload>,
 )

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
@@ -23,6 +23,7 @@ import exchange.dydx.abacus.state.manager.ConfigFile
 import exchange.dydx.abacus.state.manager.GasToken
 import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
+import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -503,6 +504,10 @@ class AsyncAbacusStateManagerV2(
         return adaptor?.cancelOrderPayload(orderId)
     }
 
+    override fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload? {
+        return adaptor?.cancelOrdersPayload(marketId)
+    }
+
     override fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload? {
         return adaptor?.triggerOrdersPayload()
     }
@@ -597,6 +602,15 @@ class AsyncAbacusStateManagerV2(
     override fun cancelOrder(orderId: String, callback: TransactionCallback) {
         try {
             adaptor?.cancelOrder(orderId, callback)
+        } catch (e: Exception) {
+            val error = V4TransactionErrors.error(null, e.toString())
+            callback(false, error, null)
+        }
+    }
+
+    override fun cancelOrders(marketId: String?, callback: TransactionCallback) {
+        try {
+            adaptor?.cancelOrders(marketId, callback)
         } catch (e: Exception) {
             val error = V4TransactionErrors.error(null, e.toString())
             callback(false, error, null)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
@@ -23,7 +23,7 @@ import exchange.dydx.abacus.state.manager.ConfigFile
 import exchange.dydx.abacus.state.manager.GasToken
 import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
-import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
+import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -504,8 +504,8 @@ class AsyncAbacusStateManagerV2(
         return adaptor?.cancelOrderPayload(orderId)
     }
 
-    override fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload? {
-        return adaptor?.cancelOrdersPayload(marketId)
+    override fun cancelAllOrdersPayload(marketId: String?): HumanReadableCancelAllOrdersPayload? {
+        return adaptor?.cancelAllOrdersPayload(marketId)
     }
 
     override fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload? {
@@ -608,9 +608,9 @@ class AsyncAbacusStateManagerV2(
         }
     }
 
-    override fun cancelOrders(marketId: String?, callback: TransactionCallback) {
+    override fun cancelAllOrders(marketId: String?, callback: TransactionCallback) {
         try {
-            adaptor?.cancelOrders(marketId, callback)
+            adaptor?.cancelAllOrders(marketId, callback)
         } catch (e: Exception) {
             val error = V4TransactionErrors.error(null, e.toString())
             callback(false, error, null)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
@@ -26,7 +26,7 @@ import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.GasToken
 import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
-import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
+import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -57,10 +57,10 @@ import exchange.dydx.abacus.state.v2.supervisor.accountAddress
 import exchange.dydx.abacus.state.v2.supervisor.addressRestriction
 import exchange.dydx.abacus.state.v2.supervisor.adjustIsolatedMargin
 import exchange.dydx.abacus.state.v2.supervisor.adjustIsolatedMarginPayload
+import exchange.dydx.abacus.state.v2.supervisor.cancelAllOrders
+import exchange.dydx.abacus.state.v2.supervisor.cancelAllOrdersPayload
 import exchange.dydx.abacus.state.v2.supervisor.cancelOrder
 import exchange.dydx.abacus.state.v2.supervisor.cancelOrderPayload
-import exchange.dydx.abacus.state.v2.supervisor.cancelOrders
-import exchange.dydx.abacus.state.v2.supervisor.cancelOrdersPayload
 import exchange.dydx.abacus.state.v2.supervisor.closePosition
 import exchange.dydx.abacus.state.v2.supervisor.closePositionPayload
 import exchange.dydx.abacus.state.v2.supervisor.commitAdjustIsolatedMargin
@@ -541,8 +541,8 @@ internal class StateManagerAdaptorV2(
         return accounts.cancelOrderPayload(orderId)
     }
 
-    internal fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload? {
-        return accounts.cancelOrdersPayload(marketId)
+    internal fun cancelAllOrdersPayload(marketId: String?): HumanReadableCancelAllOrdersPayload? {
+        return accounts.cancelAllOrdersPayload(marketId)
     }
 
     internal fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload? {
@@ -603,8 +603,8 @@ internal class StateManagerAdaptorV2(
         accounts.cancelOrder(orderId, callback)
     }
 
-    internal fun cancelOrders(marketId: String?, callback: TransactionCallback) {
-        accounts.cancelOrders(marketId, callback)
+    internal fun cancelAllOrders(marketId: String?, callback: TransactionCallback) {
+        accounts.cancelAllOrders(marketId, callback)
     }
 
     internal fun orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
@@ -26,6 +26,7 @@ import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.GasToken
 import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
+import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -58,6 +59,8 @@ import exchange.dydx.abacus.state.v2.supervisor.adjustIsolatedMargin
 import exchange.dydx.abacus.state.v2.supervisor.adjustIsolatedMarginPayload
 import exchange.dydx.abacus.state.v2.supervisor.cancelOrder
 import exchange.dydx.abacus.state.v2.supervisor.cancelOrderPayload
+import exchange.dydx.abacus.state.v2.supervisor.cancelOrders
+import exchange.dydx.abacus.state.v2.supervisor.cancelOrdersPayload
 import exchange.dydx.abacus.state.v2.supervisor.closePosition
 import exchange.dydx.abacus.state.v2.supervisor.closePositionPayload
 import exchange.dydx.abacus.state.v2.supervisor.commitAdjustIsolatedMargin
@@ -538,6 +541,10 @@ internal class StateManagerAdaptorV2(
         return accounts.cancelOrderPayload(orderId)
     }
 
+    internal fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload? {
+        return accounts.cancelOrdersPayload(marketId)
+    }
+
     internal fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload? {
         return accounts.triggerOrdersPayload(currentHeight)
     }
@@ -594,6 +601,10 @@ internal class StateManagerAdaptorV2(
 
     internal fun cancelOrder(orderId: String, callback: TransactionCallback) {
         accounts.cancelOrder(orderId, callback)
+    }
+
+    internal fun cancelOrders(marketId: String?, callback: TransactionCallback) {
+        accounts.cancelOrders(marketId, callback)
     }
 
     internal fun orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -21,7 +21,7 @@ import exchange.dydx.abacus.state.changes.StateChanges
 import exchange.dydx.abacus.state.manager.ApiData
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
-import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
+import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -1181,8 +1181,8 @@ internal fun AccountSupervisor.cancelOrderPayload(
     return subaccount?.cancelOrderPayload(orderId)
 }
 
-internal fun AccountSupervisor.cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload? {
-    return subaccount?.cancelOrdersPayload(marketId)
+internal fun AccountSupervisor.cancelAllOrdersPayload(marketId: String?): HumanReadableCancelAllOrdersPayload? {
+    return subaccount?.cancelAllOrdersPayload(marketId)
 }
 
 internal fun AccountSupervisor.depositPayload(): HumanReadableDepositPayload? {
@@ -1236,8 +1236,8 @@ internal fun AccountSupervisor.cancelOrder(orderId: String, callback: Transactio
     subaccount?.cancelOrder(orderId = orderId, callback = callback)
 }
 
-internal fun AccountSupervisor.cancelOrders(marketId: String?, callback: TransactionCallback) {
-    subaccount?.cancelOrders(marketId, callback)
+internal fun AccountSupervisor.cancelAllOrders(marketId: String?, callback: TransactionCallback) {
+    subaccount?.cancelAllOrders(marketId, callback)
 }
 
 internal fun AccountSupervisor.orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -21,6 +21,7 @@ import exchange.dydx.abacus.state.changes.StateChanges
 import exchange.dydx.abacus.state.manager.ApiData
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
+import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -1180,6 +1181,10 @@ internal fun AccountSupervisor.cancelOrderPayload(
     return subaccount?.cancelOrderPayload(orderId)
 }
 
+internal fun AccountSupervisor.cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload? {
+    return subaccount?.cancelOrdersPayload(marketId)
+}
+
 internal fun AccountSupervisor.depositPayload(): HumanReadableDepositPayload? {
     return subaccount?.depositPayload()
 }
@@ -1229,6 +1234,10 @@ internal fun AccountSupervisor.faucet(amount: Double, callback: TransactionCallb
 
 internal fun AccountSupervisor.cancelOrder(orderId: String, callback: TransactionCallback) {
     subaccount?.cancelOrder(orderId = orderId, callback = callback)
+}
+
+internal fun AccountSupervisor.cancelOrders(marketId: String?, callback: TransactionCallback) {
+    subaccount?.cancelOrders(marketId, callback)
 }
 
 internal fun AccountSupervisor.orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
@@ -15,6 +15,7 @@ import exchange.dydx.abacus.state.manager.ApiData
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
+import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -275,6 +276,10 @@ internal fun AccountsSupervisor.cancelOrderPayload(orderId: String): HumanReadab
     return account?.cancelOrderPayload(orderId)
 }
 
+internal fun AccountsSupervisor.cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload? {
+    return account?.cancelOrdersPayload(marketId)
+}
+
 internal fun AccountsSupervisor.depositPayload(): HumanReadableDepositPayload? {
     return account?.depositPayload()
 }
@@ -335,6 +340,10 @@ internal fun AccountsSupervisor.faucet(amount: Double, callback: TransactionCall
 
 internal fun AccountsSupervisor.cancelOrder(orderId: String, callback: TransactionCallback) {
     account?.cancelOrder(orderId, callback)
+}
+
+internal fun AccountsSupervisor.cancelOrders(marketId: String?, callback: TransactionCallback) {
+    account?.cancelOrders(marketId, callback)
 }
 
 internal fun AccountsSupervisor.orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
@@ -15,7 +15,7 @@ import exchange.dydx.abacus.state.manager.ApiData
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
-import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
+import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -276,8 +276,8 @@ internal fun AccountsSupervisor.cancelOrderPayload(orderId: String): HumanReadab
     return account?.cancelOrderPayload(orderId)
 }
 
-internal fun AccountsSupervisor.cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload? {
-    return account?.cancelOrdersPayload(marketId)
+internal fun AccountsSupervisor.cancelAllOrdersPayload(marketId: String?): HumanReadableCancelAllOrdersPayload? {
+    return account?.cancelAllOrdersPayload(marketId)
 }
 
 internal fun AccountsSupervisor.depositPayload(): HumanReadableDepositPayload? {
@@ -342,8 +342,8 @@ internal fun AccountsSupervisor.cancelOrder(orderId: String, callback: Transacti
     account?.cancelOrder(orderId, callback)
 }
 
-internal fun AccountsSupervisor.cancelOrders(marketId: String?, callback: TransactionCallback) {
-    account?.cancelOrders(marketId, callback)
+internal fun AccountsSupervisor.cancelAllOrders(marketId: String?, callback: TransactionCallback) {
+    account?.cancelAllOrders(marketId, callback)
 }
 
 internal fun AccountsSupervisor.orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -14,6 +14,7 @@ import exchange.dydx.abacus.state.changes.StateChanges
 import exchange.dydx.abacus.state.manager.ApiData
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.FaucetRecord
+import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadableFaucetPayload
@@ -328,6 +329,10 @@ internal class SubaccountSupervisor(
         return payloadProvider.cancelOrderPayload(orderId)
     }
 
+    internal fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload {
+        return payloadProvider.cancelOrdersPayload(marketId)
+    }
+
     fun trade(
         data: String?,
         type: TradeInputField?,
@@ -423,6 +428,10 @@ internal class SubaccountSupervisor(
 
     internal fun cancelOrder(orderId: String, isOrphanedTriggerOrder: Boolean = false, callback: TransactionCallback): HumanReadableCancelOrderPayload {
         return transactionSupervisor.cancelOrder(orderId, isOrphanedTriggerOrder, callback)
+    }
+
+    internal fun cancelOrders(marketId: String?, callback: TransactionCallback): HumanReadableCancelMultipleOrdersPayload {
+        return transactionSupervisor.cancelOrders(marketId, callback)
     }
 
     internal fun commitTriggerOrders(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -14,7 +14,7 @@ import exchange.dydx.abacus.state.changes.StateChanges
 import exchange.dydx.abacus.state.manager.ApiData
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.FaucetRecord
-import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
+import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadableFaucetPayload
@@ -329,8 +329,8 @@ internal class SubaccountSupervisor(
         return payloadProvider.cancelOrderPayload(orderId)
     }
 
-    internal fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload {
-        return payloadProvider.cancelOrdersPayload(marketId)
+    internal fun cancelAllOrdersPayload(marketId: String?): HumanReadableCancelAllOrdersPayload {
+        return payloadProvider.cancelAllOrdersPayload(marketId)
     }
 
     fun trade(
@@ -430,8 +430,8 @@ internal class SubaccountSupervisor(
         return transactionSupervisor.cancelOrder(orderId, isOrphanedTriggerOrder, callback)
     }
 
-    internal fun cancelOrders(marketId: String?, callback: TransactionCallback): HumanReadableCancelMultipleOrdersPayload {
-        return transactionSupervisor.cancelOrders(marketId, callback)
+    internal fun cancelAllOrders(marketId: String?, callback: TransactionCallback): HumanReadableCancelAllOrdersPayload {
+        return transactionSupervisor.cancelAllOrders(marketId, callback)
     }
 
     internal fun commitTriggerOrders(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountTransactionPayloadProvider.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountTransactionPayloadProvider.kt
@@ -10,6 +10,7 @@ import exchange.dydx.abacus.output.input.OrderStatus
 import exchange.dydx.abacus.output.input.OrderType
 import exchange.dydx.abacus.output.input.TradeInputGoodUntil
 import exchange.dydx.abacus.output.input.TriggerOrder
+import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -22,8 +23,10 @@ import exchange.dydx.abacus.utils.LIMIT_CLOSE_ORDER_DEFAULT_DURATION_DAYS
 import exchange.dydx.abacus.utils.MAX_SUBACCOUNT_NUMBER
 import exchange.dydx.abacus.utils.NUM_PARENT_SUBACCOUNTS
 import exchange.dydx.abacus.utils.SHORT_TERM_ORDER_DURATION
+import kollections.iEmptyList
 import kollections.iListOf
 import kollections.iMutableListOf
+import kollections.toIList
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.seconds
 
@@ -34,6 +37,9 @@ internal interface SubaccountTransactionPayloadProviderProtocol {
 
     @Throws(Exception::class)
     fun cancelOrderPayload(orderId: String): HumanReadableCancelOrderPayload
+
+    @Throws(Exception::class)
+    fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload
 
     fun triggerOrdersPayload(currentHeight: Int?): HumanReadableTriggerOrdersPayload
 
@@ -166,6 +172,22 @@ internal class SubaccountTransactionPayloadProvider(
             clobPairId = clobPairId,
             goodTilBlock = goodTilBlock,
             goodTilBlockTime = goodTilBlockTime,
+        )
+    }
+
+    @Throws(Exception::class)
+    override fun cancelOrdersPayload(
+        marketId: String?,
+    ): HumanReadableCancelMultipleOrdersPayload {
+        val subaccount = stateMachine.state?.subaccount(subaccountNumber) ?: throw Exception("subaccount is null")
+        val openOrders = subaccount.orders?.let { orders ->
+            orders.filter { ( marketId == null || it.marketId == marketId ) && it.status.isOpen }
+        } ?: iEmptyList()
+        val cancelPayloads = openOrders.map { cancelOrderPayload(it.id) }.sortedBy { payload -> payload.orderFlags }.toIList()
+
+        return HumanReadableCancelMultipleOrdersPayload(
+            marketId = marketId,
+            payloads = cancelPayloads
         )
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountTransactionPayloadProvider.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountTransactionPayloadProvider.kt
@@ -10,7 +10,7 @@ import exchange.dydx.abacus.output.input.OrderStatus
 import exchange.dydx.abacus.output.input.OrderType
 import exchange.dydx.abacus.output.input.TradeInputGoodUntil
 import exchange.dydx.abacus.output.input.TriggerOrder
-import exchange.dydx.abacus.state.manager.HumanReadableCancelMultipleOrdersPayload
+import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -39,7 +39,7 @@ internal interface SubaccountTransactionPayloadProviderProtocol {
     fun cancelOrderPayload(orderId: String): HumanReadableCancelOrderPayload
 
     @Throws(Exception::class)
-    fun cancelOrdersPayload(marketId: String?): HumanReadableCancelMultipleOrdersPayload
+    fun cancelAllOrdersPayload(marketId: String?): HumanReadableCancelAllOrdersPayload
 
     fun triggerOrdersPayload(currentHeight: Int?): HumanReadableTriggerOrdersPayload
 
@@ -176,18 +176,18 @@ internal class SubaccountTransactionPayloadProvider(
     }
 
     @Throws(Exception::class)
-    override fun cancelOrdersPayload(
+    override fun cancelAllOrdersPayload(
         marketId: String?,
-    ): HumanReadableCancelMultipleOrdersPayload {
+    ): HumanReadableCancelAllOrdersPayload {
         val subaccount = stateMachine.state?.subaccount(subaccountNumber) ?: throw Exception("subaccount is null")
         val openOrders = subaccount.orders?.let { orders ->
-            orders.filter { ( marketId == null || it.marketId == marketId ) && it.status.isOpen }
+            orders.filter { (marketId == null || it.marketId == marketId) && it.status.isOpen }
         } ?: iEmptyList()
         val cancelPayloads = openOrders.map { cancelOrderPayload(it.id) }.sortedBy { payload -> payload.orderFlags }.toIList()
 
-        return HumanReadableCancelMultipleOrdersPayload(
+        return HumanReadableCancelAllOrdersPayload(
             marketId = marketId,
-            payloads = cancelPayloads
+            payloads = cancelPayloads,
         )
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/AnalyticsUtils.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/AnalyticsUtils.kt
@@ -180,9 +180,10 @@ class AnalyticsUtils {
         existingOrder: SubaccountOrder?,
         fromSlTpDialog: Boolean? = false,
         isOrphanedTriggerOrder: Boolean = false,
+        isCancelAll: Boolean = false,
     ): IMap<String, Any>? {
         return ParsingHelper.merge(
-            formatCancelOrderPayload(payload, fromSlTpDialog, isOrphanedTriggerOrder),
+            formatCancelOrderPayload(payload, fromSlTpDialog, isOrphanedTriggerOrder, isCancelAll),
             if (existingOrder != null) formatOrder(existingOrder) else mapOf(),
         )?.toIMap()
     }
@@ -196,10 +197,12 @@ class AnalyticsUtils {
         payload: HumanReadableCancelOrderPayload,
         fromSlTpDialog: Boolean? = false,
         isOrphanedTriggerOrder: Boolean = false,
+        isCancelAll: Boolean = false,
     ): IMap<String, Any>? {
         return iMapOf(
             "fromSlTpDialog" to fromSlTpDialog,
             "isAutomaticallyCanceledByFrontend" to isOrphanedTriggerOrder,
+            "isCancelAll" to isCancelAll,
             "subaccountNumber" to payload.subaccountNumber,
             "clientId" to payload.clientId,
             "orderId" to payload.orderId,

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -217,7 +217,7 @@ class V4TransactionTests : NetworkTests() {
         val callback: TransactionCallback = { _, _, _ -> statefulCancelCalledCount++ }
         val cancelPayloads = testChain!!.canceldOrderPayloads
 
-        subaccountSupervisor?.cancelOrders(null, callback)
+        subaccountSupervisor?.cancelAllOrders(null, callback)
         // there are 2 short term orders and 4 stateful orders
         // hence 2 stateful orders should be queued
         assertEquals(3, cancelPayloads.size)
@@ -239,7 +239,7 @@ class V4TransactionTests : NetworkTests() {
         val callback: TransactionCallback = { _, _, _ -> statefulCancelCalledCount++ }
         val cancelPayloads = testChain!!.canceldOrderPayloads
 
-        subaccountSupervisor?.cancelOrders("ETH-USD", callback)
+        subaccountSupervisor?.cancelAllOrders("ETH-USD", callback)
         // there are 1 short term order and 3 stateful orders in "ETH"
         // hence 2 stateful orders should be queued
         assertEquals(2, cancelPayloads.size)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -209,6 +209,50 @@ class V4TransactionTests : NetworkTests() {
     }
 
     @Test
+    fun testCancelAllOrders() {
+        setStateMachineConnected(stateManager)
+        testWebSocket?.simulateReceived(mock.accountsChannel.v4_channel_data_with_orders)
+
+        var statefulCancelCalledCount = 0
+        val callback: TransactionCallback = { _, _, _ -> statefulCancelCalledCount++ }
+        val cancelPayloads = testChain!!.canceldOrderPayloads
+
+        subaccountSupervisor?.cancelOrders(null, callback)
+        // there are 2 short term orders and 4 stateful orders
+        // hence 2 stateful orders should be queued
+        assertEquals(3, cancelPayloads.size)
+        assertEquals(2, subaccountSupervisor?.transactionQueue?.size)
+        repeat(4) {
+            testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
+        }
+
+        assertEquals(4, statefulCancelCalledCount)
+        assertEquals(5, cancelPayloads.size)
+    }
+
+    @Test
+    fun testCancelAllOrdersUnderMarket() {
+        setStateMachineConnected(stateManager)
+        testWebSocket?.simulateReceived(mock.accountsChannel.v4_channel_data_with_orders)
+
+        var statefulCancelCalledCount = 0
+        val callback: TransactionCallback = { _, _, _ -> statefulCancelCalledCount++ }
+        val cancelPayloads = testChain!!.canceldOrderPayloads
+
+        subaccountSupervisor?.cancelOrders("ETH-USD", callback)
+        // there are 1 short term order and 3 stateful orders in "ETH"
+        // hence 2 stateful orders should be queued
+        assertEquals(2, cancelPayloads.size)
+        assertEquals(2, subaccountSupervisor?.transactionQueue?.size)
+        repeat(3) {
+            testChain?.simulateTransactionResponse(testChain!!.dummySuccess)
+        }
+        assertTransactionQueueEmpty()
+        assertEquals(3, statefulCancelCalledCount)
+        assertEquals(4, cancelPayloads.size)
+    }
+
+    @Test
     fun testCancelTriggerOrdersWithClosedOrFlippedPositions() {
         setStateMachineConnected(stateManager)
         val canceldOrderPayloads = testChain!!.canceldOrderPayloads

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AccountsChannelMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/payloads/AccountsChannelMock.kt
@@ -1949,6 +1949,28 @@ internal class AccountsChannelMock {
                     "goodTilBlock": "8864635",
                     "ticker": "ETH-USD",
                     "clientMetadata": "1"
+                },
+                {
+                    "id": "734617f4-29ba-50fe-878d-391ad4e4fbae",
+                    "subaccountId": "e470a747-3aa0-543e-aafa-0bd27d568901",
+                    "clientId": "1597910999",
+                    "clobPairId": "0",
+                    "side": "BUY",
+                    "size": "0.1",
+                    "totalFilled": "0",
+                    "price": "42000",
+                    "type": "LIMIT",
+                    "status": "OPEN",
+                    "timeInForce": "IOC",
+                    "reduceOnly": true,
+                    "orderFlags": "0",
+                    "goodTilBlockTime": "2024-04-02T15:57:16.000Z",
+                    "createdAtHeight": "8489771",
+                    "clientMetadata": "0",
+                    "updatedAt": "2024-03-15T06:37:01.731Z",
+                    "updatedAtHeight": "8489771",
+                    "postOnly": false,
+                    "ticker": "BTC-USD"
                 }
               ],
               "fills":[

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version = '1.9.9'
+    spec.version = '1.9.10'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
add functionality to cancel all orders (either in all markets or a single market)

(originally wanted to use batch cancel for short term orders, but integration was a bit more complicated (due to needing tx broadcast mode to get success/failed order ids, and canceling short term orders via FE almost always fails). therefore will reconsider when batch cancel also support stateful orders.

-> decided to just rely on TX queue to submit cancels one by one. short term cancels don't need txcommit so they will go first. we could potentially run into rate limiting issue here but decided that it'll be rare for retail users.)

testing:
- unit test
- tested locally on web