### PR TITLE
enable balancePercent field on (cross) market orders

### DIFF
--- a/docs/Input/TradeInput.md
+++ b/docs/Input/TradeInput.md
@@ -223,6 +223,7 @@ The orderbook entries taken by the market order
 data class TradeInputOptions(  
 &emsp;val needsSize: Boolean,  
 &emsp;val needsLeverage: Boolean,  
+&emsp;val needsBalancePercent: Boolean,
 &emsp;val maxLeverage: Double?,  
 &emsp;val needsLimitPrice: Boolean,
 &emsp;val needsTargetLeverage: Boolean,
@@ -247,6 +248,10 @@ UX should ask user for size
 ## needsLeverage
 
 UX should ask user for leverage input
+
+## needsBalancePercent
+
+UX should ask user for balance percent input
 
 ## maxLeverage
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -1066,6 +1066,7 @@ internal class TradeInputCalculator(
                 return when (MarginMode.invoke(marginMode)) {
                     MarginMode.Isolated -> listOf(
                         sizeField(),
+                        // balancePercentField(), TODO: enable in CT-1180
                         bracketsField(),
                         marginModeField(market, account, subaccount),
                         reduceOnlyField(),
@@ -1073,6 +1074,7 @@ internal class TradeInputCalculator(
                     else -> listOf(
                         sizeField(),
                         leverageField(),
+                        balancePercentField(),
                         bracketsField(),
                         marginModeField(market, account, subaccount),
                         reduceOnlyField(),
@@ -1153,6 +1155,13 @@ internal class TradeInputCalculator(
     private fun leverageField(): Map<String, Any> {
         return mapOf(
             "field" to "size.leverage",
+            "type" to "double",
+        )
+    }
+
+    private fun balancePercentField(): Map<String, Any> {
+        return mapOf(
+            "field" to "size.balancePercent",
             "type" to "double",
         )
     }
@@ -1346,6 +1355,7 @@ internal class TradeInputCalculator(
             val options = mutableMapOf<String, Any>(
                 "needsSize" to false,
                 "needsLeverage" to false,
+                "needsBalancePercent" to false,
                 "needsTargetLeverage" to false,
                 "needsTriggerPrice" to false,
                 "needsLimitPrice" to false,
@@ -1363,6 +1373,7 @@ internal class TradeInputCalculator(
                     when (parser.asString(field["field"])) {
                         "size.size" -> options["needsSize"] = true
                         "size.leverage" -> options["needsLeverage"] = true
+                        "size.balancePercent" -> options["needsBalancePercent"] = true
                         "price.triggerPrice" -> options["needsTriggerPrice"] = true
                         "price.limitPrice" -> options["needsLimitPrice"] = true
                         "price.trailingPercent" -> options["needsTrailingPercent"] = true

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputOptionsCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputOptionsCalculator.kt
@@ -81,6 +81,7 @@ internal class TradeInputOptionsCalculator(
                 return when (trade.marginMode) {
                     MarginMode.Isolated -> listOf(
                         sizeField(),
+                        // balancePercentField(), TODO: enable in CT-1180
                         bracketsField(),
                         marginModeField(market, account, subaccount),
                         reduceOnlyField(),
@@ -89,6 +90,7 @@ internal class TradeInputOptionsCalculator(
                     else -> listOf(
                         sizeField(),
                         leverageField(),
+                        balancePercentField(),
                         bracketsField(),
                         marginModeField(market, account, subaccount),
                         reduceOnlyField(),
@@ -181,6 +183,7 @@ internal class TradeInputOptionsCalculator(
                 when (parser.asString(field["field"])) {
                     "size.size" -> options.needsSize = true
                     "size.leverage" -> options.needsLeverage = true
+                    "size.balancePercent" -> options.needsBalancePercent = true
                     "price.triggerPrice" -> options.needsTriggerPrice = true
                     "price.limitPrice" -> options.needsLimitPrice = true
                     "price.trailingPercent" -> options.needsTrailingPercent = true
@@ -400,6 +403,13 @@ internal class TradeInputOptionsCalculator(
     private fun leverageField(): Map<String, Any> {
         return mapOf(
             "field" to "size.leverage",
+            "type" to "double",
+        )
+    }
+
+    private fun balancePercentField(): Map<String, Any> {
+        return mapOf(
+            "field" to "size.balancePercent",
             "type" to "double",
         )
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
@@ -70,6 +70,7 @@ data class TradeInputOptions(
     val needsMarginMode: Boolean,
     val needsSize: Boolean,
     val needsLeverage: Boolean,
+    val needsBalancePercent: Boolean,
     val maxLeverage: Double?,
     val needsLimitPrice: Boolean,
     val needsTargetLeverage: Boolean,
@@ -184,6 +185,7 @@ data class TradeInputOptions(
                 needsMarginMode = state.needsMarginMode,
                 needsSize = state.needsSize,
                 needsLeverage = state.needsLeverage,
+                needsBalancePercent = state.needsBalancePercent,
                 maxLeverage = state.maxLeverage,
                 needsLimitPrice = state.needsLimitPrice,
                 needsTargetLeverage = state.needsTargetLeverage,
@@ -215,6 +217,7 @@ data class TradeInputOptions(
                 val needsMarginMode = parser.asBool(data["needsMarginMode"]) ?: true
                 val needsSize = parser.asBool(data["needsSize"]) ?: false
                 val needsLeverage = parser.asBool(data["needsLeverage"]) ?: false
+                val needsBalancePercent = parser.asBool(data["needsBalancePercent"]) ?: false
                 val maxLeverage = parser.asDouble(data["maxLeverage"])
                 val needsLimitPrice = parser.asBool(data["needsLimitPrice"]) ?: false
                 val needsTargetLeverage = parser.asBool(data["needsTargetLeverage"]) ?: false
@@ -282,6 +285,7 @@ data class TradeInputOptions(
                     existing?.needsMarginMode != needsMarginMode ||
                     existing.needsSize != needsSize ||
                     existing.needsLeverage != needsLeverage ||
+                    existing.needsBalancePercent != needsBalancePercent ||
                     existing.maxLeverage != maxLeverage ||
                     existing.needsLimitPrice != needsLimitPrice ||
                     existing.needsTargetLeverage != needsTargetLeverage ||
@@ -302,6 +306,7 @@ data class TradeInputOptions(
                         needsMarginMode,
                         needsSize,
                         needsLeverage,
+                        needsBalancePercent,
                         maxLeverage,
                         needsLimitPrice,
                         needsTargetLeverage,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
@@ -151,6 +151,7 @@ internal data class InternalTradeInputOptions(
     var needsMarginMode: Boolean = false,
     var needsSize: Boolean = false,
     var needsLeverage: Boolean = false,
+    var needsBalancePercent: Boolean = false,
     var maxLeverage: Double? = null,
     var needsLimitPrice: Boolean = false,
     var needsTargetLeverage: Boolean = false,

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/BaseTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/BaseTests.kt
@@ -733,6 +733,7 @@ open class BaseTests(
             assertEquals(data.needsMarginMode, obj.needsMarginMode, "$trace.needsMarginMode $doesntMatchText")
             assertEquals(data.needsSize, obj.needsSize, "$trace.needsSize $doesntMatchText")
             assertEquals(data.needsLeverage, obj.needsLeverage, "$trace.needsLeverage $doesntMatchText")
+            assertEquals(data.needsBalancePercent, obj.needsBalancePercent, "$trace.needsBalancePercent $doesntMatchText")
             assertEquals(data.needsBrackets, obj.needsBrackets, "$trace.needsBrackets $doesntMatchText")
             assertEquals(data.needsGoodUntil, obj.needsGoodUntil, "$trace.needsGoodUntil $doesntMatchText")
             assertEquals(data.needsLimitPrice, obj.needsLimitPrice, "$trace.needsLimitPrice $doesntMatchText")
@@ -770,6 +771,11 @@ open class BaseTests(
                 parser.asBool(data["needsLeverage"]) ?: false,
                 obj.needsLeverage,
                 "$trace.needsLeverage $doesntMatchText",
+            )
+            assertEquals(
+                parser.asBool(data["needsBalancePercent"]) ?: false,
+                obj.needsBalancePercent,
+                "$trace.needsBalancePercent $doesntMatchText",
             )
             assertEquals(
                 parser.asBool(data["needsBrackets"]) ?: false,

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/TradeInputOptionsTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/TradeInputOptionsTests.kt
@@ -126,6 +126,7 @@ class TradeInputOptionsTests : V4BaseTests() {
             val options = trade.options
             assertEquals(options.needsSize, true)
             assertEquals(options.needsLeverage, true)
+            assertEquals(options.needsBalancePercent, true)
             assertEquals(options.needsTriggerPrice, false)
             assertEquals(options.needsLimitPrice, false)
             assertEquals(options.needsTrailingPercent, false)
@@ -145,6 +146,7 @@ class TradeInputOptionsTests : V4BaseTests() {
                         "options": {
                             "needsSize": true,
                             "needsLeverage": true,
+                            "needsBalancePercent": true,
                             "needsTriggerPrice": false,
                             "needsLimitPrice": false,
                             "needsTrailingPercent": false,
@@ -168,6 +170,7 @@ class TradeInputOptionsTests : V4BaseTests() {
             val options = trade.options
             assertEquals(options.needsSize, true)
             assertEquals(options.needsLeverage, false)
+            assertEquals(options.needsBalancePercent, false)
             assertEquals(options.needsTriggerPrice, false)
             assertEquals(options.needsLimitPrice, true)
             assertEquals(options.needsTrailingPercent, false)
@@ -187,6 +190,7 @@ class TradeInputOptionsTests : V4BaseTests() {
                         "options": {
                             "needsSize": true,
                             "needsLeverage": false,
+                            "needsBalancePercent": false,
                             "needsTriggerPrice": false,
                             "needsLimitPrice": true,
                             "needsTrailingPercent": false,
@@ -210,6 +214,7 @@ class TradeInputOptionsTests : V4BaseTests() {
             val options = trade.options
             assertEquals(options.needsSize, true)
             assertEquals(options.needsLeverage, false)
+            assertEquals(options.needsBalancePercent, false)
             assertEquals(options.needsTriggerPrice, false)
             assertEquals(options.needsLimitPrice, true)
             assertEquals(options.needsTrailingPercent, false)
@@ -229,6 +234,7 @@ class TradeInputOptionsTests : V4BaseTests() {
                         "options": {
                             "needsSize": true,
                             "needsLeverage": false,
+                            "needsBalancePercent": false,
                             "needsTriggerPrice": false,
                             "needsLimitPrice": true,
                             "needsTrailingPercent": false,
@@ -252,6 +258,7 @@ class TradeInputOptionsTests : V4BaseTests() {
             val options = trade.options
             assertEquals(options.needsSize, true)
             assertEquals(options.needsLeverage, false)
+            assertEquals(options.needsBalancePercent, false)
             assertEquals(options.needsTriggerPrice, false)
             assertEquals(options.needsLimitPrice, true)
             assertEquals(options.needsTrailingPercent, false)
@@ -290,6 +297,7 @@ class TradeInputOptionsTests : V4BaseTests() {
                         "options": {
                             "needsSize": true,
                             "needsLeverage": false,
+                            "needsBalancePercent": false,
                             "needsTriggerPrice": false,
                             "needsLimitPrice": true,
                             "needsTrailingPercent": false,


### PR DESCRIPTION
adds a `needsBalancePercent` to `TradeInput` which tells caller whether we should render toggles. For now, only enabling for cross market orders because isolated margin has a slight rounding bug + calculations need to be updated to take into account `targetLeverage`

see below for proof of concept:



https://github.com/user-attachments/assets/133a53a9-ae46-42f5-8004-00de121f2409


