### PR TITLE
Set the indexer URL without callback

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.11.9"
+version = "1.11.10"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionsSupervisor.kt
@@ -171,16 +171,7 @@ internal class ConnectionsSupervisor(
     }
 
     private fun bestEffortConnectIndexer() {
-        findOptimalIndexer { config ->
-            this.indexerConfig = config
-        }
-    }
-
-    private fun findOptimalIndexer(callback: (config: IndexerURIs?) -> Unit) {
-        val first = helper.configs.indexerConfigs?.firstOrNull()
-        helper.ioImplementations.threading?.async(ThreadingType.abacus) {
-            callback(first)
-        }
+        indexerConfig = helper.configs.indexerConfigs?.firstOrNull()
     }
 
     private fun bestEffortConnectChain() {

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.11.9'
+    spec.version                  = '1.11.10'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Fix a problem with last PR.  The indexer url is needed when calling getOptimalNode, so we need to set it without an async callback.