### PR TITLE
add new balancePercent input to trade size inputs

### DIFF
--- a/docs/Input/TradeInput.md
+++ b/docs/Input/TradeInput.md
@@ -86,6 +86,8 @@ data class TradeInputSize(
 &emsp;val size: Double?,  
 &emsp;val usdcSize: Double?,  
 &emsp;val leverage: Double?,  
+&emsp;val percent: Double?,  
+&emsp;val balancePercent: Double?,  
 &emsp;val input: String?  
 )
 
@@ -101,10 +103,14 @@ Size of the trade in USDC
 
 Leverage of the order
 
+## balancePercent
+
+Percent (of available balance / free collateral) to use for the order. Currently only on market orders.
+
 ## input
 
 Which one of the fields are entered by the user:
-size, usdcSize, leverage
+size, usdcSize, leverage, balancePercent
 
 # TradeInputPrice
 

--- a/docs/Input/TradeInput.md
+++ b/docs/Input/TradeInput.md
@@ -103,14 +103,19 @@ Size of the trade in USDC
 
 Leverage of the order
 
+## percent
+
+Percentage (of existing position) to use for the order. Only used for the close position input.
+
 ## balancePercent
 
-Percent (of available balance / free collateral) to use for the order. Currently only on market orders.
+Percentage (of available balance / free collateral) to use for the order. Currently only on market orders.
 
 ## input
 
 Which one of the fields are entered by the user:
-size, usdcSize, leverage, balancePercent
+- TradeInput: size, usdcSize, leverage, percent, balancePercent
+- ClosePositionInput: size, percent
 
 # TradeInputPrice
 
@@ -177,6 +182,7 @@ Execution settings for the bracket orders
 data class TradeInputMarketOrder(  
 &emsp;val size: Double?,  
 &emsp;val usdcSize: Double?,  
+&emsp;val balancePercent: Double?,  
 &emsp;val price: Double?,  
 &emsp;val worstPrice: Double?,  
 &emsp;val filled: Boolean,  
@@ -190,6 +196,11 @@ size of the market order
 ## usdcSize
 
 USDC amount of the market order
+
+## balancePercent
+
+Percentage (of available balance / free collateral) of the market order
+
 
 ## price
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -475,9 +475,10 @@ internal class TradeInputCalculator(
         input: String,
     ): Map<String, Any>? {
         val tradeSize = parser.asNativeMap(trade["size"])
+
         if (tradeSize != null) {
-            val freeCollateral = parser.asDouble(parser.value(subaccount, "freeCollateral.current")) ?: Numeric.double.ZERO
             val maxMarketLeverage = maxMarketLeverage(market)
+            val freeCollateral = parser.asDouble(parser.value(subaccount, "freeCollateral.current")) ?: Numeric.double.ZERO
 
             return when (input) {
                 "size.size", "size.percent" -> {
@@ -603,7 +604,11 @@ internal class TradeInputCalculator(
                         }
                     }
                 }
-                val balancePercentTotal = balanceTotal / freeCollateral
+                val balancePercentTotal = if (freeCollateral > Numeric.double.ZERO) {
+                    balanceTotal / freeCollateral
+                } else {
+                    Numeric.double.ZERO
+                }
                 marketOrder(
                     marketOrderOrderBook,
                     sizeTotal,
@@ -728,7 +733,11 @@ internal class TradeInputCalculator(
                         }
                     }
                 }
-                val balancePercentTotal = (usdcSizeTotal / maxMarketLeverage) / freeCollateral
+                val balancePercentTotal = if (freeCollateral > Numeric.double.ZERO) {
+                    (usdcSizeTotal / maxMarketLeverage) / freeCollateral
+                } else {
+                    Numeric.double.ZERO
+                }
                 marketOrder(
                     marketOrderOrderBook,
                     sizeTotal,
@@ -830,7 +839,11 @@ internal class TradeInputCalculator(
                         }
                     }
                 }
-                val balancePercentTotal = (usdcSizeTotal / maxMarketLeverage) / freeCollateral
+                val balancePercentTotal = if (freeCollateral > Numeric.double.ZERO) {
+                    (usdcSizeTotal / maxMarketLeverage) / freeCollateral
+                } else {
+                    Numeric.double.ZERO
+                }
                 marketOrder(
                     marketOrderOrderBook,
                     sizeTotal,
@@ -986,7 +999,11 @@ internal class TradeInputCalculator(
                 break@orderbookLoop
             }
         }
-        val balancePercentTotal = (usdcSizeTotal / maxMarketLeverage) / freeCollateral
+        val balancePercentTotal = if (freeCollateral > Numeric.double.ZERO) {
+            (usdcSizeTotal / maxMarketLeverage) / freeCollateral
+        } else {
+            Numeric.double.ZERO
+        }
         return marketOrder(
             marketOrderOrderBook,
             sizeTotal,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/AdjustIsolatedMarginInputCalculatorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/AdjustIsolatedMarginInputCalculatorV2.kt
@@ -99,12 +99,7 @@ internal class AdjustIsolatedMarginInputCalculatorV2(
             val amountPercent = modified.amountPercent
             val amountValue = modified.amount
 
-            val initialMarginFraction = market.perpetualMarket?.configs?.effectiveInitialMarginFraction ?: return modified
-            val maxMarketLeverage = if (initialMarginFraction <= Numeric.double.ZERO) {
-                return modified
-            } else {
-                Numeric.double.ONE / initialMarginFraction
-            }
+            val maxMarketLeverage = market.perpetualMarket?.configs?.maxMarketLeverage ?: Numeric.double.ONE
 
             when (inputType) {
                 IsolatedMarginInputType.Amount -> {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputMarketOrderCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputMarketOrderCalculator.kt
@@ -106,13 +106,7 @@ internal class TradeInputMarketOrderCalculator() {
         val tradeSize = trade.size
         if (tradeSize != null) {
             val freeCollateral = subaccount?.calculated?.get(CalculationPeriod.current)?.freeCollateral ?: return null
-
-            val initialMarginFraction = market?.perpetualMarket?.configs?.effectiveInitialMarginFraction
-            val maxMarketLeverage = if (initialMarginFraction == null || initialMarginFraction <= Numeric.double.ZERO) {
-                Numeric.double.ONE
-            } else {
-                Numeric.double.ONE / initialMarginFraction
-            }
+            val maxMarketLeverage = market?.perpetualMarket?.configs?.maxMarketLeverage ?: Numeric.double.ONE
 
             return when (input) {
                 "size.size", "size.percent" -> {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputMarketOrderCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputMarketOrderCalculator.kt
@@ -358,7 +358,7 @@ internal class TradeInputMarketOrderCalculator() {
                         }
                     }
                 }
-                val balancePercentTotal = (usdcSizeTotal / maxMarketLeverage) / freeCollateral
+                val balancePercentTotal = (usdcSizeTotal / maxMarketLeverage) / freeCollateralq
                 createMarketOrderWith(
                     orderbook = marketOrderOrderBook,
                     size = sizeTotal,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputMarketOrderCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputMarketOrderCalculator.kt
@@ -104,8 +104,9 @@ internal class TradeInputMarketOrderCalculator() {
         input: String?,
     ): TradeInputMarketOrder? {
         val tradeSize = trade.size
-        if (tradeSize != null) {
-            val freeCollateral = subaccount?.calculated?.get(CalculationPeriod.current)?.freeCollateral ?: return null
+        val freeCollateral = subaccount?.calculated?.get(CalculationPeriod.current)?.freeCollateral
+
+        if (tradeSize != null && freeCollateral != null && freeCollateral > Numeric.double.ZERO) {
             val maxMarketLeverage = market?.perpetualMarket?.configs?.maxMarketLeverage ?: Numeric.double.ONE
 
             return when (input) {
@@ -358,7 +359,7 @@ internal class TradeInputMarketOrderCalculator() {
                         }
                     }
                 }
-                val balancePercentTotal = (usdcSizeTotal / maxMarketLeverage) / freeCollateralq
+                val balancePercentTotal = (usdcSizeTotal / maxMarketLeverage) / freeCollateral
                 createMarketOrderWith(
                     orderbook = marketOrderOrderBook,
                     size = sizeTotal,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputOptionsCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputOptionsCalculator.kt
@@ -354,17 +354,9 @@ internal class TradeInputOptionsCalculator(
             return null
         }
 
-        val initialMarginFraction =
-            market.perpetualMarket?.configs?.effectiveInitialMarginFraction ?: return null
-
-        val maxMarketLeverage = if (initialMarginFraction <= Numeric.double.ZERO) {
-            return null
-        } else {
-            Numeric.double.ONE / initialMarginFraction
-        }
-
         val equity = subaccount.calculated[CalculationPeriod.current]?.equity
         val freeCollateral = subaccount.calculated[CalculationPeriod.current]?.freeCollateral ?: Numeric.double.ZERO
+        val maxMarketLeverage = market.perpetualMarket?.configs?.maxMarketLeverage ?: Numeric.double.ONE
         val positionNotionalTotal = position?.calculated?.get(CalculationPeriod.current)?.notionalTotal ?: Numeric.double.ZERO
 
         return if (equity != null && equity > Numeric.double.ZERO) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
@@ -528,6 +528,7 @@ data class TradeInputSize(
     val size: Double?,
     val usdcSize: Double?,
     val leverage: Double?,
+    val balancePercent: Double?,
     val input: String?,
 ) {
     companion object {
@@ -542,13 +543,15 @@ data class TradeInputSize(
                 val size = parser.asDouble(data["size"])
                 val usdcSize = parser.asDouble(data["usdcSize"])
                 val leverage = parser.asDouble(data["leverage"])
+                val balancePercent = parser.asDouble(data["balancePercent"])
                 val input = parser.asString(data["input"])
                 return if (existing?.size != size ||
                     existing?.usdcSize != usdcSize ||
                     existing?.leverage != leverage ||
+                    existing?.balancePercent != balancePercent ||
                     existing?.input != input
                 ) {
-                    TradeInputSize(size, usdcSize, leverage, input)
+                    TradeInputSize(size, usdcSize, leverage, balancePercent, input)
                 } else {
                     existing
                 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
@@ -464,6 +464,7 @@ data class OrderbookUsage(
 data class TradeInputMarketOrder(
     val size: Double?,
     val usdcSize: Double?,
+    val balancePercent: Double?,
     val price: Double?,
     val worstPrice: Double?,
     val filled: Boolean,
@@ -480,6 +481,7 @@ data class TradeInputMarketOrder(
             data?.let {
                 val size = parser.asDouble(data["size"])
                 val usdcSize = parser.asDouble(data["usdcSize"])
+                val balancePercent = parser.asDouble(data["balancePercent"])
                 val price = parser.asDouble(data["price"])
                 val worstPrice = parser.asDouble(data["worstPrice"])
                 val filled = parser.asBool(data["filled"]) ?: false
@@ -499,6 +501,7 @@ data class TradeInputMarketOrder(
                 }
                 return if (existing?.size != size ||
                     existing?.usdcSize != usdcSize ||
+                    existing?.balancePercent != balancePercent ||
                     existing?.price != price ||
                     existing?.worstPrice != worstPrice ||
                     existing?.filled != filled ||
@@ -507,6 +510,7 @@ data class TradeInputMarketOrder(
                     TradeInputMarketOrder(
                         size,
                         usdcSize,
+                        balancePercent,
                         price,
                         worstPrice,
                         filled,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/ClosePositionInputProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/ClosePositionInputProcessor.kt
@@ -115,6 +115,7 @@ internal class ClosePositionInputProcessor(
                         size = null,
                         usdcSize = null,
                         leverage = null,
+                        balancePercent = null,
                         input = "size.percent",
                     )
 
@@ -230,6 +231,7 @@ internal class ClosePositionInputProcessor(
             size = null,
             usdcSize = null,
             leverage = null,
+            balancePercent = null,
             input = "size.percent",
         )
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/TradeInputField+Actions.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/TradeInputField+Actions.kt
@@ -22,7 +22,7 @@ import exchange.dydx.abacus.state.model.TradeInputField
 internal val TradeInputField.validTradeInputAction: ((InternalTradeInputState) -> Boolean)?
     get() = when (this) {
         TradeInputField.type, TradeInputField.side -> null
-        TradeInputField.size, TradeInputField.usdcSize, TradeInputField.leverage -> { state -> state.options.needsSize }
+        TradeInputField.size, TradeInputField.usdcSize, TradeInputField.leverage, TradeInputField.balancePercent -> { state -> state.options.needsSize }
         TradeInputField.limitPrice -> { state -> state.options.needsLimitPrice }
         TradeInputField.triggerPrice -> { state -> state.options.needsTriggerPrice }
         TradeInputField.trailingPercent -> { state -> state.options.needsTrailingPercent }
@@ -57,6 +57,7 @@ internal val TradeInputField.valueAction: ((InternalTradeInputState) -> Any?)?
         TradeInputField.size -> { state -> state.size?.size }
         TradeInputField.usdcSize -> { state -> state.size?.usdcSize }
         TradeInputField.leverage -> { state -> state.size?.leverage }
+        TradeInputField.balancePercent -> { state -> state.size?.balancePercent }
 
         TradeInputField.lastInput -> { state -> state.size?.input }
         TradeInputField.limitPrice -> { state -> state.price?.limitPrice }
@@ -215,5 +216,9 @@ internal val TradeInputField.updateValueAction: ((InternalTradeInputState, Strin
 
         TradeInputField.leverage -> { trade, value, parser ->
             trade.size = TradeInputSize.safeCreate(trade.size).copy(leverage = parser.asDouble(value))
+        }
+
+        TradeInputField.balancePercent -> { trade, value, parser ->
+            trade.size = TradeInputSize.safeCreate(trade.size).copy(balancePercent = parser.asDouble(value))
         }
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/TradeInputProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/TradeInputProcessor.kt
@@ -194,6 +194,7 @@ internal class TradeInputProcessor(
                 TradeInputField.size,
                 TradeInputField.usdcSize,
                 TradeInputField.leverage,
+                TradeInputField.balancePercent,
                 TradeInputField.targetLeverage,
                 -> {
                     sizeChanged =
@@ -260,6 +261,7 @@ internal class TradeInputProcessor(
                 TradeInputField.size,
                 TradeInputField.usdcSize,
                 TradeInputField.leverage,
+                TradeInputField.balancePercent,
                 -> {
                     trade.size = TradeInputSize.safeCreate(trade.size).copy(input = inputType.rawValue)
                 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/TradeInputProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/TradeInputProcessor.kt
@@ -174,7 +174,7 @@ internal class TradeInputProcessor(
             when (inputType) {
                 TradeInputField.type, TradeInputField.side -> {
                     if (inputData != null) {
-                        if (trade.size?.input == "size.leverage") {
+                        if (trade.size?.input == "size.leverage" || trade.size?.input == "size.balancePercent") {
                             trade.size = TradeInputSize.safeCreate(trade.size).copy(input = "size.size")
                         }
                         inputType.updateValueAction?.invoke(trade, inputData, parser)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/TradeInputProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/input/TradeInputProcessor.kt
@@ -174,7 +174,8 @@ internal class TradeInputProcessor(
             when (inputType) {
                 TradeInputField.type, TradeInputField.side -> {
                     if (inputData != null) {
-                        if (trade.size?.input == "size.leverage" || trade.size?.input == "size.balancePercent") {
+                        val sizeInput = TradeInputField.invoke(trade.size?.input)
+                        if (sizeInput == TradeInputField.leverage || sizeInput == TradeInputField.balancePercent) {
                             trade.size = TradeInputSize.safeCreate(trade.size).copy(input = "size.size")
                         }
                         inputType.updateValueAction?.invoke(trade, inputData, parser)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
@@ -436,6 +436,7 @@ internal fun TradeInputSize.Companion.safeCreate(existing: TradeInputSize?): Tra
         size = null,
         usdcSize = null,
         leverage = null,
+        balancePercent = null,
         input = null,
     )
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
@@ -276,7 +276,7 @@ fun TradingStateMachine.trade(
                 TradeInputField.type, TradeInputField.side -> {
                     val text = parser.asString(data)
                     if (text != null) {
-                        if (parser.asString(parser.value(trade, "size.input")) == "size.leverage") {
+                        if (parser.asString(parser.value(trade, "size.input")) == "size.leverage" || parser.asString(parser.value(trade, "size.input")) == "size.balancePercent") {
                             trade.safeSet("size.input", "size.size")
                         }
                         trade[typeText] = text

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
@@ -30,6 +30,7 @@ enum class TradeInputField(val rawValue: String) {
     size("size.size"),
     usdcSize("size.usdcSize"),
     leverage("size.leverage"),
+    balancePercent("size.balancePercent"),
     lastInput("size.input"),
 
     limitPrice("price.limitPrice"),
@@ -304,6 +305,7 @@ fun TradingStateMachine.trade(
                 TradeInputField.size,
                 TradeInputField.usdcSize,
                 TradeInputField.leverage,
+                TradeInputField.balancePercent,
                 TradeInputField.targetLeverage,
                 -> {
                     sizeChanged =
@@ -403,6 +405,7 @@ fun TradingStateMachine.trade(
         when (type) {
             TradeInputField.size,
             TradeInputField.usdcSize,
+            TradeInputField.balancePercent,
             TradeInputField.leverage,
             -> {
                 trade.safeSet("size.input", typeText)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine+TradeInput.kt
@@ -276,7 +276,8 @@ fun TradingStateMachine.trade(
                 TradeInputField.type, TradeInputField.side -> {
                     val text = parser.asString(data)
                     if (text != null) {
-                        if (parser.asString(parser.value(trade, "size.input")) == "size.leverage" || parser.asString(parser.value(trade, "size.input")) == "size.balancePercent") {
+                        val sizeInput = TradeInputField.invoke(parser.asString(parser.value(trade, "size.input")))
+                        if (sizeInput == TradeInputField.leverage || sizeInput == TradeInputField.balancePercent) {
                             trade.safeSet("size.input", "size.size")
                         }
                         trade[typeText] = text

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
@@ -1053,7 +1053,8 @@ open class TradingStateMachine(
                 if (internalState.input.currentType == InputType.TRADE) {
                     val trade = internalState.input.trade
                     val account = internalState.wallet.account
-                    if (trade.size?.input == "size.size" || trade.size?.input == "size.usdcSize" || trade.size?.input == "size.balancePercent") {
+                    val sizeInput = TradeInputField.invoke(trade.size?.input)
+                    if (sizeInput == TradeInputField.size || sizeInput == TradeInputField.usdcSize || sizeInput == TradeInputField.balancePercent) {
                         val subaccountNumber = changes.subaccountNumbers?.firstOrNull()
                         val marketId = trade.marketId
                         if (subaccountNumber != null && marketId != null) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/model/TradingStateMachine.kt
@@ -1053,7 +1053,7 @@ open class TradingStateMachine(
                 if (internalState.input.currentType == InputType.TRADE) {
                     val trade = internalState.input.trade
                     val account = internalState.wallet.account
-                    if (trade.size?.input == "size.size" || trade.size?.input == "size.usdcSize") {
+                    if (trade.size?.input == "size.size" || trade.size?.input == "size.usdcSize" || trade.size?.input == "size.balancePercent") {
                         val subaccountNumber = changes.subaccountNumbers?.firstOrNull()
                         val marketId = trade.marketId
                         if (subaccountNumber != null && marketId != null) {
@@ -1074,7 +1074,7 @@ open class TradingStateMachine(
                 when (parser.asString(modified["current"])) {
                     "trade" -> {
                         when (parser.asString(parser.value(modified, "trade.size.input"))) {
-                            "size.size", "size.usdcSize" -> {
+                            "size.size", "size.usdcSize", "size.balancePercent" -> {
                                 val subaccountNumber = changes.subaccountNumbers?.firstOrNull()
                                 val marketId =
                                     parser.asString(parser.value(modified, "trade.marketId"))

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -11,6 +11,9 @@ internal const val QUANTUM_MULTIPLIER = 1_000_000
 // Route Param Constants
 internal const val SLIPPAGE_PERCENT = "1"
 
+// Trade Constants
+internal const val MAX_FREE_COLLATERAL_BUFFER_PERCENT = 0.98
+
 // Isolated Margin Constants
 internal const val MAX_LEVERAGE_BUFFER_PERCENT = 0.98
 internal const val MARGIN_COLLATERALIZATION_CHECK_BUFFER = 0.01;

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
@@ -15,7 +15,6 @@ import kollections.iListOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 
 open class V4TradeInputTests : V4BaseTests() {
     @Test

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
@@ -571,10 +571,10 @@ open class V4TradeInputTests : V4BaseTests() {
             assertNotNull(size)
             assertEquals(size.usdcSize, 10.0)
             assertEquals(size.size, 0.006)
-            assertEquals(size.balancePercent, 0.000005) // freeCollateral: 100000, 20x leverage
+            assertEquals(size.balancePercent, 0.0000049629) // freeCollateral: 100000, 20x leverage
             assertEquals(size.input, "size.usdcSize")
             val errors = perp.internalState.input.errors
-            assertNull(errors)
+            assertEquals(errors?.size, 0)
         } else {
             test(
                 {
@@ -602,12 +602,12 @@ open class V4TradeInputTests : V4BaseTests() {
             perp.trade("10", TradeInputField.size, 0)
             val size = perp.internalState.input.trade.size
             assertNotNull(size)
-            assertEquals(size.usdcSize, 16540.0)
+            assertEquals(size.usdcSize, 16543.0)
             assertEquals(size.size, 10.0)
-            assertEquals(size.balancePercent, 0.00827) // freeCollateral: 100000, 20x leverage
+            assertEquals(size.balancePercent, 0.0082715) // freeCollateral: 100000, 20x leverage
             assertEquals(size.input, "size.size")
             val errors = perp.internalState.input.errors
-            assertNull(errors)
+            assertEquals(errors?.size, 0)
         } else {
             test(
                 {
@@ -635,12 +635,12 @@ open class V4TradeInputTests : V4BaseTests() {
             perp.trade("0.5", TradeInputField.balancePercent, 0)
             val size = perp.internalState.input.trade.size
             assertNotNull(size)
-            assertEquals(size.usdcSize, 16540.0)
-            assertEquals(size.size, 593.6)
+            assertEquals(size.usdcSize, 979999.8321)
+            assertEquals(size.size, 593.5779999999999)
             assertEquals(size.balancePercent, 0.5) // freeCollateral: 100000, 20x leverage
             assertEquals(size.input, "size.balancePercent")
             val errors = perp.internalState.input.errors
-            assertNull(errors)
+            assertEquals(errors?.size, 0)
         } else {
             test(
                 {

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
@@ -15,6 +15,7 @@ import kollections.iListOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 open class V4TradeInputTests : V4BaseTests() {
     @Test
@@ -90,9 +91,29 @@ open class V4TradeInputTests : V4BaseTests() {
             )
         }
 
-        test({
+        if (perp.staticTyping) {
             perp.trade("LIMIT", TradeInputField.type, 0)
-        }, null)
+            val size = perp.internalState.input.trade.size
+            assertNotNull(size)
+            assertEquals(size.input, "size.size")
+        } else {
+            test(
+                {
+                    perp.trade("LIMIT", TradeInputField.type, 0)
+                },
+                """
+                {
+                    "input": {
+                        "trade": {
+                            "size": {
+                                "input": "size.size"
+                            }
+                        }
+                    }
+                }
+                """.trimIndent(),
+            )
+        }
 
         test({
             perp.trade("BUY", TradeInputField.side, 0)
@@ -538,6 +559,105 @@ open class V4TradeInputTests : V4BaseTests() {
                             "code": "REQUIRED_SIZE"
                         }
                     ]
+                }
+            }
+                """.trimIndent(),
+            )
+        }
+
+        if (perp.staticTyping) {
+            perp.trade("10", TradeInputField.usdcSize, 0)
+            val size = perp.internalState.input.trade.size
+            assertNotNull(size)
+            assertEquals(size.usdcSize, 10.0)
+            assertEquals(size.size, 0.006)
+            assertEquals(size.balancePercent, 0.000005) // freeCollateral: 100000, 20x leverage
+            assertEquals(size.input, "size.usdcSize")
+            val errors = perp.internalState.input.errors
+            assertNull(errors)
+        } else {
+            test(
+                {
+                    perp.trade("10", TradeInputField.usdcSize, 0)
+                },
+                """
+            {
+                "input": {
+                    "trade": {
+                        "size": {
+                            "usdcSize": 10.0,
+                            "size": 0.006,
+                            "balancePercent": 0.000005,
+                            "input": "size.usdcSize"
+                        }
+                    },
+                    "errors": null
+                }
+            }
+                """.trimIndent(),
+            )
+        }
+
+        if (perp.staticTyping) {
+            perp.trade("10", TradeInputField.size, 0)
+            val size = perp.internalState.input.trade.size
+            assertNotNull(size)
+            assertEquals(size.usdcSize, 16540.0)
+            assertEquals(size.size, 10.0)
+            assertEquals(size.balancePercent, 0.00827) // freeCollateral: 100000, 20x leverage
+            assertEquals(size.input, "size.size")
+            val errors = perp.internalState.input.errors
+            assertNull(errors)
+        } else {
+            test(
+                {
+                    perp.trade("10", TradeInputField.size, 0)
+                },
+                """
+            {
+                "input": {
+                    "trade": {
+                        "size": {
+                            "usdcSize": 16540.0,
+                            "size": 10.0,
+                            "balancePercent": 0.00827,
+                            "input": "size.size"
+                        }
+                    },
+                    "errors": null
+                }
+            }
+                """.trimIndent(),
+            )
+        }
+
+        if (perp.staticTyping) {
+            perp.trade("0.5", TradeInputField.balancePercent, 0)
+            val size = perp.internalState.input.trade.size
+            assertNotNull(size)
+            assertEquals(size.usdcSize, 16540.0)
+            assertEquals(size.size, 593.6)
+            assertEquals(size.balancePercent, 0.5) // freeCollateral: 100000, 20x leverage
+            assertEquals(size.input, "size.balancePercent")
+            val errors = perp.internalState.input.errors
+            assertNull(errors)
+        } else {
+            test(
+                {
+                    perp.trade("0.5", TradeInputField.balancePercent, 0)
+                },
+                """
+            {
+                "input": {
+                    "trade": {
+                        "size": {
+                            "usdcSize": 1000000.0,
+                            "size": 593.6,
+                            "balancePercent": 0.5,
+                            "input": "size.balancePercent"
+                        }
+                    },
+                    "errors": null
                 }
             }
                 """.trimIndent(),


### PR DESCRIPTION
Adds a `balancePercent` to trade size inputs such that user can choose an amount for their trade based on the percentage of their available balance (we're replacing the 1x...10x leverage buttons with this percentage toggle). See screen recording proof of concept:


https://github.com/user-attachments/assets/c8562fa9-508d-435c-bd59-53cc64398f9b


For now, this only applies to cross market orders. Will follow up in separate PR to enable for isolated market orders (will probably choose to use a `needsPercentBalance` field). Will likely not enable for limit orders until leverage slider is added. 

Note this change is non breaking: to get this, caller just has to update to call into this new field (and set appropriately). 
