### PR TITLE
fix: fix isolated pnl transfer calc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.11.11"
+version = "1.11.12"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TradeInputCalculator.kt
@@ -626,7 +626,7 @@ internal class TradeInputCalculator(
                     OrderSide.Buy -> entryPrice - (oraclePrice ?: entryPrice)
                     OrderSide.Sell -> (oraclePrice ?: entryPrice) - entryPrice
                 }
-                val pnlImpact = (diff * balance * tradeLeverage) / (entryPrice + diff * tradeLeverage)
+                val pnlImpact = if ((entryPrice + diff * tradeLeverage) > Numeric.double.ZERO) (diff * balance * tradeLeverage) / (entryPrice + diff * tradeLeverage) else Numeric.double.ZERO
                 max(pnlImpact, Numeric.double.ZERO)
             }
         }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputMarketOrderCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TradeInput/TradeInputMarketOrderCalculator.kt
@@ -246,8 +246,8 @@ internal class TradeInputMarketOrderCalculator() {
                     OrderSide.Buy -> entryPrice - (oraclePrice ?: entryPrice)
                     OrderSide.Sell -> (oraclePrice ?: entryPrice) - entryPrice
                 }
-                val res = (diff * desiredBalance * tradeLeverage) / (entryPrice + diff * tradeLeverage)
-                max(res, Numeric.double.ZERO)
+                val pnlImpact = if ((entryPrice + diff * tradeLeverage) > Numeric.double.ZERO) (diff * desiredBalance * tradeLeverage) / (entryPrice + diff * tradeLeverage) else Numeric.double.ZERO
+                max(pnlImpact, Numeric.double.ZERO)
             }
         }
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -12,10 +12,9 @@ internal const val QUANTUM_MULTIPLIER = 1_000_000
 internal const val SLIPPAGE_PERCENT = "1"
 
 // Trade Constants
-internal const val MAX_FREE_CROSS_COLLATERAL_BUFFER_PERCENT = 0.95
+internal const val MAX_FREE_COLLATERAL_BUFFER_PERCENT = 0.95
 
 // Isolated Margin Constants
-internal const val MAX_FREE_ISOLATED_COLLATERAL_BUFFER_PERCENT = 0.95
 internal const val MAX_LEVERAGE_BUFFER_PERCENT = 0.98
 internal const val MARGIN_COLLATERALIZATION_CHECK_BUFFER = 0.01;
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -15,7 +15,7 @@ internal const val SLIPPAGE_PERCENT = "1"
 internal const val MAX_FREE_CROSS_COLLATERAL_BUFFER_PERCENT = 0.95
 
 // Isolated Margin Constants
-internal const val MAX_FREE_ISOLATED_COLLATERAL_BUFFER_PERCENT = 0.93
+internal const val MAX_FREE_ISOLATED_COLLATERAL_BUFFER_PERCENT = 0.95
 internal const val MAX_LEVERAGE_BUFFER_PERCENT = 0.98
 internal const val MARGIN_COLLATERALIZATION_CHECK_BUFFER = 0.01;
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.11.11'
+    spec.version                  = '1.11.12'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
noticed a bug when testing this feature - isolated margin percent inputs looked wrong esp when the amount was high - realized it was cuz the collateral transfer calculation was wrong - we need to include the isolatedPnlImpact in the balance used

(for some reason when I build locally now it keeps telling the testnet chain is halted? I tried with building a local abacus with no change but an extra space and it still said halted so assuming this is not related)

https://github.com/user-attachments/assets/5323f9e2-7ea5-4347-aa78-045ab320cc28


