### PR TITLE
feat: market close all positions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.11.10"
+version = "1.11.11"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/protocols/PublicProtocols.kt
@@ -204,6 +204,7 @@ enum class AnalyticsEvent {
     TradePlaceOrderClick,
     TradeCancelOrderClick,
     TradeCancelAllOrdersClick,
+    TradeCloseAllPositionsClick,
     TradePlaceOrder,
     TradeCancelOrder,
     TradePlaceOrderSubmissionConfirmed,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/AsyncAbacusStateManagerProtocol.kt
@@ -66,6 +66,7 @@ interface AsyncAbacusStateManagerProtocol {
     // these functions provide payload
     fun placeOrderPayload(): HumanReadablePlaceOrderPayload?
     fun closePositionPayload(): HumanReadablePlaceOrderPayload?
+    fun closeAllPositionsPayload(): HumanReadableCloseAllPositionsPayload?
     fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload?
     fun cancelOrderPayload(orderId: String): HumanReadableCancelOrderPayload?
     fun cancelAllOrdersPayload(marketId: String?): HumanReadableCancelAllOrdersPayload?
@@ -87,6 +88,7 @@ interface AsyncAbacusStateManagerProtocol {
     fun faucet(amount: Double, callback: TransactionCallback)
     fun cancelOrder(orderId: String, callback: TransactionCallback)
     fun cancelAllOrders(marketId: String?, callback: TransactionCallback)
+    fun closeAllPositions(callback: TransactionCallback)
 
     // Bridge functions.
     // If client is not using cancelOrder function, it should call orderCanceled function with

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/utils/Payloads.kt
@@ -3,6 +3,7 @@ package exchange.dydx.abacus.state.manager
 import exchange.dydx.abacus.output.input.OrderStatus
 import exchange.dydx.abacus.utils.IList
 import kollections.JsExport
+import kollections.List
 import kotlinx.serialization.Serializable
 
 internal data class Subaccount(
@@ -87,7 +88,13 @@ data class HumanReadableCancelOrderPayload(
 @Serializable
 data class HumanReadableCancelAllOrdersPayload(
     val marketId: String?,
-    val payloads: IList<HumanReadableCancelOrderPayload>,
+    val payloads: List<HumanReadableCancelOrderPayload>,
+)
+
+@JsExport
+@Serializable
+data class HumanReadableCloseAllPositionsPayload(
+    val payloads: List<HumanReadablePlaceOrderPayload>,
 )
 
 @JsExport

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
@@ -26,6 +26,7 @@ import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
 import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
+import exchange.dydx.abacus.state.manager.HumanReadableCloseAllPositionsPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableSubaccountTransferPayload
@@ -516,6 +517,10 @@ class AsyncAbacusStateManagerV2(
         return adaptor?.cancelAllOrdersPayload(marketId)
     }
 
+    override fun closeAllPositionsPayload(): HumanReadableCloseAllPositionsPayload? {
+        return adaptor?.closeAllPositionsPayload()
+    }
+
     override fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload? {
         return adaptor?.triggerOrdersPayload()
     }
@@ -619,6 +624,15 @@ class AsyncAbacusStateManagerV2(
     override fun cancelAllOrders(marketId: String?, callback: TransactionCallback) {
         try {
             adaptor?.cancelAllOrders(marketId, callback)
+        } catch (e: Exception) {
+            val error = V4TransactionErrors.error(null, e.toString())
+            callback(false, error, null)
+        }
+    }
+
+    override fun closeAllPositions(callback: TransactionCallback) {
+        try {
+            adaptor?.closeAllPositions(callback)
         } catch (e: Exception) {
             val error = V4TransactionErrors.error(null, e.toString())
             callback(false, error, null)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/StateManagerAdaptorV2.kt
@@ -28,6 +28,7 @@ import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
 import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
+import exchange.dydx.abacus.state.manager.HumanReadableCloseAllPositionsPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableSubaccountTransferPayload
@@ -62,6 +63,8 @@ import exchange.dydx.abacus.state.v2.supervisor.cancelAllOrders
 import exchange.dydx.abacus.state.v2.supervisor.cancelAllOrdersPayload
 import exchange.dydx.abacus.state.v2.supervisor.cancelOrder
 import exchange.dydx.abacus.state.v2.supervisor.cancelOrderPayload
+import exchange.dydx.abacus.state.v2.supervisor.closeAllPositions
+import exchange.dydx.abacus.state.v2.supervisor.closeAllPositionsPayload
 import exchange.dydx.abacus.state.v2.supervisor.closePosition
 import exchange.dydx.abacus.state.v2.supervisor.closePositionPayload
 import exchange.dydx.abacus.state.v2.supervisor.commitAdjustIsolatedMargin
@@ -546,6 +549,10 @@ internal class StateManagerAdaptorV2(
         return accounts.cancelAllOrdersPayload(marketId)
     }
 
+    internal fun closeAllPositionsPayload(): HumanReadableCloseAllPositionsPayload? {
+        return accounts.closeAllPositionsPayload(currentHeight)
+    }
+
     internal fun triggerOrdersPayload(): HumanReadableTriggerOrdersPayload? {
         return accounts.triggerOrdersPayload(currentHeight)
     }
@@ -606,6 +613,10 @@ internal class StateManagerAdaptorV2(
 
     internal fun cancelAllOrders(marketId: String?, callback: TransactionCallback) {
         accounts.cancelAllOrders(marketId, callback)
+    }
+
+    internal fun closeAllPositions(callback: TransactionCallback) {
+        accounts.closeAllPositions(currentHeight, callback)
     }
 
     internal fun orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -23,6 +23,7 @@ import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
 import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
+import exchange.dydx.abacus.state.manager.HumanReadableCloseAllPositionsPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableSubaccountTransferPayload
@@ -1154,6 +1155,10 @@ internal fun AccountSupervisor.cancelAllOrdersPayload(marketId: String?): HumanR
     return subaccount?.cancelAllOrdersPayload(marketId)
 }
 
+internal fun AccountSupervisor.closeAllPositionsPayload(currentHeight: Int?): HumanReadableCloseAllPositionsPayload? {
+    return subaccount?.closeAllPositionsPayload(currentHeight)
+}
+
 internal fun AccountSupervisor.depositPayload(): HumanReadableDepositPayload? {
     return subaccount?.depositPayload()
 }
@@ -1207,6 +1212,10 @@ internal fun AccountSupervisor.cancelOrder(orderId: String, callback: Transactio
 
 internal fun AccountSupervisor.cancelAllOrders(marketId: String?, callback: TransactionCallback) {
     subaccount?.cancelAllOrders(marketId, callback)
+}
+
+internal fun AccountSupervisor.closeAllPositions(currentHeight: Int?, callback: TransactionCallback) {
+    subaccount?.closeAllPositions(currentHeight, callback)
 }
 
 internal fun AccountSupervisor.orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
@@ -17,6 +17,7 @@ import exchange.dydx.abacus.state.manager.HistoricalPnlPeriod
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
 import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
+import exchange.dydx.abacus.state.manager.HumanReadableCloseAllPositionsPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
 import exchange.dydx.abacus.state.manager.HumanReadableSubaccountTransferPayload
@@ -295,6 +296,10 @@ internal fun AccountsSupervisor.cancelAllOrdersPayload(marketId: String?): Human
     return account?.cancelAllOrdersPayload(marketId)
 }
 
+internal fun AccountsSupervisor.closeAllPositionsPayload(currentHeight: Int?): HumanReadableCloseAllPositionsPayload? {
+    return account?.closeAllPositionsPayload(currentHeight)
+}
+
 internal fun AccountsSupervisor.depositPayload(): HumanReadableDepositPayload? {
     return account?.depositPayload()
 }
@@ -359,6 +364,10 @@ internal fun AccountsSupervisor.cancelOrder(orderId: String, callback: Transacti
 
 internal fun AccountsSupervisor.cancelAllOrders(marketId: String?, callback: TransactionCallback) {
     account?.cancelAllOrders(marketId, callback)
+}
+
+internal fun AccountsSupervisor.closeAllPositions(currentHeight: Int?, callback:TransactionCallback) {
+    account?.closeAllPositions(currentHeight, callback)
 }
 
 internal fun AccountsSupervisor.orderCanceled(orderId: String) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountsSupervisor.kt
@@ -366,7 +366,7 @@ internal fun AccountsSupervisor.cancelAllOrders(marketId: String?, callback: Tra
     account?.cancelAllOrders(marketId, callback)
 }
 
-internal fun AccountsSupervisor.closeAllPositions(currentHeight: Int?, callback:TransactionCallback) {
+internal fun AccountsSupervisor.closeAllPositions(currentHeight: Int?, callback: TransactionCallback) {
     account?.closeAllPositions(currentHeight, callback)
 }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -16,6 +16,7 @@ import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.FaucetRecord
 import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableCancelOrderPayload
+import exchange.dydx.abacus.state.manager.HumanReadableCloseAllPositionsPayload
 import exchange.dydx.abacus.state.manager.HumanReadableDepositPayload
 import exchange.dydx.abacus.state.manager.HumanReadableFaucetPayload
 import exchange.dydx.abacus.state.manager.HumanReadablePlaceOrderPayload
@@ -334,6 +335,10 @@ internal class SubaccountSupervisor(
         return payloadProvider.cancelAllOrdersPayload(marketId)
     }
 
+    internal fun closeAllPositionsPayload(currentHeight: Int?): HumanReadableCloseAllPositionsPayload {
+        return payloadProvider.closeAllPositionsPayload(currentHeight)
+    }
+
     fun trade(
         data: String?,
         type: TradeInputField?,
@@ -433,6 +438,10 @@ internal class SubaccountSupervisor(
 
     internal fun cancelAllOrders(marketId: String?, callback: TransactionCallback): HumanReadableCancelAllOrdersPayload {
         return transactionSupervisor.cancelAllOrders(marketId, callback)
+    }
+
+    internal fun closeAllPositions(currentHeight: Int?, callback: TransactionCallback): HumanReadableCloseAllPositionsPayload {
+        return transactionSupervisor.closeAllPositions(currentHeight, callback)
     }
 
     internal fun commitTriggerOrders(

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountTransactionPayloadProvider.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountTransactionPayloadProvider.kt
@@ -1,7 +1,6 @@
 package exchange.dydx.abacus.state.v2.supervisor
 
 import abs
-import exchange.dydx.abacus.calculator.CalculationPeriod
 import exchange.dydx.abacus.calculator.MarginCalculator
 import exchange.dydx.abacus.calculator.SlippageConstants.MARKET_ORDER_MAX_SLIPPAGE
 import exchange.dydx.abacus.calculator.TriggerOrdersConstants.TRIGGER_ORDER_DEFAULT_DURATION_DAYS

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -253,6 +253,21 @@ class V4TransactionTests : NetworkTests() {
     }
 
     @Test
+    fun testCloseAllPositions() {
+        setStateMachineConnected(stateManager)
+        testWebSocket?.simulateReceived(mock.accountsChannel.v4_parent_subaccounts_subscribed_with_trigger_orders_and_open_positions)
+
+        var orderPlacedCallCount = 0
+        val callback: TransactionCallback = { _, _, _ -> orderPlacedCallCount++ }
+        val closePositionPayloads = testChain!!.placeOrderPayloads
+
+        subaccountSupervisor?.closeAllPositions(0, callback)
+        assertTransactionQueueEmpty()
+        // there are 3 open positions
+        assertEquals(3, closePositionPayloads.size)
+    }
+
+    @Test
     fun testCancelTriggerOrdersWithClosedOrFlippedPositions() {
         setStateMachineConnected(stateManager)
         val canceldOrderPayloads = testChain!!.canceldOrderPayloads

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.11.10'
+    spec.version                  = '1.11.11'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
adding a helper function to market close all open positions under parent subaccount 0

in the future when indexer supports mid price ws endpoint, and protocol support limit close (reduce-only non-IOC), we'll only add a limit close option. until then, this is just full closing all positions with market price (i.e. oracle price + slippage)

tested locally https://github.com/dydxprotocol/v4-web/pull/1031