### PR TITLE
TRCL-3643 Static Typing: TransferInput

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/ReceiptCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/ReceiptCalculator.kt
@@ -3,7 +3,9 @@ package exchange.dydx.abacus.calculator
 import exchange.dydx.abacus.output.input.InputType
 import exchange.dydx.abacus.output.input.OrderType
 import exchange.dydx.abacus.output.input.ReceiptLine
+import exchange.dydx.abacus.output.input.TransferType
 import exchange.dydx.abacus.state.internalstate.InternalInputState
+import exchange.dydx.abacus.state.manager.StatsigConfig
 
 internal class ReceiptCalculator {
     fun calculate(
@@ -48,51 +50,46 @@ internal class ReceiptCalculator {
                 }
 
                 InputType.TRANSFER -> {
-                    null // TODO when working with transfer
-                    /*
-                val transfer = parser.asNativeMap(input["transfer"]) ?: return null
-                val type = parser.asString(transfer["type"]) ?: return null
-                return when (type) {
-                    "DEPOSIT", "WITHDRAWAL" -> {
-                        if (StatsigConfig.useSkip) {
+                    when (input.transfer.type) {
+                        TransferType.deposit, TransferType.withdrawal -> {
+                            if (StatsigConfig.useSkip) {
+                                listOf(
+                                    ReceiptLine.Equity,
+                                    ReceiptLine.BuyingPower,
+                                    ReceiptLine.BridgeFee,
+                                    // add these back when supported by Skip
+//                            ReceiptLine.ExchangeRate,
+//                            ReceiptLine.ExchangeReceived,
+//                            ReceiptLine.Fee,
+                                    ReceiptLine.Slippage,
+                                    ReceiptLine.TransferRouteEstimatedDuration,
+                                )
+                            } else {
+                                listOf(
+                                    ReceiptLine.Equity,
+                                    ReceiptLine.BuyingPower,
+                                    ReceiptLine.ExchangeRate,
+                                    ReceiptLine.ExchangeReceived,
+                                    ReceiptLine.Fee,
+//                                ReceiptLine.BridgeFee,
+                                    ReceiptLine.Slippage,
+                                    ReceiptLine.TransferRouteEstimatedDuration,
+                                )
+                            }
+                        }
+
+                        TransferType.transferOut -> {
                             listOf(
-                                ReceiptLine.Equity.rawValue,
-                                ReceiptLine.BuyingPower.rawValue,
-                                ReceiptLine.BridgeFee.rawValue,
-                                // add these back when supported by Skip
-//                            ReceiptLine.ExchangeRate.rawValue,
-//                            ReceiptLine.ExchangeReceived.rawValue,
-//                            ReceiptLine.Fee.rawValue,
-                                ReceiptLine.Slippage.rawValue,
-                                ReceiptLine.TransferRouteEstimatedDuration.rawValue,
-                            )
-                        } else {
-                            listOf(
-                                ReceiptLine.Equity.rawValue,
-                                ReceiptLine.BuyingPower.rawValue,
-                                ReceiptLine.ExchangeRate.rawValue,
-                                ReceiptLine.ExchangeReceived.rawValue,
-                                ReceiptLine.Fee.rawValue,
-//                                ReceiptLine.BridgeFee.rawValue,
-                                ReceiptLine.Slippage.rawValue,
-                                ReceiptLine.TransferRouteEstimatedDuration.rawValue,
+                                ReceiptLine.Equity,
+                                ReceiptLine.MarginUsage,
+                                ReceiptLine.Fee,
                             )
                         }
-                    }
 
-                    "TRANSFER_OUT" -> {
-                        listOf(
-                            ReceiptLine.Equity.rawValue,
-                            ReceiptLine.MarginUsage.rawValue,
-                            ReceiptLine.Fee.rawValue,
-                        )
+                        else -> {
+                            listOf()
+                        }
                     }
-
-                    else -> {
-                        listOf()
-                    }
-                }
-                     */
                 }
 
                 InputType.ADJUST_ISOLATED_MARGIN -> {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TransferInputCalculatorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TransferInputCalculatorV2.kt
@@ -1,0 +1,140 @@
+package exchange.dydx.abacus.calculator.v2
+
+import exchange.dydx.abacus.calculator.CalculationPeriod
+import exchange.dydx.abacus.output.input.TransferInputSummary
+import exchange.dydx.abacus.output.input.TransferType
+import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.state.internalstate.InternalTransferInputState
+import exchange.dydx.abacus.state.internalstate.InternalWalletState
+
+internal class TransferInputCalculatorV2(
+    private val parser: ParserProtocol,
+    private val subaccountTransformer: SubaccountTransformerV2 = SubaccountTransformerV2(parser),
+) {
+    fun calculate(
+        transfer: InternalTransferInputState,
+        wallet: InternalWalletState,
+        subaccountNumber: Int?,
+    ): InternalTransferInputState {
+        if (wallet.isAccountConnected && transfer.type != null) {
+            finalize(transfer)
+
+            subaccountTransformer.applyTransferToWallet(
+                wallet = wallet,
+                subaccountNumber = subaccountNumber,
+                transfer = transfer,
+                parser = parser,
+                period = CalculationPeriod.post,
+            )
+        }
+        return transfer
+    }
+
+    private fun finalize(
+        transfer: InternalTransferInputState,
+    ): InternalTransferInputState {
+        transfer.summary = summaryForType(transfer)
+        return transfer
+    }
+
+    private fun summaryForType(
+        transfer: InternalTransferInputState,
+    ): TransferInputSummary? {
+        val type = transfer.type ?: return null
+        when (type) {
+            TransferType.deposit -> {
+                val size = parser.asDouble(transfer.size?.size)
+                var usdcSize = parser.asDouble(transfer.size?.usdcSize)
+                val fee = parser.asDouble(transfer.fee)
+
+                val route = transfer.route
+
+                val slippage = parser.asDouble(parser.value(route, "slippage"))
+                val exchangeRate = parser.asDouble(parser.value(route, "exchangeRate"))
+                val estimatedRouteDuration = parser.asDouble(parser.value(route, "estimatedRouteDuration"))
+                val bridgeFee = parser.asDouble(parser.value(route, "bridgeFee"))
+                val gasFee = parser.asDouble(parser.value(route, "gasFee"))
+                val toAmount = parser.asDouble(parser.value(route, "toAmount"))
+                val toAmountMin = parser.asDouble(parser.value(route, "toAmountMin"))
+                val toAmountUSDC = parser.asDouble(parser.value(route, "toAmountUSDC"))
+                var aggregatePriceImpact = parser.asDouble(parser.value(route, "aggregatePriceImpact"))
+                aggregatePriceImpact = if (aggregatePriceImpact != null) aggregatePriceImpact / 100.0 else null
+
+                usdcSize = if (usdcSize != null) {
+                    usdcSize
+                } else if (size != null && exchangeRate != null) {
+                    exchangeRate * size
+                } else {
+                    null
+                }
+
+                return TransferInputSummary(
+                    filled = true,
+                    fee = fee,
+                    slippage = slippage,
+                    exchangeRate = exchangeRate,
+                    estimatedRouteDuration = estimatedRouteDuration,
+                    usdcSize = usdcSize,
+                    bridgeFee = bridgeFee,
+                    gasFee = gasFee,
+                    toAmount = toAmount,
+                    toAmountMin = toAmountMin,
+                    toAmountUSDC = toAmountUSDC,
+                    aggregatePriceImpact = aggregatePriceImpact,
+                )
+            }
+
+            TransferType.withdrawal -> {
+                val usdcSize = parser.asDouble(transfer.size?.usdcSize)
+                val fee = parser.asDouble(transfer.fee)
+
+                val route = transfer.route
+
+                val slippage = parser.asDouble(parser.value(route, "slippage"))
+                val exchangeRate = parser.asDouble(parser.value(route, "exchangeRate"))
+                val estimatedRouteDuration = parser.asDouble(parser.value(route, "estimatedRouteDuration"))
+                val bridgeFee = parser.asDouble(parser.value(route, "bridgeFee"))
+                val gasFee = parser.asDouble(parser.value(route, "gasFee"))
+                val toAmount = parser.asDouble(parser.value(route, "toAmount"))
+                val toAmountMin = parser.asDouble(parser.value(route, "toAmountMin"))
+                val toAmountUSDC = parser.asDouble(parser.value(route, "toAmountUSDC"))
+                var aggregatePriceImpact = parser.asDouble(parser.value(route, "aggregatePriceImpact"))
+                aggregatePriceImpact = if (aggregatePriceImpact != null) aggregatePriceImpact / 100.0 else null
+
+                return TransferInputSummary(
+                    filled = true,
+                    fee = fee,
+                    slippage = slippage,
+                    exchangeRate = exchangeRate,
+                    estimatedRouteDuration = estimatedRouteDuration,
+                    usdcSize = usdcSize,
+                    bridgeFee = bridgeFee,
+                    gasFee = gasFee,
+                    toAmount = toAmount,
+                    toAmountMin = toAmountMin,
+                    toAmountUSDC = toAmountUSDC,
+                    aggregatePriceImpact = aggregatePriceImpact,
+                )
+            }
+
+            TransferType.transferOut -> {
+                val usdcSize = parser.asDouble(transfer.size?.usdcSize)
+
+                return TransferInputSummary(
+                    filled = true,
+                    gasFee = transfer.fee,
+                    usdcSize = usdcSize,
+                    fee = null,
+                    slippage = null,
+                    exchangeRate = null,
+                    estimatedRouteDuration = null,
+                    bridgeFee = null,
+                    toAmount = null,
+                    toAmountMin = null,
+                    toAmountUSDC = null,
+                    aggregatePriceImpact = null,
+                )
+            }
+        }
+    }
+}

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/Input.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/Input.kt
@@ -70,8 +70,14 @@ data class Input(
                     ClosePositionInput.create(existing?.closePosition, parser, parser.asMap(data?.get("closePosition")))
                 }
 
-                val transfer =
-                    TransferInput.create(existing?.transfer, parser, parser.asMap(data?.get("transfer")), environment, internalState?.transfer)
+                val transfer = TransferInput.create(
+                    existing = existing?.transfer,
+                    parser = parser,
+                    data = parser.asMap(data?.get("transfer")),
+                    environment = environment,
+                    internalState = internalState?.input?.transfer,
+                    staticTyping = staticTyping,
+                )
 
                 val triggerOrders = if (staticTyping) {
                     TriggerOrdersInput.create(state = internalState?.input?.triggerOrders)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
@@ -41,9 +41,9 @@ data class DepositInputOptions(
                 val needsAddress = parser.asBool(data["needsAddress"])
                 val needsFastSpeed = parser.asBool(data["needsFastSpeed"])
 
-                val chains: IList<SelectionOption>? = internalState?.chains?.toIList() ?: iListOf()
+                val chains: IList<SelectionOption> = internalState?.chains?.toIList() ?: iListOf()
 
-                val assets: IList<SelectionOption>? = internalState?.tokens?.toIList() ?: iListOf()
+                val assets: IList<SelectionOption> = internalState?.tokens?.toIList() ?: iListOf()
 
                 var exchanges: IMutableList<SelectionOption>? = null
                 exchangeList?.let { data ->
@@ -63,12 +63,12 @@ data class DepositInputOptions(
                     existing?.assets != assets
                 ) {
                     DepositInputOptions(
-                        needsSize,
-                        needsAddress,
-                        needsFastSpeed,
-                        exchanges,
-                        chains,
-                        assets,
+                        needsSize = needsSize,
+                        needsAddress = needsAddress,
+                        needsFastSpeed = needsFastSpeed,
+                        exchanges = exchanges,
+                        chains = chains,
+                        assets = assets,
                     )
                 } else {
                     existing
@@ -104,9 +104,9 @@ data class WithdrawalInputOptions(
                 val needsAddress = parser.asBool(data["needsAddress"])
                 val needsFastSpeed = parser.asBool(data["needsFastSpeed"])
 
-                val chains: IList<SelectionOption>? = internalState?.chains?.toIList() ?: iListOf()
+                val chains: IList<SelectionOption> = internalState?.chains?.toIList() ?: iListOf()
 
-                val assets: IList<SelectionOption>? = internalState?.tokens?.toIList() ?: iListOf()
+                val assets: IList<SelectionOption> = internalState?.tokens?.toIList() ?: iListOf()
 
                 var exchanges: IMutableList<SelectionOption>? = null
                 exchangeList?.let { data ->
@@ -126,12 +126,12 @@ data class WithdrawalInputOptions(
                     existing?.assets != assets
                 ) {
                     WithdrawalInputOptions(
-                        needsSize,
-                        needsAddress,
-                        needsFastSpeed,
-                        exchanges,
-                        chains,
-                        assets,
+                        needsSize = needsSize,
+                        needsAddress = needsAddress,
+                        needsFastSpeed = needsFastSpeed,
+                        exchanges = exchanges,
+                        chains = chains,
+                        assets = assets,
                     )
                 } else {
                     existing
@@ -166,10 +166,10 @@ data class TransferOutInputOptions(
             val chainName = environment?.chainName
             val chainOption: SelectionOption = if (chainName != null) {
                 SelectionOption(
-                    "chain",
-                    chainName,
-                    null,
-                    environment.chainLogo,
+                    type = "chain",
+                    string = chainName,
+                    stringKey = null,
+                    iconUrl = environment.chainLogo,
                 )
             } else {
                 return null
@@ -179,10 +179,10 @@ data class TransferOutInputOptions(
             val assets: IList<SelectionOption> = environment.tokens.keys.map { key ->
                 val token = environment.tokens[key]!!
                 SelectionOption(
-                    key,
-                    token.name,
-                    null,
-                    token.imageUrl,
+                    type = key,
+                    string = token.name,
+                    stringKey = null,
+                    iconUrl = token.imageUrl,
                 )
             }.toIList()
 
@@ -192,10 +192,10 @@ data class TransferOutInputOptions(
                 existing.assets != assets
             ) {
                 TransferOutInputOptions(
-                    needsSize,
-                    needsAddress,
-                    chains,
-                    assets,
+                    needsSize = needsSize,
+                    needsAddress = needsAddress,
+                    chains = chains,
+                    assets = assets,
                 )
             } else {
                 existing
@@ -462,8 +462,8 @@ enum class TransferType(val rawValue: String) {
     transferOut("TRANSFER_OUT");
 
     companion object {
-        operator fun invoke(rawValue: String) =
-            TransferType.values().firstOrNull { it.rawValue == rawValue }
+        operator fun invoke(rawValue: String?) =
+            entries.firstOrNull { it.rawValue == rawValue }
     }
 }
 
@@ -498,71 +498,103 @@ data class TransferInput(
             parser: ParserProtocol,
             data: Map<*, *>?,
             environment: V4Environment?,
-            internalState: InternalTransferInputState?
+            internalState: InternalTransferInputState?,
+            staticTyping: Boolean,
         ): TransferInput? {
             Logger.d { "creating Transfer Input\n" }
 
-            data?.let {
-                val type = parser.asString(data["type"])?.let {
-                    TransferType.invoke(it)
+            if (internalState != null || data != null) {
+                val type = if (staticTyping) {
+                    internalState?.type
+                } else {
+                    parser.asString(data?.get("type"))?.let {
+                        TransferType.invoke(it)
+                    }
                 }
 
-                val size =
-                    TransferInputSize.create(existing?.size, parser, parser.asMap(data["size"]))
-                val fastSpeed = parser.asBool(data["fastSpeed"]) ?: false
-                val fee = parser.asDouble(data["fee"])
-                val exchange = parser.asString(data["exchange"])
-                val chain = parser.asString(data["chain"])
-                val token = parser.asString(data["token"])
-                val address = parser.asString(data["address"])
-                val memo = parser.asString(data["memo"])
+                val size = if (staticTyping) {
+                    internalState?.size
+                } else {
+                    TransferInputSize.create(existing?.size, parser, parser.asMap(data?.get("size")))
+                }
+                val fastSpeed = if (staticTyping) internalState?.fastSpeed ?: false else parser.asBool(data?.get("fastSpeed")) ?: false
+                val fee = if (staticTyping) internalState?.fee else parser.asDouble(data?.get("fee"))
+                val exchange = if (staticTyping) internalState?.exchange else parser.asString(data?.get("exchange"))
+                val chain = if (staticTyping) internalState?.chain else parser.asString(data?.get("chain"))
+                val token = if (staticTyping) internalState?.token else parser.asString(data?.get("token"))
+                val address = if (staticTyping) internalState?.address else parser.asString(data?.get("address"))
+                val memo = if (staticTyping) internalState?.memo else parser.asString(data?.get("memo"))
 
                 var depositOptions: DepositInputOptions? = null
                 if (type == TransferType.deposit) {
-                    depositOptions = DepositInputOptions.create(
-                        existing?.depositOptions,
-                        parser,
-                        parser.asMap(data["depositOptions"]),
-                        internalState,
-                    )
+                    depositOptions = if (staticTyping) {
+                        internalState?.depositOptions
+                    } else {
+                        DepositInputOptions.create(
+                            existing = existing?.depositOptions,
+                            parser = parser,
+                            data = parser.asMap(data?.get("depositOptions")),
+                            internalState = internalState,
+                        )
+                    }
                 }
 
                 var withdrawalOptions: WithdrawalInputOptions? = null
                 if (type == TransferType.withdrawal) {
-                    withdrawalOptions = WithdrawalInputOptions.create(
-                        existing?.withdrawalOptions,
-                        parser,
-                        parser.asMap(data["withdrawalOptions"]),
-                        internalState,
-                    )
+                    withdrawalOptions = if (staticTyping) {
+                        internalState?.withdrawalOptions
+                    } else {
+                        WithdrawalInputOptions.create(
+                            existing = existing?.withdrawalOptions,
+                            parser = parser,
+                            data = parser.asMap(data?.get("withdrawalOptions")),
+                            internalState = internalState,
+                        )
+                    }
                 }
 
                 var transferOutOptions: TransferOutInputOptions? = null
                 if (type == TransferType.transferOut) {
-                    transferOutOptions = TransferOutInputOptions.create(
-                        existing?.transferOutOptions,
-                        parser,
-                        parser.asMap(data["transferOutOptions"]),
-                        environment,
+                    transferOutOptions = if (staticTyping) {
+                        internalState?.transferOutOptions
+                    } else {
+                        TransferOutInputOptions.create(
+                            existing = existing?.transferOutOptions,
+                            parser = parser,
+                            data = parser.asMap(data?.get("transferOutOptions")),
+                            environment = environment,
+                        )
+                    }
+                }
+
+                val summary = if (staticTyping) {
+                    internalState?.summary
+                } else {
+                    TransferInputSummary.create(
+                        existing = existing?.summary,
+                        parser = parser,
+                        data = parser.asMap(data?.get("summary")),
                     )
                 }
 
-                val summary = TransferInputSummary.create(
-                    existing?.summary,
-                    parser,
-                    parser.asMap(data["summary"]),
-                )
+                val resources = if (staticTyping) {
+                    internalState?.resources
+                } else {
+                    TransferInputResources.create(
+                        existing = existing?.resources,
+                        internalState = internalState,
+                    )
+                }
 
-                val resources = TransferInputResources.create(
-                    existing?.resources,
-                    internalState,
-                )
-
-                val route = parser.asMap(data["route"])
+                val route = if (staticTyping) {
+                    internalState?.route
+                } else {
+                    parser.asMap(data?.get("route"))
+                }
                 val requestPayload = TransferInputRequestPayload.create(
-                    null,
-                    parser,
-                    parser.asMap(route?.get("requestPayload")),
+                    existing = null,
+                    parser = parser,
+                    data = parser.asMap(route?.get("requestPayload")),
                 )
 
                 val errors = parser.asString(route?.get("errors"))
@@ -597,24 +629,24 @@ data class TransferInput(
                     existing.warning != warning
                 ) {
                     TransferInput(
-                        type,
-                        size,
-                        fastSpeed,
-                        fee,
-                        exchange,
-                        chain,
-                        token,
-                        address,
-                        memo,
-                        depositOptions,
-                        withdrawalOptions,
-                        transferOutOptions,
-                        summary,
-                        resources,
-                        requestPayload,
-                        errors,
-                        errorMessage,
-                        warning,
+                        type = type,
+                        size = size,
+                        fastSpeed = fastSpeed,
+                        fee = fee,
+                        exchange = exchange,
+                        chain = chain,
+                        token = token,
+                        address = address,
+                        memo = memo,
+                        depositOptions = depositOptions,
+                        withdrawalOptions = withdrawalOptions,
+                        transferOutOptions = transferOutOptions,
+                        summary = summary,
+                        resources = resources,
+                        requestPayload = requestPayload,
+                        errors = errors,
+                        errorMessage = errorMessage,
+                        warning = warning,
                     )
                 } else {
                     existing

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/TransferInputProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/TransferInputProcessor.kt
@@ -1,0 +1,371 @@
+package exchange.dydx.abacus.processor.input
+
+import exchange.dydx.abacus.calculator.v2.TransferInputCalculatorV2
+import exchange.dydx.abacus.output.input.DepositInputOptions
+import exchange.dydx.abacus.output.input.InputType
+import exchange.dydx.abacus.output.input.SelectionOption
+import exchange.dydx.abacus.output.input.TransferInputResources
+import exchange.dydx.abacus.output.input.TransferInputSize
+import exchange.dydx.abacus.output.input.TransferOutInputOptions
+import exchange.dydx.abacus.output.input.TransferType
+import exchange.dydx.abacus.output.input.WithdrawalInputOptions
+import exchange.dydx.abacus.processor.router.IRouterProcessor
+import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.responses.ParsingError
+import exchange.dydx.abacus.state.changes.Changes
+import exchange.dydx.abacus.state.changes.StateChanges
+import exchange.dydx.abacus.state.internalstate.InternalInputState
+import exchange.dydx.abacus.state.internalstate.InternalTransferInputState
+import exchange.dydx.abacus.state.internalstate.InternalWalletState
+import exchange.dydx.abacus.state.internalstate.safeCreate
+import exchange.dydx.abacus.state.manager.ExchangeConfig.exchangeList
+import exchange.dydx.abacus.state.manager.V4Environment
+import exchange.dydx.abacus.state.model.TransferInputField
+import exchange.dydx.abacus.utils.IList
+import exchange.dydx.abacus.utils.IMutableList
+import kollections.iListOf
+import kollections.iMutableListOf
+import kollections.toIList
+import kollections.toIMap
+
+internal class TransferInputProcessor(
+    private val parser: ParserProtocol,
+    private val calculator: TransferInputCalculatorV2 = TransferInputCalculatorV2(parser = parser),
+    private val routerProcessor: IRouterProcessor,
+    private val environment: V4Environment?
+) {
+    fun transfer(
+        inputState: InternalInputState,
+        walletState: InternalWalletState,
+        data: String?,
+        inputField: TransferInputField,
+        subaccountNumber: Int = 0
+    ): InputProcessorResult {
+        val error: ParsingError? = null
+
+        if (inputState.currentType != InputType.TRANSFER) {
+            inputState.currentType = InputType.TRANSFER
+
+            inputState.transfer.size = null
+            inputState.transfer.fastSpeed = false
+            inputState.transfer.fee = null
+            inputState.transfer.exchange = null
+            inputState.transfer.chain = null
+            inputState.transfer.token = null
+            inputState.transfer.address = null
+            inputState.transfer.memo = null
+            inputState.transfer.depositOptions = null
+            inputState.transfer.withdrawalOptions = null
+            inputState.transfer.transferOutOptions = null
+            inputState.transfer.summary = null
+            inputState.transfer.resources = null
+            inputState.transfer.route = null
+
+            inputState.transfer.type = TransferType.deposit
+            val chainType = routerProcessor.defaultChainId()
+            if (chainType != null) {
+                updateTransferToChainType(inputState.transfer, chainType)
+            }
+            inputState.transfer.token = routerProcessor.defaultTokenAddress(chainType)
+
+            calculator.calculate(
+                transfer = inputState.transfer,
+                wallet = walletState,
+                subaccountNumber = subaccountNumber,
+            )
+        }
+
+        val transfer = inputState.transfer
+
+        var updated = false
+        when (inputField) {
+            TransferInputField.type -> {
+                val type = TransferType.invoke(data)
+                if (transfer.type != type) {
+                    transfer.type = type
+                    transfer.size =
+                        TransferInputSize.safeCreate(transfer.size)
+                            .copy(size = null, usdcSize = null)
+                    transfer.route = null
+                    transfer.memo = null
+                    if (type == TransferType.transferOut) {
+                        transfer.chain = "chain"
+                        transfer.token = "usdc"
+                    } else {
+                        val chainType = routerProcessor.defaultChainId()
+                        if (chainType != null) {
+                            updateTransferToChainType(transfer, chainType)
+                        }
+                        transfer.token = routerProcessor.defaultTokenAddress(chainType)
+                    }
+                }
+                updated = true
+            }
+
+            TransferInputField.address -> {
+                if (transfer.address != data) {
+                    transfer.address = data
+                    transfer.route = null
+                    updated = true
+                }
+            }
+
+            TransferInputField.token -> {
+                if (transfer.token != data) {
+                    transfer.token = data
+                    transfer.size = TransferInputSize.safeCreate(transfer.size).copy(
+                        size = null,
+                        usdcSize = null,
+                    )
+                    if (data != null) {
+                        updateTransferToTokenType(transfer, data)
+                    }
+                    updated = true
+                }
+            }
+
+            TransferInputField.usdcSize -> {
+                if (data != transfer.size?.usdcSize) {
+                    transfer.size =
+                        TransferInputSize.safeCreate(transfer.size).copy(usdcSize = data)
+                    transfer.route = null
+                    updated = true
+                }
+            }
+
+            TransferInputField.usdcFee -> {
+                val fee = parser.asDouble(data)
+                if (transfer.fee != fee) {
+                    transfer.fee = fee
+                    transfer.route = null
+                    updated = true
+                }
+            }
+
+            TransferInputField.size -> {
+                if (transfer.size?.size != data) {
+                    transfer.size = TransferInputSize.safeCreate(transfer.size).copy(size = data)
+                    transfer.route = null
+                    if (transfer.type == TransferType.deposit) {
+                        transfer.size?.copy(usdcSize = null)
+                    }
+                    updated = true
+                }
+            }
+
+            TransferInputField.fastSpeed -> {
+                val fastSpeed = parser.asBool(data) ?: false
+                if (transfer.fastSpeed != fastSpeed) {
+                    transfer.fastSpeed = fastSpeed
+                    updated = true
+                }
+            }
+
+            TransferInputField.chain -> {
+                if (data != null) {
+                    updateTransferToChainType(transfer, data)
+                }
+                updated = true
+            }
+
+            TransferInputField.exchange -> {
+                val exchange = parser.asString(data)
+                if (exchange != null) {
+                    updateTransferExchangeType(transfer, exchange)
+                }
+                updated = true
+            }
+
+            TransferInputField.MEMO -> {
+                if (transfer.memo != data) {
+                    transfer.memo = data
+                    updated = true
+                }
+            }
+        }
+
+        val type = transfer.type
+        if (updated && type != null) {
+            when (type) {
+                TransferType.deposit -> {
+                    updateDepositOptions(transfer)
+                }
+                TransferType.withdrawal -> {
+                    updateWithdrawalOptions(transfer)
+                }
+                TransferType.transferOut -> {
+                    updateTransferOutOptions(transfer)
+                }
+            }
+
+            transfer.resources = TransferInputResources.safeCreate(transfer.resources)
+                .copy(
+                    chainResources = transfer.chainResources?.toIMap(),
+                    tokenResources = transfer.tokenResources?.toIMap(),
+                )
+        }
+
+        return InputProcessorResult(
+            changes = if (updated) {
+                StateChanges(
+                    changes = iListOf(Changes.wallet, Changes.subaccount, Changes.input),
+                    markets = null,
+                    subaccountNumbers = iListOf(subaccountNumber),
+                )
+            } else {
+                null
+            },
+            error = error,
+        )
+    }
+
+    private fun updateDepositOptions(
+        transfer: InternalTransferInputState,
+    ) {
+        val chains: IList<SelectionOption> = transfer.chains?.toIList() ?: iListOf()
+        val assets: IList<SelectionOption> = transfer.tokens?.toIList() ?: iListOf()
+        var exchanges: IMutableList<SelectionOption>? = null
+        exchangeList?.let { data ->
+            exchanges = iMutableListOf()
+            for (i in data.indices) {
+                val item = data[i]
+                val selection = SelectionOption(item.name, item.label, item.label, item.icon)
+                exchanges?.add(selection)
+            }
+        }
+        transfer.depositOptions = DepositInputOptions(
+            needsSize = false,
+            needsAddress = false,
+            needsFastSpeed = false,
+            exchanges = exchanges?.toIList(),
+            chains = chains,
+            assets = assets,
+        )
+    }
+
+    private fun updateWithdrawalOptions(
+        transfer: InternalTransferInputState,
+    ) {
+        val chains: IList<SelectionOption> = transfer.chains?.toIList() ?: iListOf()
+        val assets: IList<SelectionOption> = transfer.tokens?.toIList() ?: iListOf()
+        var exchanges: IMutableList<SelectionOption>? = null
+        exchangeList?.let { data ->
+            exchanges = iMutableListOf()
+            for (i in data.indices) {
+                val item = data[i]
+                val selection = SelectionOption(item.name, item.label, item.label, item.icon)
+                exchanges?.add(selection)
+            }
+        }
+        transfer.withdrawalOptions = WithdrawalInputOptions(
+            needsSize = false,
+            needsAddress = false,
+            needsFastSpeed = false,
+            exchanges = exchanges?.toIList(),
+            chains = chains,
+            assets = assets,
+        )
+    }
+
+    private fun updateTransferOutOptions(
+        transfer: InternalTransferInputState,
+    ) {
+        val chainName = environment?.chainName
+        val chainOption: SelectionOption = if (chainName != null) {
+            SelectionOption(
+                type = "chain",
+                string = chainName,
+                stringKey = null,
+                iconUrl = environment?.chainLogo,
+            )
+        } else {
+            return
+        }
+        val chains: IList<SelectionOption> = iListOf(chainOption)
+
+        val assets: IList<SelectionOption>? = environment?.tokens?.keys?.map { key ->
+            val token = environment.tokens[key]!!
+            SelectionOption(
+                type = key,
+                string = token.name,
+                stringKey = null,
+                iconUrl = token.imageUrl,
+            )
+        }
+        transfer.transferOutOptions = TransferOutInputOptions(
+            needsSize = false,
+            needsAddress = false,
+            chains = chains,
+            assets = assets,
+        )
+    }
+
+    private fun updateTransferToChainType(
+        transfer: InternalTransferInputState,
+        chainType: String
+    ) {
+        val tokenOptions = routerProcessor.tokenOptions(chainType)
+
+        if (transfer.type != TransferType.transferOut) {
+            transfer.tokens = tokenOptions
+            transfer.chain = chainType
+            transfer.token = routerProcessor.defaultTokenAddress(chainType)
+            transfer.chainResources = routerProcessor.chainResources(chainType)
+            transfer.tokenResources = routerProcessor.tokenResources(chainType)
+        }
+        transfer.exchange = null
+        transfer.size = TransferInputSize.safeCreate(transfer.size).copy(size = null)
+        transfer.route = null
+        // needed to pass tests, remove later
+        transfer.depositOptions = DepositInputOptions.safeCreate(transfer.depositOptions)
+            .copy(assets = tokenOptions.toIList())
+        transfer.withdrawalOptions = WithdrawalInputOptions.safeCreate(transfer.withdrawalOptions)
+            .copy(assets = tokenOptions.toIList())
+    }
+
+    private fun updateTransferToTokenType(
+        transfer: InternalTransferInputState,
+        tokenAddress: String
+    ) {
+        // Code not used
+//        val selectedChainId = transfer.chain
+//        if (transfer.type == TransferType.transferOut) {
+//            transfer.size = TransferInputSize.safeCreate(transfer.size).copy(
+//                size = null, usdcSize = null
+//            )
+//        } else {
+//            transfer.safeSet(
+//                "resources.tokenSymbol",
+//                routerProcessor.selectedTokenSymbol(tokenAddress = tokenAddress, selectedChainId = selectedChainId),
+//            )
+//            transfer.safeSet(
+//                "resources.tokenDecimals",
+//                routerProcessor.selectedTokenDecimals(tokenAddress = tokenAddress, selectedChainId = selectedChainId),
+//            )
+//        }
+        transfer.route = null
+    }
+
+    private fun updateTransferExchangeType(
+        transfer: InternalTransferInputState,
+        exchange: String
+    ) {
+        val exchangeDestinationChainId = routerProcessor.exchangeDestinationChainId
+        val tokenOptions = routerProcessor.tokenOptions(exchangeDestinationChainId)
+        if (transfer.type != TransferType.transferOut) {
+            transfer.tokens = tokenOptions
+            transfer.token = routerProcessor.defaultTokenAddress(exchangeDestinationChainId)
+            transfer.tokenResources = routerProcessor.tokenResources(exchangeDestinationChainId)
+            // needed to pass tests, remove later
+            transfer.depositOptions = DepositInputOptions.safeCreate(transfer.depositOptions)
+                .copy(assets = tokenOptions.toIList())
+            transfer.withdrawalOptions = WithdrawalInputOptions.safeCreate(transfer.withdrawalOptions)
+                .copy(assets = tokenOptions.toIList())
+        }
+
+        transfer.exchange = exchange
+        transfer.chain = null
+        transfer.size = TransferInputSize.safeCreate(transfer.size).copy(size = null)
+        transfer.route = null
+    }
+}

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
@@ -50,7 +50,6 @@ import kotlinx.datetime.Instant
 
 internal data class InternalState(
     var assets: MutableMap<String, Asset> = mutableMapOf(),
-    val transfer: InternalTransferInputState = InternalTransferInputState(),
     val wallet: InternalWalletState = InternalWalletState(),
     var rewardsParams: InternalRewardsParamsState? = null,
     val launchIncentive: InternalLaunchIncentiveState = InternalLaunchIncentiveState(),
@@ -64,6 +63,7 @@ internal data class InternalInputState(
     var closePosition: InternalTradeInputState = InternalTradeInputState(),
     var triggerOrders: InternalTriggerOrdersInputState = InternalTriggerOrdersInputState(),
     var adjustIsolatedMargin: InternalAdjustIsolatedMarginInputState = InternalAdjustIsolatedMarginInputState(),
+    var transfer: InternalTransferInputState = InternalTransferInputState(),
     var receiptLines: List<ReceiptLine>? = null,
     var errors: List<ValidationError>? = null,
     var childSubaccountErrors: List<ValidationError>? = null,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalTransferInputState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalTransferInputState.kt
@@ -1,8 +1,15 @@
 package exchange.dydx.abacus.state.internalstate
 
+import exchange.dydx.abacus.output.input.DepositInputOptions
 import exchange.dydx.abacus.output.input.SelectionOption
 import exchange.dydx.abacus.output.input.TransferInputChainResource
+import exchange.dydx.abacus.output.input.TransferInputResources
+import exchange.dydx.abacus.output.input.TransferInputSize
+import exchange.dydx.abacus.output.input.TransferInputSummary
 import exchange.dydx.abacus.output.input.TransferInputTokenResource
+import exchange.dydx.abacus.output.input.TransferOutInputOptions
+import exchange.dydx.abacus.output.input.TransferType
+import exchange.dydx.abacus.output.input.WithdrawalInputOptions
 
 internal data class InternalTransferInputState(
     var chains: List<SelectionOption>? = null,
@@ -10,4 +17,82 @@ internal data class InternalTransferInputState(
     var chainResources: Map<String, TransferInputChainResource>? = null,
     var tokenResources: Map<String, TransferInputTokenResource>? = null,
     var evmSwapVenues: List<Any?> = listOf(),
+
+    var type: TransferType? = null,
+    var size: TransferInputSize? = null,
+    var fastSpeed: Boolean = false,
+    var fee: Double? = null,
+    var exchange: String? = null,
+    var chain: String? = null,
+    var token: String? = null,
+    var address: String? = null,
+    var memo: String? = null,
+    var depositOptions: DepositInputOptions? = null,
+    var withdrawalOptions: WithdrawalInputOptions? = null,
+    var transferOutOptions: TransferOutInputOptions? = null,
+    var summary: TransferInputSummary? = null,
+    var resources: TransferInputResources? = null,
+    var route: Map<String, Any>? = null,
 )
+
+internal fun TransferInputSize.Companion.safeCreate(existing: TransferInputSize?): TransferInputSize {
+    return existing ?: TransferInputSize(
+        size = null,
+        usdcSize = null,
+    )
+}
+
+internal fun DepositInputOptions.Companion.safeCreate(existing: DepositInputOptions?): DepositInputOptions {
+    return existing ?: DepositInputOptions(
+        needsSize = null,
+        needsAddress = null,
+        needsFastSpeed = null,
+        exchanges = null,
+        chains = null,
+        assets = null,
+    )
+}
+
+internal fun WithdrawalInputOptions.Companion.safeCreate(existing: WithdrawalInputOptions?): WithdrawalInputOptions {
+    return existing ?: WithdrawalInputOptions(
+        needsSize = null,
+        needsAddress = null,
+        needsFastSpeed = null,
+        exchanges = null,
+        chains = null,
+        assets = null,
+    )
+}
+
+internal fun TransferOutInputOptions.Companion.safeCreate(existing: TransferOutInputOptions?): TransferOutInputOptions {
+    return existing ?: TransferOutInputOptions(
+        needsSize = null,
+        needsAddress = null,
+        chains = null,
+        assets = null,
+    )
+}
+
+internal fun TransferInputResources.Companion.safeCreate(existing: TransferInputResources?): TransferInputResources {
+    return existing ?: TransferInputResources(
+        chainResources = null,
+        tokenResources = null,
+    )
+}
+
+internal fun TransferInputSummary.Companion.safeCreate(existing: TransferInputSummary?): TransferInputSummary {
+    return existing ?: TransferInputSummary(
+        usdcSize = null,
+        fee = null,
+        filled = false,
+        slippage = null,
+        exchangeRate = null,
+        estimatedRouteDuration = null,
+        bridgeFee = null,
+        gasFee = null,
+        toAmount = null,
+        toAmountMin = null,
+        toAmountUSDC = null,
+        aggregatePriceImpact = null,
+    )
+}

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Environment.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Environment.kt
@@ -486,22 +486,22 @@ class V4Environment(
             val featureFlags = EnvironmentFeatureFlags.parse(parser.asMap(data["featureFlags"]), parser)
 
             return V4Environment(
-                id,
-                name,
-                ethereumChainId,
-                dydxChainId,
-                squidIntegratorId,
-                chainName,
-                "$deploymentUri$chainLogo",
-                rewardsHistoryStartDateMs,
-                isMainNet,
-                endpoints,
-                links,
-                walletConnection,
-                apps,
-                tokens,
-                governance,
-                featureFlags,
+                id = id,
+                name = name,
+                ethereumChainId = ethereumChainId,
+                dydxChainId = dydxChainId,
+                squidIntegratorId = squidIntegratorId,
+                chainName = chainName,
+                chainLogo = "$deploymentUri$chainLogo",
+                rewardsHistoryStartDateMs = rewardsHistoryStartDateMs,
+                isMainNet = isMainNet,
+                endpoints = endpoints,
+                links = links,
+                walletConnection = walletConnection,
+                apps = apps,
+                tokens = tokens,
+                governance = governance,
+                featureFlags = featureFlags,
             )
         }
 
@@ -526,11 +526,11 @@ class V4Environment(
                             "$deploymentUri$it"
                         }
                         tokens[key] = TokenInfo(
-                            name,
-                            denom,
-                            decimals,
-                            gasDenom,
-                            imageUrl,
+                            name = name,
+                            denom = denom,
+                            decimals = decimals,
+                            gasDenom = gasDenom,
+                            imageUrl = imageUrl,
                         )
                     }
                 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TransferInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TransferInput.kt
@@ -1,11 +1,13 @@
 package exchange.dydx.abacus.state.model
 
 import exchange.dydx.abacus.calculator.TransferInputCalculator
+import exchange.dydx.abacus.processor.input.TransferInputProcessor
 import exchange.dydx.abacus.responses.ParsingError
 import exchange.dydx.abacus.responses.StateResponse
 import exchange.dydx.abacus.responses.cannotModify
 import exchange.dydx.abacus.state.changes.Changes
 import exchange.dydx.abacus.state.changes.StateChanges
+import exchange.dydx.abacus.state.manager.V4Environment
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.mutableMapOf
 import exchange.dydx.abacus.utils.safeSet
@@ -31,166 +33,213 @@ enum class TransferInputField(val rawValue: String) {
 
     companion object {
         operator fun invoke(rawValue: String) =
-            TradeInputField.values().firstOrNull { it.rawValue == rawValue }
+            entries.firstOrNull { it.rawValue == rawValue }
     }
 }
 
 fun TradingStateMachine.transfer(
     data: String?,
     type: TransferInputField?,
-    subaccountNumber: Int = 0
+    subaccountNumber: Int = 0,
+    environment: V4Environment,
 ): StateResponse {
-    var changes: StateChanges? = null
-    var error: ParsingError? = null
-    val typeText = type?.rawValue
+    if (staticTyping) {
+        if (type == null) {
+            val error = ParsingError.cannotModify("type")
+            return StateResponse(state, null, iListOf(error))
+        }
 
-    val input = this.input?.mutable() ?: mutableMapOf()
-    input["current"] = "transfer"
-    val transfer = parser.asMap(input["transfer"])?.mutable() ?: kotlin.run {
-        val transfer = mutableMapOf<String, Any>()
-        transfer["type"] = "DEPOSIT"
+        val processor = TransferInputProcessor(
+            parser = parser,
+            routerProcessor = routerProcessor,
+            environment = environment,
+        )
+        val result = processor.transfer(
+            inputState = internalState.input,
+            walletState = internalState.wallet,
+            data = data,
+            inputField = type,
+            subaccountNumber = subaccountNumber,
+        )
 
-        val calculator = TransferInputCalculator(parser)
-        val params = mutableMapOf<String, Any>()
-        params.safeSet("markets", parser.asMap(marketsSummary?.get("markets")))
-        params.safeSet("account", account)
-        params.safeSet("user", user)
-        params.safeSet("transfer", transfer)
-        val modified = calculator.calculate(params, subaccountNumber)
+        if (result.changes != null) {
+            updateStateChanges(result.changes)
+        }
 
-        parser.asMap(modified["transfer"])?.mutable() ?: transfer
-    }
+        return StateResponse(
+            state = state,
+            changes = result.changes,
+            errors = if (result.error != null) iListOf(result.error) else null,
+        )
+    } else {
+        var changes: StateChanges? = null
+        var error: ParsingError? = null
+        val typeText = type?.rawValue
 
-    if (typeText != null) {
-        if (validTransferInput(transfer, typeText)) {
-            when (typeText) {
-                TransferInputField.type.rawValue -> {
-                    if (transfer["type"] != parser.asString(data)) {
-                        transfer.safeSet(typeText, parser.asString(data))
-                        transfer.safeSet("size.size", null)
-                        transfer.safeSet("size.usdcSize", null)
+        val input = this.input?.mutable() ?: mutableMapOf()
+        input["current"] = "transfer"
+        val transfer = parser.asMap(input["transfer"])?.mutable() ?: kotlin.run {
+            val transfer = mutableMapOf<String, Any>()
+            transfer["type"] = "DEPOSIT"
+
+            val calculator = TransferInputCalculator(parser)
+            val params = mutableMapOf<String, Any>()
+            params.safeSet("markets", parser.asMap(marketsSummary?.get("markets")))
+            params.safeSet("account", account)
+            params.safeSet("user", user)
+            params.safeSet("transfer", transfer)
+            val modified = calculator.calculate(params, subaccountNumber)
+
+            parser.asMap(modified["transfer"])?.mutable() ?: transfer
+        }
+
+        if (typeText != null) {
+            if (validTransferInput(transfer, typeText)) {
+                when (typeText) {
+                    TransferInputField.type.rawValue -> {
+                        if (transfer["type"] != parser.asString(data)) {
+                            transfer.safeSet(typeText, parser.asString(data))
+                            transfer.safeSet("size.size", null)
+                            transfer.safeSet("size.usdcSize", null)
+                            transfer.safeSet("route", null)
+                            transfer.safeSet("requestPayload", null)
+                            transfer.safeSet("memo", null)
+                            if (parser.asString(data) == "TRANSFER_OUT") {
+                                transfer.safeSet("chain", "chain")
+                                transfer.safeSet("token", "usdc")
+                            } else {
+                                val chainType = routerProcessor.defaultChainId()
+                                if (chainType != null) {
+                                    updateTransferToChainType(transfer, chainType)
+                                }
+                                transfer.safeSet(
+                                    "token",
+                                    routerProcessor.defaultTokenAddress(chainType),
+                                )
+                            }
+                        }
+                        changes = StateChanges(
+                            iListOf(Changes.wallet, Changes.subaccount, Changes.input),
+                            null,
+                            iListOf(subaccountNumber),
+                        )
+                    }
+
+                    TransferInputField.address.rawValue -> {
+                        val address = parser.asString(data)
+                        transfer.safeSet(typeText, address)
+                        changes = StateChanges(
+                            iListOf(Changes.wallet, Changes.subaccount, Changes.input),
+                            null,
+                            iListOf(subaccountNumber),
+                        )
                         transfer.safeSet("route", null)
                         transfer.safeSet("requestPayload", null)
-                        transfer.safeSet("memo", null)
-                        if (parser.asString(data) == "TRANSFER_OUT") {
-                            transfer.safeSet("chain", "chain")
-                            transfer.safeSet("token", "usdc")
-                        } else {
-                            val chainType = routerProcessor.defaultChainId()
-                            if (chainType != null) {
-                                updateTransferToChainType(transfer, chainType)
-                            }
-                            transfer.safeSet("token", routerProcessor.defaultTokenAddress(chainType))
-                        }
                     }
-                    changes = StateChanges(
-                        iListOf(Changes.wallet, Changes.subaccount, Changes.input),
-                        null,
-                        iListOf(subaccountNumber),
-                    )
-                }
-                TransferInputField.address.rawValue -> {
-                    val address = parser.asString(data)
-                    transfer.safeSet(typeText, address)
-                    changes = StateChanges(
-                        iListOf(Changes.wallet, Changes.subaccount, Changes.input),
-                        null,
-                        iListOf(subaccountNumber),
-                    )
-                    transfer.safeSet("route", null)
-                    transfer.safeSet("requestPayload", null)
-                }
-                TransferInputField.token.rawValue -> {
-                    val token = parser.asString(data)
-                    transfer.safeSet("size.size", null)
-                    transfer.safeSet("size.usdcSize", null)
-                    transfer.safeSet(typeText, token)
-                    if (token != null) {
-                        updateTransferToTokenType(transfer, token)
-                    }
-                    changes = StateChanges(
-                        iListOf(Changes.wallet, Changes.subaccount, Changes.input),
-                        null,
-                        iListOf(subaccountNumber),
-                    )
-                }
-                TransferInputField.usdcSize.rawValue,
-                TransferInputField.usdcFee.rawValue -> {
-                    transfer.safeSet(typeText, parser.asDouble(data))
-                    transfer.safeSet("route", null)
-                    transfer.safeSet("requestPayload", null)
-                    changes = StateChanges(
-                        iListOf(Changes.wallet, Changes.subaccount, Changes.input),
-                        null,
-                        iListOf(subaccountNumber),
-                    )
-                }
-                TransferInputField.size.rawValue -> {
-                    transfer.safeSet("size.size", parser.asDouble(data))
-                    transfer.safeSet("route", null)
-                    transfer.safeSet("requestPayload", null)
-                    if (transfer["type"] == "DEPOSIT") {
+
+                    TransferInputField.token.rawValue -> {
+                        val token = parser.asString(data)
+                        transfer.safeSet("size.size", null)
                         transfer.safeSet("size.usdcSize", null)
+                        transfer.safeSet(typeText, token)
+                        if (token != null) {
+                            updateTransferToTokenType(transfer, token)
+                        }
+                        changes = StateChanges(
+                            iListOf(Changes.wallet, Changes.subaccount, Changes.input),
+                            null,
+                            iListOf(subaccountNumber),
+                        )
                     }
-                    changes = StateChanges(
-                        iListOf(Changes.wallet, Changes.subaccount, Changes.input),
-                        null,
-                        iListOf(subaccountNumber),
-                    )
-                }
-                TransferInputField.fastSpeed.rawValue -> {
-                    transfer.safeSet(typeText, parser.asBool(data))
-                    changes = StateChanges(
-                        iListOf(Changes.wallet, Changes.subaccount, Changes.input),
-                        null,
-                        iListOf(subaccountNumber),
-                    )
-                }
-                TransferInputField.chain.rawValue -> {
-                    val chainType = parser.asString(data)
-                    if (chainType != null) {
-                        updateTransferToChainType(transfer, chainType)
+
+                    TransferInputField.usdcSize.rawValue,
+                    TransferInputField.usdcFee.rawValue -> {
+                        transfer.safeSet(typeText, parser.asDouble(data))
+                        transfer.safeSet("route", null)
+                        transfer.safeSet("requestPayload", null)
+                        changes = StateChanges(
+                            iListOf(Changes.wallet, Changes.subaccount, Changes.input),
+                            null,
+                            iListOf(subaccountNumber),
+                        )
                     }
-                    changes = StateChanges(
-                        iListOf(Changes.wallet, Changes.subaccount, Changes.input),
-                        null,
-                        iListOf(subaccountNumber),
-                    )
-                }
-                TransferInputField.exchange.rawValue -> {
-                    val exchange = parser.asString(data)
-                    if (exchange != null) {
-                        updateTransferExchangeType(transfer, exchange)
+
+                    TransferInputField.size.rawValue -> {
+                        transfer.safeSet("size.size", parser.asDouble(data))
+                        transfer.safeSet("route", null)
+                        transfer.safeSet("requestPayload", null)
+                        if (transfer["type"] == "DEPOSIT") {
+                            transfer.safeSet("size.usdcSize", null)
+                        }
+                        changes = StateChanges(
+                            iListOf(Changes.wallet, Changes.subaccount, Changes.input),
+                            null,
+                            iListOf(subaccountNumber),
+                        )
                     }
-                    changes = StateChanges(
-                        iListOf(Changes.wallet, Changes.subaccount, Changes.input),
-                        null,
-                        iListOf(subaccountNumber),
-                    )
+
+                    TransferInputField.fastSpeed.rawValue -> {
+                        transfer.safeSet(typeText, parser.asBool(data))
+                        changes = StateChanges(
+                            iListOf(Changes.wallet, Changes.subaccount, Changes.input),
+                            null,
+                            iListOf(subaccountNumber),
+                        )
+                    }
+
+                    TransferInputField.chain.rawValue -> {
+                        val chainType = parser.asString(data)
+                        if (chainType != null) {
+                            updateTransferToChainType(transfer, chainType)
+                        }
+                        changes = StateChanges(
+                            iListOf(Changes.wallet, Changes.subaccount, Changes.input),
+                            null,
+                            iListOf(subaccountNumber),
+                        )
+                    }
+
+                    TransferInputField.exchange.rawValue -> {
+                        val exchange = parser.asString(data)
+                        if (exchange != null) {
+                            updateTransferExchangeType(transfer, exchange)
+                        }
+                        changes = StateChanges(
+                            iListOf(Changes.wallet, Changes.subaccount, Changes.input),
+                            null,
+                            iListOf(subaccountNumber),
+                        )
+                    }
+
+                    TransferInputField.MEMO.rawValue -> {
+                        transfer.safeSet(typeText, parser.asString(data))
+                        changes = StateChanges(
+                            iListOf(Changes.input),
+                            null,
+                            iListOf(subaccountNumber),
+                        )
+                    }
+
+                    else -> {}
                 }
-                TransferInputField.MEMO.rawValue -> {
-                    transfer.safeSet(typeText, parser.asString(data))
-                    changes = StateChanges(
-                        iListOf(Changes.input),
-                        null,
-                        iListOf(subaccountNumber),
-                    )
-                }
-                else -> {}
+            } else {
+                error = ParsingError.cannotModify(typeText)
             }
         } else {
-            error = ParsingError.cannotModify(typeText)
+            changes = StateChanges(
+                iListOf(Changes.wallet, Changes.subaccount, Changes.input),
+                null,
+                iListOf(subaccountNumber),
+            )
         }
-    } else {
-        changes = StateChanges(iListOf(Changes.wallet, Changes.subaccount, Changes.input), null, iListOf(subaccountNumber))
-    }
-    input["transfer"] = transfer
+        input["transfer"] = transfer
 
-    this.input = input
-    changes?.let {
-        updateStateChanges(it)
+        this.input = input
+        changes?.let {
+            updateStateChanges(it)
+        }
+        return StateResponse(state, changes, if (error != null) iListOf(error) else null)
     }
-    return StateResponse(state, changes, if (error != null) iListOf(error) else null)
 }
 
 private fun TradingStateMachine.updateTransferToTokenType(transfer: MutableMap<String, Any>, tokenAddress: String) {
@@ -215,11 +264,11 @@ private fun TradingStateMachine.updateTransferToTokenType(transfer: MutableMap<S
 private fun TradingStateMachine.updateTransferToChainType(transfer: MutableMap<String, Any>, chainType: String) {
     val tokenOptions = routerProcessor.tokenOptions(chainType)
     if (transfer["type"] != "TRANSFER_OUT") {
-        internalState.transfer.tokens = tokenOptions
+        internalState.input.transfer.tokens = tokenOptions
         transfer.safeSet("chain", chainType)
         transfer.safeSet("token", routerProcessor.defaultTokenAddress(chainType))
-        internalState.transfer.chainResources = routerProcessor.chainResources(chainType)
-        internalState.transfer.tokenResources = routerProcessor.tokenResources(chainType)
+        internalState.input.transfer.chainResources = routerProcessor.chainResources(chainType)
+        internalState.input.transfer.tokenResources = routerProcessor.tokenResources(chainType)
     }
     transfer.safeSet("exchange", null)
     transfer.safeSet("size.size", null)
@@ -248,9 +297,9 @@ private fun TradingStateMachine.updateTransferExchangeType(transfer: MutableMap<
     val exchangeDestinationChainId = routerProcessor.exchangeDestinationChainId
     val tokenOptions = routerProcessor.tokenOptions(exchangeDestinationChainId)
     if (transfer["type"] != "TRANSFER_OUT") {
-        internalState.transfer.tokens = tokenOptions
+        internalState.input.transfer.tokens = tokenOptions
         transfer.safeSet("token", routerProcessor.defaultTokenAddress(exchangeDestinationChainId))
-        internalState.transfer.tokenResources = routerProcessor.tokenResources(exchangeDestinationChainId)
+        internalState.input.transfer.tokenResources = routerProcessor.tokenResources(exchangeDestinationChainId)
 
 //        needed to pass tests, remove later
         transfer.safeSet(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
@@ -11,6 +11,7 @@ import exchange.dydx.abacus.calculator.TransferInputCalculator
 import exchange.dydx.abacus.calculator.TriggerOrdersInputCalculator
 import exchange.dydx.abacus.calculator.v2.AccountCalculatorV2
 import exchange.dydx.abacus.calculator.v2.AdjustIsolatedMarginInputCalculatorV2
+import exchange.dydx.abacus.calculator.v2.TransferInputCalculatorV2
 import exchange.dydx.abacus.calculator.v2.TriggerOrdersInputCalculatorV2
 import exchange.dydx.abacus.calculator.v2.tradeinput.TradeInputCalculatorV2
 import exchange.dydx.abacus.output.Asset
@@ -123,8 +124,16 @@ open class TradingStateMachine(
     }
     internal val walletProcessor = WalletProcessor(parser, localizer)
     internal val configsProcessor = ConfigsProcessor(parser, localizer)
-    private val skipProcessor = SkipProcessor(parser = parser, internalState = internalState.transfer)
-    private val squidProcessor = SquidProcessor(parser = parser, internalState = internalState.transfer)
+    private val skipProcessor = SkipProcessor(
+        parser = parser,
+        internalState = internalState.input.transfer,
+        staticTyping = staticTyping,
+    )
+    private val squidProcessor = SquidProcessor(
+        parser = parser,
+        internalState = internalState.input.transfer,
+        staticTyping = staticTyping,
+    )
     internal val routerProcessor: IRouterProcessor
         get() {
             if (StatsigConfig.useSkip) return skipProcessor
@@ -633,21 +642,28 @@ open class TradingStateMachine(
     internal fun updateStateChanges(changes: StateChanges): StateChanges {
         if (changes.changes.contains(Changes.input)) {
             val subaccountNumber = changes.subaccountNumbers?.firstOrNull()
-
-            val subaccount = if (subaccountNumber != null) {
-                parser.asNativeMap(
-                    parser.value(
-                        this.account,
-                        "subaccounts.$subaccountNumber",
-                    ),
-                )
+            if (staticTyping) {
+                val subaccount = internalState.wallet.account.subaccounts[subaccountNumber]
+                // Only run validation if the subaccount is null since updateState will run validation for each subaccount
+                if (subaccount == null) {
+                    inputValidator.validate(
+                        internalState = internalState,
+                        subaccountNumber = subaccountNumber,
+                        currentBlockAndHeight = currentBlockAndHeight,
+                        environment = environment,
+                    )
+                }
             } else {
-                null
-            }
-
-            if (!staticTyping) {
-                // Skip this for static typing.. since the validator will be called in updateState().
-                // No need to call this twice.
+                val subaccount = if (subaccountNumber != null) {
+                    parser.asNativeMap(
+                        parser.value(
+                            this.account,
+                            "subaccounts.$subaccountNumber",
+                        ),
+                    )
+                } else {
+                    null
+                }
                 this.input = inputValidator.validateDeprecated(
                     subaccountNumber = subaccountNumber,
                     wallet = this.wallet,
@@ -807,21 +823,30 @@ open class TradingStateMachine(
     }
 
     private fun calculateTransfer(subaccountNumber: Int?) {
-        val input = this.input?.mutable()
-        val transfer = parser.asNativeMap(input?.get("transfer"))
-        val calculator = TransferInputCalculator(parser)
-        val params = mutableMapOf<String, Any>()
-        params.safeSet("markets", parser.asNativeMap(marketsSummary?.get("markets")))
-        params.safeSet("user", user)
-        params.safeSet("transfer", transfer)
-        params.safeSet("wallet", wallet)
+        if (staticTyping) {
+            val calculator = TransferInputCalculatorV2(parser = parser)
+            calculator.calculate(
+                transfer = internalState.input.transfer,
+                wallet = internalState.wallet,
+                subaccountNumber = subaccountNumber,
+            )
+        } else {
+            val input = this.input?.mutable()
+            val transfer = parser.asNativeMap(input?.get("transfer"))
+            val calculator = TransferInputCalculator(parser)
+            val params = mutableMapOf<String, Any>()
+            params.safeSet("markets", parser.asNativeMap(marketsSummary?.get("markets")))
+            params.safeSet("user", user)
+            params.safeSet("transfer", transfer)
+            params.safeSet("wallet", wallet)
 
-        val modified = calculator.calculate(params, subaccountNumber)
-        this.setMarkets(parser.asNativeMap(modified["markets"]))
-        this.wallet = parser.asNativeMap(modified["wallet"])
-        input?.safeSet("transfer", parser.asNativeMap(modified["transfer"]))
+            val modified = calculator.calculate(params, subaccountNumber)
+            this.setMarkets(parser.asNativeMap(modified["markets"]))
+            this.wallet = parser.asNativeMap(modified["wallet"])
+            input?.safeSet("transfer", parser.asNativeMap(modified["transfer"]))
 
-        this.input = input
+            this.input = input
+        }
     }
 
     private fun calculateTriggerOrders(subaccountNumber: Int) {
@@ -995,28 +1020,29 @@ open class TradingStateMachine(
                     price = null, // priceOverwrite(markets),
                     configs = null, // This is used to get the IMF.. with "null" the default value 0.05 will be used
                 )
-            }
-            this.marketsSummary?.let { marketsSummary ->
-                val periods = if (this.input != null) {
-                    setOf(
-                        CalculationPeriod.current,
-                        CalculationPeriod.post,
-                        CalculationPeriod.settled,
-                    )
-                } else {
-                    setOf(CalculationPeriod.current)
-                }
+            } else {
+                this.marketsSummary?.let { marketsSummary ->
+                    val periods = if (this.input != null) {
+                        setOf(
+                            CalculationPeriod.current,
+                            CalculationPeriod.post,
+                            CalculationPeriod.settled,
+                        )
+                    } else {
+                        setOf(CalculationPeriod.current)
+                    }
 
-                parser.asNativeMap(marketsSummary["markets"])?.let { markets ->
-                    val modifiedAccount = accountCalculator.calculate(
-                        account = account,
-                        subaccountNumbers = subaccountNumbers,
-                        configs = null,
-                        markets = markets,
-                        price = priceOverwrite(markets),
-                        periods = periods,
-                    )
-                    this.account = modifiedAccount
+                    parser.asNativeMap(marketsSummary["markets"])?.let { markets ->
+                        val modifiedAccount = accountCalculator.calculate(
+                            account = account,
+                            subaccountNumbers = subaccountNumbers,
+                            configs = null,
+                            markets = markets,
+                            price = priceOverwrite(markets),
+                            periods = periods,
+                        )
+                        this.account = modifiedAccount
+                    }
                 }
             }
         }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -318,7 +318,7 @@ internal class OnboardingSupervisor(
             OSMOSIS_SWAP_VENUE,
             NEUTRON_SWAP_VENUE,
         )
-        val evmSwapVenues = stateMachine.internalState.transfer.evmSwapVenues
+        val evmSwapVenues = stateMachine.internalState.input.transfer.evmSwapVenues
         val swapVenues = evmSwapVenues + nonEvmSwapVenues
         val evmSwapEnabledOptions = mapOf(
             "bridges" to listOf(
@@ -575,7 +575,12 @@ internal class OnboardingSupervisor(
         subaccountNumber: Int?,
     ) {
         helper.ioImplementations.threading?.async(ThreadingType.abacus) {
-            val stateResponse = stateMachine.transfer(data, type, subaccountNumber ?: 0)
+            val stateResponse = stateMachine.transfer(
+                data = data,
+                type = type,
+                subaccountNumber = subaccountNumber ?: 0,
+                environment = helper.environment,
+            )
             didUpdateStateForTransfer(data, type, accountAddress, sourceAddress, subaccountNumber)
             helper.ioImplementations.threading?.async(ThreadingType.main) {
                 helper.stateNotification?.stateChanged(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/TransferInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/TransferInputValidator.kt
@@ -9,6 +9,7 @@ import exchange.dydx.abacus.state.internalstate.InternalState
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.V4Environment
 import exchange.dydx.abacus.validator.transfer.DepositValidator
+import exchange.dydx.abacus.validator.transfer.TransferFieldsValidator
 import exchange.dydx.abacus.validator.transfer.TransferOutValidator
 import exchange.dydx.abacus.validator.transfer.WithdrawalCapacityValidator
 import exchange.dydx.abacus.validator.transfer.WithdrawalGatingValidator
@@ -19,6 +20,7 @@ internal class TransferInputValidator(
     parser: ParserProtocol,
 ) : BaseInputValidator(localizer, formatter, parser), ValidatorProtocol {
     private val transferValidators = listOf<TransferValidatorProtocol>(
+        TransferFieldsValidator(localizer, formatter, parser),
         DepositValidator(localizer, formatter, parser),
         TransferOutValidator(localizer, formatter, parser),
         WithdrawalGatingValidator(localizer, formatter, parser),
@@ -32,7 +34,26 @@ internal class TransferInputValidator(
         inputType: InputType,
         environment: V4Environment?,
     ): List<ValidationError>? {
-        return null
+        if (inputType != InputType.TRANSFER) {
+            return null
+        }
+
+        val errors = mutableListOf<ValidationError>()
+        val restricted = internalState.wallet.user?.restricted ?: false
+        for (validator in transferValidators) {
+            val validatorErrors =
+                validator.validateTransfer(
+                    internalState = internalState,
+                    currentBlockAndHeight = currentBlockAndHeight,
+                    restricted = restricted,
+                    environment = environment,
+                )
+            if (validatorErrors != null) {
+                errors.addAll(validatorErrors)
+            }
+        }
+
+        return errors
     }
 
     override fun validateDeprecated(
@@ -67,71 +88,5 @@ internal class TransferInputValidator(
             return errors
         }
         return null
-    }
-
-    private fun validateClosingOnly(
-        subaccount: Map<String, Any>?,
-        market: Map<String, Any>?,
-        trade: Map<String, Any>,
-        change: PositionChange,
-        restricted: Boolean,
-    ): Map<String, Any>? {
-        val marketId = parser.asNativeMap(market?.get("assetId")) ?: ""
-        val canTrade = parser.asBool(parser.value(market, "status.canTrade")) ?: true
-        val canReduce = parser.asBool(parser.value(market, "status.canTrade")) ?: true
-        return if (canTrade) {
-            if (restricted) {
-                when (change) {
-                    PositionChange.NEW, PositionChange.INCREASING, PositionChange.CROSSING ->
-                        errorDeprecated(
-                            type = "ERROR",
-                            errorCode = "RESTRICTED_USER",
-                            fields = listOf("size.size"),
-                            actionStringKey = "APP.TRADE.MODIFY_SIZE_FIELD",
-                            titleStringKey = "ERRORS.TRADE_BOX_TITLE.MARKET_ORDER_CLOSE_POSITION_ONLY",
-                            textStringKey = "ERRORS.TRADE_BOX.MARKET_ORDER_CLOSE_POSITION_ONLY",
-                        )
-
-                    else -> null
-                }
-            } else {
-                return null
-            }
-        } else if (canReduce) {
-            when (change) {
-                PositionChange.NEW, PositionChange.INCREASING, PositionChange.CROSSING ->
-                    errorDeprecated(
-                        type = "ERROR",
-                        errorCode = "CLOSE_ONLY_MARKET",
-                        fields = listOf("size.size"),
-                        actionStringKey = "APP.TRADE.MODIFY_SIZE_FIELD",
-                        titleStringKey = "WARNINGS.TRADE_BOX_TITLE.MARKET_STATUS_CLOSE_ONLY",
-                        textStringKey = "WARNINGS.TRADE_BOX.MARKET_STATUS_CLOSE_ONLY",
-                        textParams = mapOf(
-                            "MARKET" to mapOf(
-                                "value" to marketId,
-                                "format" to "string",
-                            ),
-                        ),
-                    )
-
-                else -> null
-            }
-        } else {
-            errorDeprecated(
-                type = "ERROR",
-                errorCode = "CLOSED_MARKET",
-                fields = null,
-                actionStringKey = null,
-                titleStringKey = "WARNINGS.TRADE_BOX_TITLE.MARKET_STATUS_CLOSE_ONLY",
-                textStringKey = "WARNINGS.TRADE_BOX.MARKET_STATUS_CLOSE_ONLY",
-                textParams = mapOf(
-                    "MARKET" to mapOf(
-                        "value" to marketId,
-                        "format" to "string",
-                    ),
-                ),
-            )
-        }
     }
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/transfer/TransferFieldsValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/transfer/TransferFieldsValidator.kt
@@ -1,0 +1,89 @@
+package exchange.dydx.abacus.validator.transfer
+
+import exchange.dydx.abacus.output.input.TransferType
+import exchange.dydx.abacus.output.input.ValidationError
+import exchange.dydx.abacus.protocols.LocalizerProtocol
+import exchange.dydx.abacus.protocols.ParserProtocol
+import exchange.dydx.abacus.state.app.helper.Formatter
+import exchange.dydx.abacus.state.internalstate.InternalState
+import exchange.dydx.abacus.state.manager.BlockAndTime
+import exchange.dydx.abacus.state.manager.V4Environment
+import exchange.dydx.abacus.validator.BaseInputValidator
+import exchange.dydx.abacus.validator.TransferValidatorProtocol
+
+internal class TransferFieldsValidator(
+    localizer: LocalizerProtocol?,
+    formatter: Formatter?,
+    parser: ParserProtocol,
+) : BaseInputValidator(localizer, formatter, parser), TransferValidatorProtocol {
+    override fun validateTransfer(
+        internalState: InternalState,
+        currentBlockAndHeight: BlockAndTime?,
+        restricted: Boolean,
+        environment: V4Environment?
+    ): List<ValidationError>? {
+        val errors = mutableListOf<ValidationError>()
+        val transfer = internalState.input.transfer
+        val type = transfer.type ?: return null
+        when (type) {
+            TransferType.deposit -> {
+                val usdcSize = parser.asDouble(transfer.size?.usdcSize) ?: 0.0
+                if (usdcSize <= 0.0) {
+                    errors.add(
+                        required(
+                            errorCode = "REQUIRED_SIZE",
+                            field = "size.usdcSize",
+                            actionStringKey = "APP.TRADE.ENTER_AMOUNT",
+                        ),
+                    )
+                }
+            }
+            TransferType.withdrawal -> {
+                val usdcSize = parser.asDouble(transfer.size?.usdcSize) ?: 0.0
+                if (usdcSize <= 0.0) {
+                    errors.add(
+                        required(
+                            errorCode = "REQUIRED_SIZE",
+                            field = "size.usdcSize",
+                            actionStringKey = "APP.TRADE.ENTER_AMOUNT",
+                        ),
+                    )
+                }
+                if (transfer.address == null) {
+                    errors.add(
+                        required(
+                            errorCode = "REQUIRED_ADDRESS",
+                            field = "address",
+                            actionStringKey = "APP.DIRECT_TRANSFER_MODAL.ENTER_ETH_ADDRESS",
+                        ),
+                    )
+                }
+            }
+            TransferType.transferOut -> {
+                if (transfer.address == null) {
+                    errors.add(
+                        required(
+                            errorCode = "REQUIRED_ADDRESS",
+                            field = "address",
+                            actionStringKey = "APP.DIRECT_TRANSFER_MODAL.ENTER_ETH_ADDRESS",
+                        ),
+                    )
+                }
+            }
+        }
+
+        return errors
+    }
+
+    override fun validateTransferDeprecated(
+        wallet: Map<String, Any>?,
+        subaccount: Map<String, Any>?,
+        transfer: Map<String, Any>,
+        configs: Map<String, Any>?,
+        currentBlockAndHeight: BlockAndTime?,
+        restricted: Boolean,
+        environment: V4Environment?
+    ): List<Any>? {
+        return null
+    }
+}

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/transfer/TransferOutValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/transfer/TransferOutValidator.kt
@@ -1,5 +1,7 @@
 package exchange.dydx.abacus.validator.transfer
 
+import exchange.dydx.abacus.output.input.ErrorType
+import exchange.dydx.abacus.output.input.TransferType
 import exchange.dydx.abacus.output.input.ValidationError
 import exchange.dydx.abacus.protocols.LocalizerProtocol
 import exchange.dydx.abacus.protocols.ParserProtocol
@@ -22,7 +24,23 @@ internal class TransferOutValidator(
         restricted: Boolean,
         environment: V4Environment?
     ): List<ValidationError>? {
-        return null
+        val transfer = internalState.input.transfer ?: return null
+        val address = transfer.address
+        val type = transfer.type
+        if (type == TransferType.transferOut && !address.isNullOrEmpty() && !address.isAddressValid()) {
+            return listOf(
+                error(
+                    type = ErrorType.error,
+                    errorCode = "INVALID_ADDRESS",
+                    fields = listOf("address"),
+                    actionStringKey = "APP.DIRECT_TRANSFER_MODAL.ADDRESS_FIELD",
+                    titleStringKey = "APP.DIRECT_TRANSFER_MODAL.INVALID_ADDRESS_TITLE",
+                    textStringKey = "APP.DIRECT_TRANSFER_MODAL.INVALID_ADDRESS_BODY",
+                ),
+            )
+        } else {
+            return null
+        }
     }
 
     override fun validateTransferDeprecated(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/transfer/WithdrawalGatingValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/transfer/WithdrawalGatingValidator.kt
@@ -23,7 +23,44 @@ internal class WithdrawalGatingValidator(
         restricted: Boolean,
         environment: V4Environment?
     ): List<ValidationError>? {
-        return null
+        val currentBlock = currentBlockAndHeight?.block ?: Int.MAX_VALUE // parser.asInt(parser.value(environment, "currentBlock"))
+        val withdrawalGating = internalState.configs.withdrawalGating
+        val withdrawalsAndTransfersUnblockedAtBlock = withdrawalGating?.withdrawalsAndTransfersUnblockedAtBlock ?: 0
+        val blockDurationSeconds = if (environment?.isMainNet == true) 1.1 else 1.5
+        val secondsUntilUnblock = ((withdrawalsAndTransfersUnblockedAtBlock - currentBlock) * blockDurationSeconds).toInt()
+
+        val type = internalState.input.transfer.type ?: return null
+        when (type) {
+            TransferType.withdrawal, TransferType.transferOut -> {
+                if (secondsUntilUnblock > 0) {
+                    return listOf(
+                        error(
+                            type = ErrorType.error,
+                            errorCode = "",
+                            fields = null,
+                            actionStringKey = "WARNINGS.ACCOUNT_FUND_MANAGEMENT.${if (type == TransferType.withdrawal) "WITHDRAWAL_PAUSED_ACTION" else "TRANSFERS_PAUSED_ACTION"}",
+                            titleStringKey = "WARNINGS.ACCOUNT_FUND_MANAGEMENT.${if (type == TransferType.withdrawal) "WITHDRAWAL_PAUSED_TITLE" else "TRANSFERS_PAUSED_TITLE"}",
+                            textStringKey = "WARNINGS.ACCOUNT_FUND_MANAGEMENT.${if (type == TransferType.withdrawal) "WITHDRAWAL_PAUSED_DESCRIPTION" else "TRANSFERS_PAUSED_DESCRIPTION"}",
+                            textParams = mapOf(
+                                "SECONDS" to mapOf(
+                                    "value" to secondsUntilUnblock,
+                                    "format" to "string",
+                                ),
+                            ),
+                            action = null,
+                            link = environment?.links?.withdrawalGateLearnMore,
+                            linkText = "APP.GENERAL.LEARN_MORE_ARROW",
+                        ),
+                    )
+                } else {
+                    return null
+                }
+            }
+
+            TransferType.deposit -> {
+                return null
+            }
+        }
     }
 
     override fun validateTransferDeprecated(
@@ -37,11 +74,6 @@ internal class WithdrawalGatingValidator(
     ): List<Any>? {
         val currentBlock = currentBlockAndHeight?.block ?: Int.MAX_VALUE // parser.asInt(parser.value(environment, "currentBlock"))
         val withdrawalGating = parser.asMap(parser.value(configs, "withdrawalGating"))
-//        val withdrawalsAndTransfersUnblockedAtBlock = if (staticTyping) {
-//            internalState.configs.withdrawalGating?.withdrawalsAndTransfersUnblockedAtBlock ?: 0
-//        } else {
-//            parser.asInt(withdrawalGating?.get("withdrawalsAndTransfersUnblockedAtBlock")) ?: 0
-//        }
         val withdrawalsAndTransfersUnblockedAtBlock = parser.asInt(withdrawalGating?.get("withdrawalsAndTransfersUnblockedAtBlock")) ?: 0
         val blockDurationSeconds = if (environment?.isMainNet == true) 1.1 else 1.5
         val secondsUntilUnblock = ((withdrawalsAndTransfersUnblockedAtBlock - currentBlock) * blockDurationSeconds).toInt()

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/TransferInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/TransferInputTests.kt
@@ -1,11 +1,14 @@
 package exchange.dydx.abacus.payload
 
+import exchange.dydx.abacus.calculator.CalculationPeriod
+import exchange.dydx.abacus.output.input.TransferType
 import exchange.dydx.abacus.payload.v4.V4BaseTests
 import exchange.dydx.abacus.state.model.TransferInputField
 import exchange.dydx.abacus.state.model.transfer
 import exchange.dydx.abacus.tests.extensions.log
 import exchange.dydx.abacus.utils.ServerTime
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class TransferInputTests : V4BaseTests() {
@@ -48,11 +51,17 @@ class TransferInputTests : V4BaseTests() {
         transfer("1.3", TransferInputField.usdcFee) // if fee is deducted from usdcSize
          */
 
-        test(
-            {
-                perp.transfer("DEPOSIT", TransferInputField.type)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("DEPOSIT", TransferInputField.type, environment = mock.v4Environment)
+
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.deposit, transfer?.type)
+        } else {
+            test(
+                {
+                    perp.transfer("DEPOSIT", TransferInputField.type, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "current": "transfer",
@@ -61,14 +70,38 @@ class TransferInputTests : V4BaseTests() {
                         }
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("1", TransferInputField.usdcSize)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("1", TransferInputField.usdcSize, environment = mock.v4Environment)
+
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.deposit, transfer?.type)
+            assertEquals("1", transfer?.size?.usdcSize)
+
+            val subaccount = perp.internalState.wallet.account.subaccounts[0]!!
+            val calculatedCurrent = subaccount.calculated[CalculationPeriod.current]!!
+            val calculatedPostOrder = subaccount.calculated[CalculationPeriod.post]!!
+            assertEquals(108116.7318528828, calculatedCurrent.equity)
+            assertEquals(108117.7318528828, calculatedPostOrder.equity)
+            assertEquals(106640.3767269893, calculatedCurrent.freeCollateral)
+            assertEquals(106641.3767269893, calculatedPostOrder.freeCollateral)
+            assertEquals(99872.368956, calculatedCurrent.quoteBalance)
+            assertEquals(99873.368956, calculatedPostOrder.quoteBalance)
+            assertEquals(0.2731039128897115, calculatedCurrent.leverage)
+            assertEquals(0.27310138690337965, calculatedPostOrder.leverage)
+            assertEquals(0.013655195644485585, calculatedCurrent.marginUsage)
+            assertEquals(0.013655069345169024, calculatedPostOrder.marginUsage)
+            assertEquals(2132807.5345397857, calculatedCurrent.buyingPower)
+            assertEquals(2132827.5345397857, calculatedPostOrder.buyingPower)
+        } else {
+            test(
+                {
+                    perp.transfer("1", TransferInputField.usdcSize, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "current": "transfer",
@@ -112,14 +145,39 @@ class TransferInputTests : V4BaseTests() {
                         }
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("5000.0", TransferInputField.usdcSize)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("5000.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.deposit, transfer?.type)
+            assertEquals("5000.0", transfer?.size?.usdcSize)
+            assertEquals(5000.0, transfer?.summary?.usdcSize)
+
+            val subaccount = perp.internalState.wallet.account.subaccounts[0]!!
+            val calculatedCurrent = subaccount.calculated[CalculationPeriod.current]!!
+            val calculatedPostOrder = subaccount.calculated[CalculationPeriod.post]!!
+            assertEquals(108116.7318528828, calculatedCurrent.equity)
+            assertEquals(113116.7318528828, calculatedPostOrder.equity)
+            assertEquals(106640.3767269893, calculatedCurrent.freeCollateral)
+            assertEquals(111640.3767269893, calculatedPostOrder.freeCollateral)
+            assertEquals(99872.368956, calculatedCurrent.quoteBalance)
+            assertEquals(104872.368956, calculatedPostOrder.quoteBalance)
+            assertEquals(0.2731039128897115, calculatedCurrent.leverage)
+            assertEquals(0.2610321394033229, calculatedPostOrder.leverage)
+            assertEquals(0.013655195644485585, calculatedCurrent.marginUsage)
+            assertEquals(0.013051606970166163, calculatedPostOrder.marginUsage)
+            assertEquals(2132807.5345397857, calculatedCurrent.buyingPower)
+            assertEquals(2232807.5345397857, calculatedPostOrder.buyingPower)
+        } else {
+            test(
+                {
+                    perp.transfer("5000.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "transfer": {
@@ -169,18 +227,42 @@ class TransferInputTests : V4BaseTests() {
                         }
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
         /*
         size = 1000.0
          */
+        if (perp.staticTyping) {
+            perp.transfer("1000.0", TransferInputField.usdcSize, environment = mock.v4Environment)
 
-        test(
-            {
-                perp.transfer("1000.0", TransferInputField.usdcSize)
-            },
-            """
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.deposit, transfer?.type)
+            assertEquals("1000.0", transfer?.size?.usdcSize)
+            assertEquals(1000.0, transfer?.summary?.usdcSize)
+
+            val subaccount = perp.internalState.wallet.account.subaccounts[0]!!
+            val calculatedCurrent = subaccount.calculated[CalculationPeriod.current]!!
+            val calculatedPostOrder = subaccount.calculated[CalculationPeriod.post]!!
+            assertEquals(108116.7318528828, calculatedCurrent.equity)
+            assertEquals(109116.7318528828, calculatedPostOrder.equity)
+            assertEquals(106640.3767269893, calculatedCurrent.freeCollateral)
+            assertEquals(107640.3767269893, calculatedPostOrder.freeCollateral)
+            assertEquals(99872.368956, calculatedCurrent.quoteBalance)
+            assertEquals(100872.368956, calculatedPostOrder.quoteBalance)
+            assertEquals(0.2731039128897115, calculatedCurrent.leverage)
+            assertEquals(0.2706010528035248, calculatedPostOrder.leverage)
+            assertEquals(0.013655195644485585, calculatedCurrent.marginUsage)
+            assertEquals(0.01353005264017626, calculatedPostOrder.marginUsage)
+            assertEquals(2132807.5345397857, calculatedCurrent.buyingPower)
+            assertEquals(2152807.5345397857, calculatedPostOrder.buyingPower)
+        } else {
+            test(
+                {
+                    perp.transfer("1000.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "transfer": {
@@ -230,14 +312,41 @@ class TransferInputTests : V4BaseTests() {
                         }
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("10.0", TransferInputField.usdcFee)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("10.0", TransferInputField.usdcFee, environment = mock.v4Environment)
+
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.deposit, transfer?.type)
+            assertEquals("1000.0", transfer?.size?.usdcSize)
+            assertEquals(1000.0, transfer?.summary?.usdcSize)
+            assertEquals(10.0, transfer?.summary?.fee)
+            assertEquals(true, transfer?.summary?.filled)
+
+            val subaccount = perp.internalState.wallet.account.subaccounts[0]!!
+            val calculatedCurrent = subaccount.calculated[CalculationPeriod.current]!!
+            val calculatedPostOrder = subaccount.calculated[CalculationPeriod.post]!!
+            assertEquals(108116.7318528828, calculatedCurrent.equity)
+            assertEquals(109106.7318528828, calculatedPostOrder.equity)
+            assertEquals(106640.3767269893, calculatedCurrent.freeCollateral)
+            assertEquals(107630.3767269893, calculatedPostOrder.freeCollateral)
+            assertEquals(99872.368956, calculatedCurrent.quoteBalance)
+            assertEquals(100862.368956, calculatedPostOrder.quoteBalance)
+            assertEquals(0.2731039128897115, calculatedCurrent.leverage)
+            assertEquals(0.27062585430277314, calculatedPostOrder.leverage)
+            assertEquals(0.013655195644485585, calculatedCurrent.marginUsage)
+            assertEquals(0.013531292715138643, calculatedPostOrder.marginUsage)
+            assertEquals(2132807.5345397857, calculatedCurrent.buyingPower)
+            assertEquals(2152607.5345397857, calculatedPostOrder.buyingPower)
+        } else {
+            test(
+                {
+                    perp.transfer("10.0", TransferInputField.usdcFee, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "transfer": {
@@ -290,35 +399,61 @@ class TransferInputTests : V4BaseTests() {
                         }
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
     }
 
     private fun testSlowWithdrawalTransferInput() {
         test({
-            perp.transfer("WITHDRAWAL", TransferInputField.type)
+            perp.transfer("WITHDRAWAL", TransferInputField.type, environment = mock.v4Environment)
         }, null)
 
         test({
-            perp.transfer("false", TransferInputField.fastSpeed)
+            perp.transfer("false", TransferInputField.fastSpeed, environment = mock.v4Environment)
         }, null)
 
         test({
-            perp.transfer("0", TransferInputField.usdcFee)
+            perp.transfer("0", TransferInputField.usdcFee, environment = mock.v4Environment)
         }, null)
 
         /*
         size = 1000.0
          */
         test({
-            perp.transfer("5000.0", TransferInputField.usdcSize)
+            perp.transfer("5000.0", TransferInputField.usdcSize, environment = mock.v4Environment)
         }, null)
 
-        test(
-            {
-                perp.transfer("1000.0", TransferInputField.usdcSize)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("1000.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.withdrawal, transfer?.type)
+            assertEquals("1000.0", transfer?.size?.usdcSize)
+            assertEquals(1000.0, transfer?.summary?.usdcSize)
+            assertEquals(true, transfer?.summary?.filled)
+
+            val subaccount = perp.internalState.wallet.account.subaccounts[0]!!
+            val calculatedCurrent = subaccount.calculated[CalculationPeriod.current]!!
+            val calculatedPostOrder = subaccount.calculated[CalculationPeriod.post]!!
+            assertEquals(108116.7318528828, calculatedCurrent.equity)
+            assertEquals(107116.7318528828, calculatedPostOrder.equity)
+            assertEquals(106640.3767269893, calculatedCurrent.freeCollateral)
+            assertEquals(105640.3767269893, calculatedPostOrder.freeCollateral)
+            assertEquals(99872.368956, calculatedCurrent.quoteBalance)
+            assertEquals(98872.368956, calculatedPostOrder.quoteBalance)
+            assertEquals(0.2731039128897115, calculatedCurrent.leverage)
+            assertEquals(0.2756535044256519, calculatedPostOrder.leverage)
+            assertEquals(0.013655195644485585, calculatedCurrent.marginUsage)
+            assertEquals(0.013782675221282625, calculatedPostOrder.marginUsage)
+            assertEquals(2132807.5345397857, calculatedCurrent.buyingPower)
+            assertEquals(2112807.5345397857, calculatedPostOrder.buyingPower)
+        } else {
+            test(
+                {
+                    perp.transfer("1000.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "transfer": {
@@ -369,14 +504,40 @@ class TransferInputTests : V4BaseTests() {
                         }
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("10.0", TransferInputField.usdcFee)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("10.0", TransferInputField.usdcFee, environment = mock.v4Environment)
+
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.withdrawal, transfer?.type)
+            assertEquals("1000.0", transfer?.size?.usdcSize)
+            assertEquals(1000.0, transfer?.summary?.usdcSize)
+            assertEquals(true, transfer?.summary?.filled)
+
+            val subaccount = perp.internalState.wallet.account.subaccounts[0]!!
+            val calculatedCurrent = subaccount.calculated[CalculationPeriod.current]!!
+            val calculatedPostOrder = subaccount.calculated[CalculationPeriod.post]!!
+            assertEquals(108116.7318528828, calculatedCurrent.equity)
+            assertEquals(107106.7318528828, calculatedPostOrder.equity)
+            assertEquals(106640.3767269893, calculatedCurrent.freeCollateral)
+            assertEquals(105630.3767269893, calculatedPostOrder.freeCollateral)
+            assertEquals(99872.368956, calculatedCurrent.quoteBalance)
+            assertEquals(98862.368956, calculatedPostOrder.quoteBalance)
+            assertEquals(0.2731039128897115, calculatedCurrent.leverage)
+            assertEquals(0.2756792407635699, calculatedPostOrder.leverage)
+            assertEquals(0.013655195644485585, calculatedCurrent.marginUsage)
+            assertEquals(0.013783962038178554, calculatedPostOrder.marginUsage)
+            assertEquals(2132807.5345397857, calculatedCurrent.buyingPower)
+            assertEquals(2112607.5345397857, calculatedPostOrder.buyingPower)
+        } else {
+            test(
+                {
+                    perp.transfer("10.0", TransferInputField.usdcFee, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "transfer": {
@@ -427,35 +588,64 @@ class TransferInputTests : V4BaseTests() {
                         }
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
     }
 
     private fun testTransferOutTransferInput() {
         test({
-            perp.transfer("TRANSFER_OUT", TransferInputField.type)
+            perp.transfer("TRANSFER_OUT", TransferInputField.type, environment = mock.v4Environment)
         }, null)
 
         test({
-            perp.transfer("0.0", TransferInputField.usdcFee)
+            perp.transfer("0.0", TransferInputField.usdcFee, environment = mock.v4Environment)
         }, null)
 
         /*
         size = 1000.0
          */
         test({
-            perp.transfer("5000.0", TransferInputField.usdcSize)
+            perp.transfer("5000.0", TransferInputField.usdcSize, environment = mock.v4Environment)
         }, null)
 
         test({
-            perp.transfer("test memo", TransferInputField.MEMO)
+            perp.transfer("test memo", TransferInputField.MEMO, environment = mock.v4Environment)
         }, null)
 
-        test(
-            {
-                perp.transfer("1000.0", TransferInputField.usdcSize)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("1000.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.transferOut, transfer?.type)
+            assertEquals("1000.0", transfer?.size?.usdcSize)
+            assertEquals(1000.0, transfer?.summary?.usdcSize)
+            assertEquals(true, transfer?.summary?.filled)
+
+            val subaccount = perp.internalState.wallet.account.subaccounts[0]!!
+            val calculatedCurrent = subaccount.calculated[CalculationPeriod.current]!!
+            val calculatedPostOrder = subaccount.calculated[CalculationPeriod.post]!!
+            assertEquals(108116.7318528828, calculatedCurrent.equity)
+            assertEquals(107116.7318528828, calculatedPostOrder.equity)
+            assertEquals(106640.3767269893, calculatedCurrent.freeCollateral)
+            assertEquals(105640.3767269893, calculatedPostOrder.freeCollateral)
+            assertEquals(99872.368956, calculatedCurrent.quoteBalance)
+            assertEquals(98872.368956, calculatedPostOrder.quoteBalance)
+            assertEquals(0.2731039128897115, calculatedCurrent.leverage)
+            assertEquals(0.2756535044256519, calculatedPostOrder.leverage)
+            assertEquals(0.013655195644485585, calculatedCurrent.marginUsage)
+            assertEquals(0.013782675221282625, calculatedPostOrder.marginUsage)
+            assertEquals(2132807.5345397857, calculatedCurrent.buyingPower)
+            assertEquals(2112807.5345397857, calculatedPostOrder.buyingPower)
+
+            assertTrue { perp.state?.input?.transfer?.transferOutOptions?.assets?.count() == 2 }
+            assertTrue { perp.state?.input?.transfer?.transferOutOptions?.chains?.count() == 1 }
+        } else {
+            test(
+                {
+                    perp.transfer("1000.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "transfer": {
@@ -506,20 +696,28 @@ class TransferInputTests : V4BaseTests() {
                         }
                     }
                 }
-            """.trimIndent(),
-            { response ->
-                assertTrue { response.state?.input?.transfer?.transferOutOptions?.assets?.count() == 2 }
-                assertTrue { response.state?.input?.transfer?.transferOutOptions?.chains?.count() == 1 }
-            },
-        )
+                """.trimIndent(),
+                { response ->
+                    assertTrue { response.state?.input?.transfer?.transferOutOptions?.assets?.count() == 2 }
+                    assertTrue { response.state?.input?.transfer?.transferOutOptions?.chains?.count() == 1 }
+                },
+            )
+        }
     }
 
     private fun testTransferInputTypeChange() {
-        test(
-            {
-                perp.transfer("DEPOSIT", TransferInputField.type)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer(data = "DEPOSIT", type = TransferInputField.type, environment = mock.v4Environment)
+
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.deposit, transfer?.type)
+            assertEquals(null, transfer?.memo)
+        } else {
+            test(
+                {
+                    perp.transfer(data = "DEPOSIT", type = TransferInputField.type, environment = mock.v4Environment)
+                },
+                """
         {
             "input": {
                 "transfer": {
@@ -528,14 +726,22 @@ class TransferInputTests : V4BaseTests() {
                 }
             }
         }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("TRANSFER_OUT", TransferInputField.type)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer(data = "TRANSFER_OUT", type = TransferInputField.type, environment = mock.v4Environment)
+
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.transferOut, transfer?.type)
+            assertEquals(null, transfer?.memo)
+        } else {
+            test(
+                {
+                    perp.transfer(data = "TRANSFER_OUT", type = TransferInputField.type, environment = mock.v4Environment)
+                },
+                """
     {
         "input": {
             "transfer": {
@@ -544,14 +750,26 @@ class TransferInputTests : V4BaseTests() {
             }
         }
     }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("test memo", TransferInputField.MEMO)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer(data = "test memo", type = TransferInputField.MEMO, environment = mock.v4Environment)
+
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.transferOut, transfer?.type)
+            assertEquals("test memo", transfer?.memo)
+        } else {
+            test(
+                {
+                    perp.transfer(
+                        data = "test memo",
+                        type = TransferInputField.MEMO,
+                        environment = mock.v4Environment,
+                    )
+                },
+                """
         {
             "input": {
                 "transfer": {
@@ -560,14 +778,22 @@ class TransferInputTests : V4BaseTests() {
                 }
             }
         }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("WITHDRAWAL", TransferInputField.type)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("WITHDRAWAL", TransferInputField.type, environment = mock.v4Environment)
+
+            val transfer = perp.state?.input?.transfer
+            assertEquals(TransferType.withdrawal, transfer?.type)
+            assertEquals(null, transfer?.memo)
+        } else {
+            test(
+                {
+                    perp.transfer("WITHDRAWAL", TransferInputField.type, environment = mock.v4Environment)
+                },
+                """
     {
         "input": {
             "transfer": {
@@ -576,7 +802,8 @@ class TransferInputTests : V4BaseTests() {
             }
         }
     }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
     }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4BaseTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4BaseTests.kt
@@ -28,7 +28,9 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-open class V4BaseTests(useParentSubaccount: Boolean = false) : BaseTests(127, useParentSubaccount) {
+open class V4BaseTests(
+    useParentSubaccount: Boolean = false
+) : BaseTests(127, useParentSubaccount) {
     internal val testWsUrl =
         AbUrl.fromString("wss://indexer.v4staging.dydx.exchange/v4/ws")
     internal val testRestUrl =

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4SquidTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4SquidTests.kt
@@ -24,7 +24,7 @@ class V4SquidTests : V4BaseTests() {
         assertNotNull(stateChange)
 
         test({
-            perp.transfer("DEPOSIT", TransferInputField.type, 0)
+            perp.transfer("DEPOSIT", TransferInputField.type, 0, environment = mock.v4Environment)
         }, null, {
             val chains = it.state?.input?.transfer?.depositOptions?.chains!!
             assertTrue(chains.size > 0)
@@ -36,7 +36,7 @@ class V4SquidTests : V4BaseTests() {
         })
 
         test({
-            perp.transfer(null, TransferInputField.type, 0)
+            perp.transfer(null, TransferInputField.type, 0, environment = mock.v4Environment)
         }, null, {
             assertTrue(it.state?.input?.transfer?.depositOptions == null)
         })
@@ -54,7 +54,7 @@ class V4SquidTests : V4BaseTests() {
         assertNotNull(stateChange)
 
         test({
-            perp.transfer("DEPOSIT", TransferInputField.type, 0)
+            perp.transfer("DEPOSIT", TransferInputField.type, 0, environment = mock.v4Environment)
         }, null, {
             val assets = it.state?.input?.transfer?.depositOptions?.assets!!
             assertTrue(assets.size > 0)
@@ -67,7 +67,7 @@ class V4SquidTests : V4BaseTests() {
         })
 
         test({
-            perp.transfer(null, TransferInputField.type, 0)
+            perp.transfer(null, TransferInputField.type, 0, environment = mock.v4Environment)
         }, null, {
             assertTrue(it.state?.input?.transfer?.depositOptions == null)
         })
@@ -77,7 +77,7 @@ class V4SquidTests : V4BaseTests() {
     fun testSquidRouteV2() {
         setup()
 
-        perp.transfer("DEPOSIT", TransferInputField.type, 0)
+        perp.transfer("DEPOSIT", TransferInputField.type, 0, environment = mock.v4Environment)
 
         var stateChange = perp.squidV2SdkInfo(mock.squidV2AssetsMock.payload)
         assertNotNull(stateChange)
@@ -86,23 +86,41 @@ class V4SquidTests : V4BaseTests() {
         assertNotNull(stateChange)
 
         test({
-            perp.transfer("DEPOSIT", TransferInputField.type, 0)
+            perp.transfer("DEPOSIT", TransferInputField.type, 0, environment = mock.v4Environment)
         }, null, {
-            val summary = it.state?.input?.transfer?.summary!!
+            val summary =
+                if (perp.staticTyping) {
+                    perp.internalState.input.transfer.summary
+                } else {
+                    it.state?.input?.transfer?.summary!!
+                }
             assertNotNull(summary)
             assertTrue { summary.slippage!!.toInt() == 0 }
             assertTrue { summary.exchangeRate!! > 0 }
             assertTrue { summary.estimatedRouteDuration!! > 0 }
             assertTrue { summary.gasFee!! > 0 }
             // assertTrue { summary.bridgeFee!! > 0 }
-            assertNotNull(it.state?.input?.transfer?.requestPayload)
-            assertNotNull(it.state?.input?.transfer?.size?.usdcSize)
+            if (perp.staticTyping) {
+                val route = perp.internalState.input.transfer.route
+                val requestPayload = parser.asNativeMap(parser.value(route, "requestPayload"))
+                assertNotNull(requestPayload)
+                assertNotNull(perp.internalState.input.transfer.size?.usdcSize)
+            } else {
+                assertNotNull(it.state?.input?.transfer?.requestPayload)
+                assertNotNull(it.state?.input?.transfer?.size?.usdcSize)
+            }
         })
 
         test({
-            perp.transfer("0", TransferInputField.size, 0)
+            perp.transfer("0", TransferInputField.size, 0, environment = mock.v4Environment)
         }, null, {
-            assertNull(it.state?.input?.transfer?.requestPayload)
+            if (perp.staticTyping) {
+                val route = perp.internalState.input.transfer.route
+                val requestPayload = parser.asNativeMap(parser.value(route, "requestPayload"))
+                assertNull(requestPayload)
+            } else {
+                assertNull(it.state?.input?.transfer?.requestPayload)
+            }
         })
     }
 
@@ -110,7 +128,7 @@ class V4SquidTests : V4BaseTests() {
     fun testSquidRoute() {
         setup()
 
-        perp.transfer("DEPOSIT", TransferInputField.type, 0)
+        perp.transfer("DEPOSIT", TransferInputField.type, 0, environment = mock.v4Environment)
 
         var stateChange = perp.routerChains(mock.squidChainsMock.payload)
         assertNotNull(stateChange)
@@ -122,7 +140,7 @@ class V4SquidTests : V4BaseTests() {
         assertNotNull(stateChange)
 
         test({
-            perp.transfer("DEPOSIT", TransferInputField.type, 0)
+            perp.transfer("DEPOSIT", TransferInputField.type, 0, environment = mock.v4Environment)
         }, null, {
             val summary = it.state?.input?.transfer?.summary!!
             assertNotNull(summary)
@@ -136,7 +154,7 @@ class V4SquidTests : V4BaseTests() {
         })
 
         test({
-            perp.transfer("0", TransferInputField.size, 0)
+            perp.transfer("0", TransferInputField.size, 0, environment = mock.v4Environment)
         }, null, {
             assertNull(it.state?.input?.transfer?.requestPayload)
         })
@@ -146,7 +164,7 @@ class V4SquidTests : V4BaseTests() {
     fun testSquidRoute_error() {
         setup()
 
-        perp.transfer("DEPOSIT", TransferInputField.type, 0)
+        perp.transfer("DEPOSIT", TransferInputField.type, 0, environment = mock.v4Environment)
 
         var stateChange = perp.routerChains(mock.squidChainsMock.payload)
         assertNotNull(stateChange)
@@ -158,7 +176,7 @@ class V4SquidTests : V4BaseTests() {
         assertNotNull(stateChange)
 
         test({
-            perp.transfer("DEPOSIT", TransferInputField.type, 0)
+            perp.transfer("DEPOSIT", TransferInputField.type, 0, environment = mock.v4Environment)
         }, null, {
             val errors = it.state?.input?.transfer?.errors!!
             assertNotNull(errors)
@@ -181,7 +199,7 @@ class V4SquidTests : V4BaseTests() {
         perp.updateStateChanges(stateChange)
 
         test({
-            perp.transfer("DEPOSIT", TransferInputField.type, 0)
+            perp.transfer("DEPOSIT", TransferInputField.type, 0, environment = mock.v4Environment)
         }, null, {
             val transferStatuses = it.state?.transferStatuses
             assertNotNull(transferStatuses)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
@@ -29,7 +29,7 @@ class SkipProcessorTests {
 
     internal val internalState = InternalTransferInputState()
     internal val parser = Parser()
-    internal val skipProcessor = SkipProcessor(parser = parser, internalState = internalState)
+    internal val skipProcessor = SkipProcessor(parser = parser, internalState = internalState, staticTyping = false)
     internal val skipChainsMock = SkipChainsMock()
     internal val skipTokensMock = SkipTokensMock()
     internal val skipRouteMock = SkipRouteMock()

--- a/src/commonTest/kotlin/exchange.dydx.abacus/validation/TransferRequiredInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/validation/TransferRequiredInputTests.kt
@@ -1,11 +1,15 @@
 package exchange.dydx.abacus.validation
 
+import exchange.dydx.abacus.output.input.ErrorType
+import exchange.dydx.abacus.output.input.TransferType
 import exchange.dydx.abacus.payload.v4.V4BaseTests
 import exchange.dydx.abacus.state.model.TransferInputField
 import exchange.dydx.abacus.state.model.transfer
 import exchange.dydx.abacus.tests.extensions.log
 import exchange.dydx.abacus.utils.ServerTime
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class TransferRequiredInputTests : V4BaseTests() {
     @Test
@@ -35,16 +39,28 @@ class TransferRequiredInputTests : V4BaseTests() {
     override fun reset() {
         super.reset()
         test({
-            perp.transfer(null, null)
+            perp.transfer(null, null, environment = mock.v4Environment)
         }, null)
     }
 
     private fun testTransferInputDeposit() {
-        test(
-            {
-                perp.transfer("DEPOSIT", TransferInputField.type)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("DEPOSIT", TransferInputField.type, environment = mock.v4Environment)
+
+            val transfer = perp.internalState.input.transfer
+            assertEquals(TransferType.deposit, transfer.type)
+
+            val error = perp.internalState.input.errors?.firstOrNull()
+            assertEquals("REQUIRED_SIZE", error?.code)
+            assertEquals(ErrorType.required, error?.type)
+            assertEquals("size.usdcSize", error?.fields?.first())
+            assertEquals("APP.TRADE.ENTER_AMOUNT", error?.resources?.action?.stringKey)
+        } else {
+            test(
+                {
+                    perp.transfer("DEPOSIT", TransferInputField.type, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "current": "transfer",
@@ -67,14 +83,24 @@ class TransferRequiredInputTests : V4BaseTests() {
                         ]
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("1.0", TransferInputField.usdcSize)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("1.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+
+            val transfer = perp.internalState.input.transfer
+            assertEquals(TransferType.deposit, transfer.type)
+
+            val error = perp.internalState.input.errors?.firstOrNull()
+            assertEquals(null, error)
+        } else {
+            test(
+                {
+                    perp.transfer("1.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "current": "transfer",
@@ -84,16 +110,33 @@ class TransferRequiredInputTests : V4BaseTests() {
                         "errors": null
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
     }
 
     private fun testTransferInputWithdraw() {
-        test(
-            {
-                perp.transfer("WITHDRAWAL", TransferInputField.type)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("WITHDRAWAL", TransferInputField.type, environment = mock.v4Environment)
+
+            val transfer = perp.internalState.input.transfer
+            assertEquals(TransferType.withdrawal, transfer.type)
+
+            val error = perp.internalState.input.errors?.firstOrNull()
+            assertEquals("REQUIRED_SIZE", error?.code)
+            assertEquals(ErrorType.required, error?.type)
+            assertEquals("size.usdcSize", error?.fields?.first())
+            assertEquals("APP.TRADE.ENTER_AMOUNT", error?.resources?.action?.stringKey)
+        } else {
+            test(
+                {
+                    perp.transfer(
+                        "WITHDRAWAL",
+                        TransferInputField.type,
+                        environment = mock.v4Environment,
+                    )
+                },
+                """
                 {
                     "input": {
                         "current": "transfer",
@@ -116,14 +159,28 @@ class TransferRequiredInputTests : V4BaseTests() {
                         ]
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("1.0", TransferInputField.usdcSize)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("1.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+
+            val transfer = perp.internalState.input.transfer
+            assertEquals(TransferType.withdrawal, transfer.type)
+
+            val error = perp.internalState.input.errors?.firstOrNull()
+            assertEquals("REQUIRED_ADDRESS", error?.code)
+            assertEquals(ErrorType.required, error?.type)
+
+            perp.transfer("dydx16zfx8g4jg9vels3rsvcym490tkn5la304c57e9", TransferInputField.address, environment = mock.v4Environment)
+            assertNull(perp.internalState.input.errors?.firstOrNull())
+        } else {
+            test(
+                {
+                    perp.transfer("1.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "current": "transfer",
@@ -133,16 +190,29 @@ class TransferRequiredInputTests : V4BaseTests() {
                         "errors": null
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
     }
 
     private fun testTransferInputTransferOut() {
-        test(
-            {
-                perp.transfer("TRANSFER_OUT", TransferInputField.type)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("TRANSFER_OUT", TransferInputField.type, environment = mock.v4Environment)
+
+            val transfer = perp.internalState.input.transfer
+            assertEquals(TransferType.transferOut, transfer.type)
+
+            val error = perp.internalState.input.errors?.firstOrNull()
+            assertEquals("REQUIRED_ADDRESS", error?.code)
+            assertEquals(ErrorType.required, error?.type)
+            assertEquals("address", error?.fields?.first())
+            assertEquals("APP.DIRECT_TRANSFER_MODAL.ENTER_ETH_ADDRESS", error?.resources?.action?.stringKey)
+        } else {
+            test(
+                {
+                    perp.transfer("TRANSFER_OUT", TransferInputField.type, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "current": "transfer",
@@ -165,14 +235,24 @@ class TransferRequiredInputTests : V4BaseTests() {
                         ]
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("1.0", TransferInputField.usdcSize)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("1.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+
+            val transfer = perp.internalState.input.transfer
+            assertEquals(TransferType.transferOut, transfer.type)
+
+            val error = perp.internalState.input.errors?.firstOrNull()
+            assertEquals("REQUIRED_ADDRESS", error?.code)
+        } else {
+            test(
+                {
+                    perp.transfer("1.0", TransferInputField.usdcSize, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "current": "transfer",
@@ -195,14 +275,27 @@ class TransferRequiredInputTests : V4BaseTests() {
                         ]
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("dydx1111111", TransferInputField.address)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("dydx1111111", TransferInputField.address, environment = mock.v4Environment)
+
+            val transfer = perp.internalState.input.transfer
+            assertEquals(TransferType.transferOut, transfer.type)
+
+            val error = perp.internalState.input.errors?.firstOrNull()
+            assertEquals("INVALID_ADDRESS", error?.code)
+            assertEquals(ErrorType.error, error?.type)
+            assertEquals("address", error?.fields?.first())
+            assertEquals("APP.DIRECT_TRANSFER_MODAL.ADDRESS_FIELD", error?.resources?.action?.stringKey)
+        } else {
+            test(
+                {
+                    perp.transfer("dydx1111111", TransferInputField.address, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "current": "transfer",
@@ -224,14 +317,23 @@ class TransferRequiredInputTests : V4BaseTests() {
                         ]
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
 
-        test(
-            {
-                perp.transfer("dydx16zfx8g4jg9vels3rsvcym490tkn5la304c57e9", TransferInputField.address)
-            },
-            """
+        if (perp.staticTyping) {
+            perp.transfer("dydx16zfx8g4jg9vels3rsvcym490tkn5la304c57e9", TransferInputField.address, environment = mock.v4Environment)
+
+            val transfer = perp.internalState.input.transfer
+            assertEquals(TransferType.transferOut, transfer.type)
+
+            assertNull(perp.internalState.input.errors?.firstOrNull())
+        } else {
+            test(
+                {
+                    perp.transfer("dydx16zfx8g4jg9vels3rsvcym490tkn5la304c57e9", TransferInputField.address, environment = mock.v4Environment)
+                },
+                """
                 {
                     "input": {
                         "current": "transfer",
@@ -241,7 +343,8 @@ class TransferRequiredInputTests : V4BaseTests() {
                         "errors": null
                     }
                 }
-            """.trimIndent(),
-        )
+                """.trimIndent(),
+            )
+        }
     }
 }


### PR DESCRIPTION
- Updating Transfer Input for static typing. The Squid/Skip payload is still parsed as map, and can be converted in the future if we have time.
- Updating Withdrawal gating for static typing.
- Updating all remaining tests. You can now set staticTyping = true in BaseTests to test the new codepath.
- Tested on Android