### PR TITLE
chore: add usdcSize type to ErrorFormat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.11.4"
+version = "1.11.5"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/ValidationError.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/ValidationError.kt
@@ -10,10 +10,25 @@ import kotlinx.serialization.Serializable
 
 @JsExport
 @Serializable
+enum class ErrorFormat(val rawValue: String) {
+    StringVal("string"),
+    UsdcPrice("usdcPrice"),
+    Price("price"),
+    Percent("percent"),
+    Size("size");
+
+    companion object {
+        operator fun invoke(rawValue: String?) =
+            ErrorFormat.values().firstOrNull { it.rawValue == rawValue }
+    }
+}
+
+@JsExport
+@Serializable
 data class ErrorParam(
     val key: String,
     val value: String?,
-    val format: String?
+    val format: ErrorFormat?
 ) {
     companion object {
         internal fun create(
@@ -26,7 +41,9 @@ data class ErrorParam(
             data?.let {
                 parser.asString(data["key"])?.let { key ->
                     val value = data["value"]
-                    val format = parser.asString(data["format"])
+                    val format = parser.asString(data["format"])?.let {
+                        ErrorFormat.invoke(it)
+                    }
                     return if (existing?.key != key ||
                         existing.value != value ||
                         existing.format != format

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
@@ -140,7 +140,7 @@ internal class TradeOrderInputValidator(
                         textParams = mapOf(
                             "MIN_VALUE" to mapOf(
                                 "value" to isolatedLimitOrderMinimumEquity,
-                                "format" to "price",
+                                "format" to "usdcPrice",
                             ),
                         ),
                         learnMoreLink = environment?.links?.equityTiersLearnMore,
@@ -169,7 +169,7 @@ internal class TradeOrderInputValidator(
                         textParams = mapOf(
                             "MIN_VALUE" to mapOf(
                                 "value" to isolatedLimitOrderMinimumEquity,
-                                "format" to "price",
+                                "format" to "usdcPrice",
                             ),
                         ),
                         learnMoreLink = environment?.links?.equityTiersLearnMore,

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4TradeInputTests.kt
@@ -1,6 +1,7 @@
 package exchange.dydx.abacus.payload.v4
 
 import exchange.dydx.abacus.calculator.CalculationPeriod
+import exchange.dydx.abacus.output.input.ErrorFormat
 import exchange.dydx.abacus.output.input.ErrorType
 import exchange.dydx.abacus.output.input.OrderSide
 import exchange.dydx.abacus.output.input.OrderStatus
@@ -733,7 +734,7 @@ open class V4TradeInputTests : V4BaseTests() {
             assertEquals("ERRORS.TRADE_BOX.ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM", error?.resources?.text?.stringKey)
             val param = error?.resources?.text?.params?.first()!!
             assertEquals("20.0", param.value)
-            assertEquals("price", param.format)
+            assertEquals(ErrorFormat.UsdcPrice, param.format)
             assertEquals("MIN_VALUE", param.key)
             assertEquals("APP.TRADE.MODIFY_SIZE_FIELD", error?.resources?.action?.stringKey)
         } else {
@@ -774,7 +775,7 @@ open class V4TradeInputTests : V4BaseTests() {
                                     "params": [
                                         {
                                             "value": 20.0,
-                                            "format": "price",
+                                            "format": "usdcPrice",
                                             "key": "MIN_VALUE"
                                         }
                                     ]

--- a/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4WithdrawalSafetyChecksTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/payload/v4/V4WithdrawalSafetyChecksTests.kt
@@ -1,5 +1,6 @@
 package exchange.dydx.abacus.payload.v4
 
+import exchange.dydx.abacus.output.input.ErrorFormat
 import exchange.dydx.abacus.output.input.ErrorType
 import exchange.dydx.abacus.output.input.TransferType
 import exchange.dydx.abacus.responses.ParsingError
@@ -69,7 +70,7 @@ class V4WithdrawalSafetyChecksTests : V4BaseTests() {
             assertEquals(1, resources?.text?.params?.size)
             val param = resources?.text?.params?.get(0)
             assertEquals("1", param?.value)
-            assertEquals("string", param?.format)
+            assertEquals(ErrorFormat.StringVal, param?.format)
             assertEquals("SECONDS", param?.key)
         } else {
             test(
@@ -190,7 +191,7 @@ class V4WithdrawalSafetyChecksTests : V4BaseTests() {
             assertEquals(resources?.text?.params?.size, 1)
             val param = resources?.text?.params?.get(0)
             assertEquals(param?.value, "1234.567891")
-            assertEquals(param?.format, "price")
+            assertEquals(param?.format, ErrorFormat.Price)
             assertEquals(param?.key, "USDC_LIMIT")
 
             assertEquals(

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.11.4'
+    spec.version                  = '1.11.5'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Created the enum `ErrorFormat` instead of just having a bunch of strings for `ErrorParam.format`
- Added a new option: `UsdcPrice` instead of just having `Price`
  - Reason here is that web currently parses this as formatting the price val to market `tickSize` decimals, but for some cases (like the isolated margin error), we know it's usdc and should always be formatted to 2 decimal places
  - Passing through type `UsdcPrice` allows web to switch case on it and use `2` decimal places instead of looking at `tickSize`
 
I dug around for a long time in `BaseInputValidator.kt` to see if I could just have abacus format it properly and not have the web format it [here](https://github.com/dydxprotocol/v4-web/blob/main/src/lib/tradeData.ts#L70) but got absolutely lost and couldn't quite untangle how things are being done. 
- We should be correctly formatting things [here](https://github.com/dydxprotocol/v4-abacus/blob/main/src/commonMain/kotlin/exchange.dydx.abacus/validator/BaseInputValidator.kt#L166) but web doesn't actually get any of these changes
- Managed to deduce that it's because these changes are only being applied to `localized` ([here](https://github.com/dydxprotocol/v4-abacus/blob/main/src/commonMain/kotlin/exchange.dydx.abacus/validator/BaseInputValidator.kt#L158)) but for some reason on web this is just returning the `stringKey` and the param isn't actually being passed through
- Considered updating this whole path but unsure if mobile is using this `localized` property and didn't wanna break anything

This seemed like the easiest (should be non breaking for mobile) change.