### PR TITLE
fix: empty route addresses [OTE-769]

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/OnboardingSupervisor.kt
@@ -660,7 +660,8 @@ internal class OnboardingSupervisor(
         subaccountNumber: Int?,
     ) {
         val toChain = state?.input?.transfer?.chain ?: return
-        val toAddress = state?.input?.transfer?.address
+        val toAddress = state.input.transfer.address ?: return
+        if (toAddress.isBlank()) return
         val toTokenDenom = state.input.transfer.token ?: return
         val toTokenSkipDenom = stateMachine.routerProcessor.getTokenByDenomAndChainId(
             tokenDenom = toTokenDenom,
@@ -671,7 +672,7 @@ internal class OnboardingSupervisor(
 //        So we prefer the skimDenom and default to the regular denom for API calls.
         val toTokenDenomForAPIUse = toTokenSkipDenom ?: toTokenDenom
 
-        val usdcSize = helper.parser.asDecimal(state?.input?.transfer?.size?.usdcSize) ?: return
+        val usdcSize = helper.parser.asDecimal(state.input.transfer.size?.usdcSize) ?: return
         val fromAmount = if (usdcSize > gas) {
             ((usdcSize - gas) * Numeric.decimal.TEN.pow(decimals)).toBigInteger()
         } else {
@@ -736,6 +737,7 @@ internal class OnboardingSupervisor(
         val toChain = state?.input?.transfer?.chain ?: return
         val toToken = state.input.transfer.token ?: return
         val toAddress = state.input.transfer.address ?: return
+        if (toAddress.isBlank()) return
         val usdcSize = helper.parser.asDecimal(state.input.transfer.size?.usdcSize) ?: return
         val fromAmount = if (usdcSize > gas) {
             ((usdcSize - gas) * Numeric.decimal.TEN.pow(decimals)).toBigInteger()


### PR DESCRIPTION
This should get rid of the vast majority of our route errors with the name `proto: (line X:X): invalid value for string type: null`

This was occurring due to the fact that some nully string values were being accepted in the abacus code before attempting to fire an API request. Until we have datadog it'll be a bit challenging to trace them down, but this should clear most if not all of them