### PR TITLE
TRCL-3682 Add isNew to PerpetualMarket

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/Market.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/Market.kt
@@ -313,6 +313,7 @@ data class MarketPerpetual(
     val openInterestLowerCap: Double? = null,
     val openInterestUpperCap: Double? = null,
     val line: IList<Double>?,
+    val isNew: Boolean = false,
 ) {
     companion object {
         internal fun create(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketsProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketsProcessor.kt
@@ -8,6 +8,7 @@ import exchange.dydx.abacus.state.internalstate.InternalMarketSummaryState
 import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.safeSet
+import indexer.codegen.IndexerSparklineTimePeriod
 import indexer.models.IndexerCompositeMarketObject
 import indexer.models.IndexerWsMarketUpdateResponse
 
@@ -29,7 +30,8 @@ internal interface MarketsProcessorProtocol : BaseProcessorProtocol {
 
     fun processSparklines(
         existing: InternalMarketSummaryState,
-        content: Map<String, List<String>>?
+        content: Map<String, List<String>>?,
+        period: IndexerSparklineTimePeriod,
     ): InternalMarketSummaryState
 }
 
@@ -110,13 +112,15 @@ internal class MarketsProcessor(
 
     override fun processSparklines(
         existing: InternalMarketSummaryState,
-        content: Map<String, List<String>>?
+        content: Map<String, List<String>>?,
+        period: IndexerSparklineTimePeriod,
     ): InternalMarketSummaryState {
         for ((marketId, sparklines) in content ?: mapOf()) {
             val marketState = existing.markets[marketId] ?: InternalMarketState()
             val receivedMarket = marketProcessor.processSparklines(
                 marketId = marketId,
                 payload = sparklines,
+                period = period,
             )
             if (receivedMarket != marketState.perpetualMarket) {
                 marketState.perpetualMarket = receivedMarket

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketsSummaryProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketsSummaryProcessor.kt
@@ -10,6 +10,7 @@ import exchange.dydx.abacus.utils.safeSet
 import indexer.codegen.IndexerCandleResponse
 import indexer.codegen.IndexerCandleResponseObject
 import indexer.codegen.IndexerOrderbookResponseObject
+import indexer.codegen.IndexerSparklineTimePeriod
 import indexer.codegen.IndexerTradeResponse
 import indexer.models.IndexerCompositeMarketObject
 import indexer.models.IndexerWsMarketUpdateResponse
@@ -60,8 +61,9 @@ internal class MarketsSummaryProcessor(
     fun processSparklines(
         existing: InternalMarketSummaryState,
         content: Map<String, List<String>>?,
+        period: IndexerSparklineTimePeriod,
     ): InternalMarketSummaryState {
-        marketsProcessor.processSparklines(existing, content)
+        marketsProcessor.processSparklines(existing, content, period)
         return existing
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Sparklines.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Sparklines.kt
@@ -3,15 +3,27 @@ package exchange.dydx.abacus.state.model
 import exchange.dydx.abacus.protocols.asTypedStringMapOfList
 import exchange.dydx.abacus.state.changes.Changes
 import exchange.dydx.abacus.state.changes.StateChanges
+import indexer.codegen.IndexerSparklineTimePeriod
 import kollections.iListOf
 
-internal fun TradingStateMachine.sparklines(payload: String): StateChanges? {
+internal fun TradingStateMachine.sparklines(
+    payload: String,
+    period: IndexerSparklineTimePeriod
+): StateChanges? {
     val json = parser.decodeJsonObject(payload) as? Map<String, List<String>>
     if (staticTyping) {
         val sparklines = parser.asTypedStringMapOfList<String>(json)
         return if (sparklines != null) {
-            marketsProcessor.processSparklines(internalState.marketsSummary, sparklines)
-            StateChanges(iListOf(Changes.sparklines, Changes.markets), null)
+            when (period) {
+                IndexerSparklineTimePeriod.ONEDAY -> {
+                    marketsProcessor.processSparklines(internalState.marketsSummary, sparklines, period)
+                    StateChanges(iListOf(Changes.sparklines, Changes.markets), null)
+                }
+                IndexerSparklineTimePeriod.SEVENDAYS -> {
+                    marketsProcessor.processSparklines(internalState.marketsSummary, sparklines, period)
+                    StateChanges(iListOf(Changes.markets), null)
+                }
+            }
         } else {
             StateChanges.noChange
         }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Sparklines.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+Sparklines.kt
@@ -14,13 +14,12 @@ internal fun TradingStateMachine.sparklines(
     if (staticTyping) {
         val sparklines = parser.asTypedStringMapOfList<String>(json)
         return if (sparklines != null) {
+            marketsProcessor.processSparklines(internalState.marketsSummary, sparklines, period)
             when (period) {
                 IndexerSparklineTimePeriod.ONEDAY -> {
-                    marketsProcessor.processSparklines(internalState.marketsSummary, sparklines, period)
                     StateChanges(iListOf(Changes.sparklines, Changes.markets), null)
                 }
                 IndexerSparklineTimePeriod.SEVENDAYS -> {
-                    marketsProcessor.processSparklines(internalState.marketsSummary, sparklines, period)
                     StateChanges(iListOf(Changes.markets), null)
                 }
             }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
@@ -80,6 +80,7 @@ import exchange.dydx.abacus.utils.mutableMapOf
 import exchange.dydx.abacus.utils.safeSet
 import exchange.dydx.abacus.utils.typedSafeSet
 import exchange.dydx.abacus.validator.InputValidator
+import indexer.codegen.IndexerSparklineTimePeriod
 import indexer.models.configs.ConfigsMarketAsset
 import kollections.JsExport
 import kollections.iListOf
@@ -536,7 +537,7 @@ open class TradingStateMachine(
             }
 
             "/v4/sparklines" -> {
-                changes = sparklines(payload)
+                changes = sparklines(payload, IndexerSparklineTimePeriod.ONEDAY)
             }
 
             "/v4/fills" -> {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
@@ -165,10 +165,10 @@ internal class StateManagerAdaptorV2(
     )
 
     private val markets = MarketsSupervisor(
-        stateMachine,
-        networkHelper,
-        analyticsUtils,
-        appConfigs.marketConfigs,
+        stateMachine = stateMachine,
+        helper = networkHelper,
+        analyticsUtils = analyticsUtils,
+        configs = appConfigs.marketConfigs,
     )
 
     private val triggerOrderToastGenerator = TriggerOrderToastGenerator(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/Configs.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/Configs.kt
@@ -43,6 +43,7 @@ data class MarketsConfigs(
     val subscribeToOrderbook: Boolean,
     val subscribeToTrades: Boolean,
     val subscribeToCandles: Boolean,
+    val retrieveSevenDaySparkline: Boolean,
 ) {
     companion object {
         val forApp = MarketsConfigs(
@@ -53,6 +54,7 @@ data class MarketsConfigs(
             subscribeToOrderbook = true,
             subscribeToTrades = true,
             subscribeToCandles = true,
+            retrieveSevenDaySparkline = true,
         )
         val forWeb = MarketsConfigs(
             retrieveSparklines = true,
@@ -62,6 +64,7 @@ data class MarketsConfigs(
             subscribeToOrderbook = true,
             subscribeToTrades = true,
             subscribeToCandles = false,
+            retrieveSevenDaySparkline = false,
         )
         val forProgrammaticTraders = MarketsConfigs(
             retrieveSparklines = false,
@@ -71,6 +74,7 @@ data class MarketsConfigs(
             subscribeToOrderbook = true,
             subscribeToTrades = false,
             subscribeToCandles = false,
+            retrieveSevenDaySparkline = false,
         )
     }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4ForegroundCycleTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4ForegroundCycleTests.kt
@@ -48,17 +48,17 @@ class V4ForegroundCycleTests : NetworkTests() {
         val localizer = BaseTests.testLocalizer(ioImplementations)
         val uiImplementations = BaseTests.testUIImplementations(localizer)
         stateManager = AsyncAbacusStateManagerV2(
-            "https://api.examples.com",
-            "DEV",
-            if (forIsolatedMargins) {
+            deploymentUri = "https://api.examples.com",
+            deployment = "DEV",
+            appConfigs = if (forIsolatedMargins) {
                 AppConfigsV2.forAppWithIsolatedMargins
             } else {
                 AppConfigsV2.forApp
             },
-            ioImplementations,
-            uiImplementations,
-            TestState(),
-            null,
+            ioImplementations = ioImplementations,
+            uiImplementations = uiImplementations,
+            stateNotification = TestState(),
+            dataNotification = null,
         )
         stateManager.environmentId = "dydxprotocol-staging"
         return stateManager
@@ -205,6 +205,7 @@ class V4ForegroundCycleTests : NetworkTests() {
                     "https://api.examples.com/configs/exchanges.json",
                     "https://api.dydx.exchange/v4/geo",
                     "https://indexer.v4staging.dydx.exchange/v4/sparklines?timePeriod=ONE_DAY",
+                    "https://indexer.v4staging.dydx.exchange/v4/sparklines?timePeriod=SEVEN_DAYS",
                     "https://indexer.v4staging.dydx.exchange/v4/candles/perpetualMarkets/ETH-USD?resolution=1DAY",
                     "https://indexer.v4staging.dydx.exchange/v4/historicalFunding/ETH-USD"
                 ]
@@ -264,7 +265,6 @@ class V4ForegroundCycleTests : NetworkTests() {
 //            """.trimIndent(),
             """
                 [
-                    
                     "https://api.examples.com/configs/documentation.json",
                     "https://indexer.v4staging.dydx.exchange/v4/time",
                     "https://indexer.v4staging.dydx.exchange/v4/height",
@@ -275,6 +275,7 @@ class V4ForegroundCycleTests : NetworkTests() {
                     "https://api.examples.com/configs/exchanges.json",
                     "https://api.dydx.exchange/v4/geo",
                     "https://indexer.v4staging.dydx.exchange/v4/sparklines?timePeriod=ONE_DAY",
+                    "https://indexer.v4staging.dydx.exchange/v4/sparklines?timePeriod=SEVEN_DAYS",
                     "https://indexer.v4staging.dydx.exchange/v4/candles/perpetualMarkets/ETH-USD?resolution=1DAY",
                     "https://indexer.v4staging.dydx.exchange/v4/historicalFunding/ETH-USD",
                     "https://indexer.v4staging.dydx.exchange/v4/candles/perpetualMarkets/BTC-USD?resolution=1DAY",
@@ -330,6 +331,7 @@ class V4ForegroundCycleTests : NetworkTests() {
                     "https://api.examples.com/configs/exchanges.json",
                     "https://api.dydx.exchange/v4/geo",
                     "https://indexer.v4staging.dydx.exchange/v4/sparklines?timePeriod=ONE_DAY",
+                    "https://indexer.v4staging.dydx.exchange/v4/sparklines?timePeriod=SEVEN_DAYS",
                     "https://indexer.v4staging.dydx.exchange/v4/candles/perpetualMarkets/ETH-USD?resolution=1DAY",
                     "https://indexer.v4staging.dydx.exchange/v4/historicalFunding/ETH-USD"
                 ]

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/BaseTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/BaseTests.kt
@@ -95,7 +95,7 @@ internal typealias VerificationFunction = (response: StateResponse) -> Unit
 open class BaseTests(
     private val maxSubaccountNumber: Int,
     private val useParentSubaccount: Boolean,
-    private val staticTyping: Boolean = false, // turn on static typing for testing
+    private val staticTyping: Boolean = true, // turn on static typing for testing
 ) {
     open val doAsserts = true
     internal val deploymentUri = "https://api.examples.com"

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/markets/MarketProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/markets/MarketProcessorTests.kt
@@ -9,6 +9,7 @@ import exchange.dydx.abacus.output.PerpetualMarketType
 import exchange.dydx.abacus.utils.Parser
 import indexer.codegen.IndexerPerpetualMarketStatus
 import indexer.codegen.IndexerPerpetualMarketType
+import indexer.codegen.IndexerSparklineTimePeriod
 import indexer.models.IndexerCompositeMarketObject
 import indexer.models.IndexerWsMarketOraclePriceObject
 import kollections.toIList
@@ -149,7 +150,25 @@ class MarketProcessorTests {
     @Test
     fun testProcessSparklines() {
         processor.process("BTC-USD", marketPayloadMock)
-        val output = processor.processSparklines("BTC-USD", listOf("1", "2", "3"))
+        val output = processor.processSparklines(
+            marketId = "BTC-USD",
+            payload = listOf("1", "2", "3"),
+            period = IndexerSparklineTimePeriod.ONEDAY,
+        )
         assertEquals(output?.perpetual?.line, listOf(3.0, 2.0, 1.0).toIList())
+
+        val output2 = processor.processSparklines(
+            marketId = "BTC-USD",
+            payload = listOf("1", "2", "3"),
+            period = IndexerSparklineTimePeriod.SEVENDAYS,
+        )
+        assertEquals(output2?.perpetual?.isNew, true)
+
+        val output3 = processor.processSparklines(
+            marketId = "BTC-USD",
+            payload = MutableList(42) { "1" }, // 42 elements
+            period = IndexerSparklineTimePeriod.SEVENDAYS,
+        )
+        assertEquals(output3?.perpetual?.isNew, false)
     }
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/markets/MarketsProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/markets/MarketsProcessorTests.kt
@@ -3,6 +3,7 @@ package exchange.dydx.abacus.processor.markets
 import exchange.dydx.abacus.state.internalstate.InternalMarketSummaryState
 import exchange.dydx.abacus.tests.mock.processor.markets.MarketProcessorMock
 import exchange.dydx.abacus.utils.Parser
+import indexer.codegen.IndexerSparklineTimePeriod
 import indexer.models.IndexerWsMarketUpdateResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -99,7 +100,7 @@ class MarketsProcessorTests {
             "BTC-USD" to listOf("1", "2", "3"),
             "ETH-USD" to listOf("1", "2", "3"),
         )
-        val result = processor.processSparklines(state, sparklines)
+        val result = processor.processSparklines(state, sparklines, IndexerSparklineTimePeriod.ONEDAY)
         assertEquals(2, marketProcessor.processSparklinesCallCount)
         assertEquals(2, result.markets.size)
     }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/tests/mock/processor/markets/MarketProcessorMock.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/tests/mock/processor/markets/MarketProcessorMock.kt
@@ -3,6 +3,7 @@ package exchange.dydx.abacus.tests.mock.processor.markets
 import exchange.dydx.abacus.output.PerpetualMarket
 import exchange.dydx.abacus.processor.markets.MarketProcessorProtocol
 import exchange.dydx.abacus.state.manager.V4Environment
+import indexer.codegen.IndexerSparklineTimePeriod
 import indexer.models.IndexerCompositeMarketObject
 import indexer.models.IndexerWsMarketOraclePriceObject
 
@@ -32,7 +33,7 @@ class MarketProcessorMock : MarketProcessorProtocol {
         return processOraclePriceAction?.invoke(marketId, payload)
     }
 
-    override fun processSparklines(marketId: String, payload: List<String>): PerpetualMarket? {
+    override fun processSparklines(marketId: String, payload: List<String>, period: IndexerSparklineTimePeriod): PerpetualMarket? {
         processSparklinesCallCount++
         return processSparklinesAction?.invoke(marketId, payload)
     }


### PR DESCRIPTION
Fetching 7 day sparkline to determine if the market is new for mobile apps.  Web already does this outside Abacus, and it's currently configured to fetch for mobile apps only.  But we can remove the web code and use the isNew field from Abacus in the future.

Also updating the 1 day sparkline fetch interval from 1 minute to 1 hour per Slack discussion.