### PR TITLE
fix: fix web not connecting to abacus

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.11.13"
+version = "1.11.14"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionsSupervisor.kt
@@ -391,7 +391,6 @@ internal class ConnectionsSupervisor(
             val timer = helper.ioImplementations.timer ?: CoroutineTimer.instance
             chainTimer = timer.schedule(serverPollingDuration, null) {
                 if (readyToConnect) {
-                    validatorUrl = null
                     bestEffortConnectChain()
                 }
                 false

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.11.13'
+    spec.version                  = '1.11.14'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
web wasn't connecting after abacus version bump - isolated it to a change from this version 

https://github.com/dydxprotocol/v4-abacus/pull/661
<img width="377" alt="Screenshot 2024-09-20 at 11 08 13 AM" src="https://github.com/user-attachments/assets/5e2282f6-c87f-47e4-9bfc-bfa2312e1350">

fixed by removing setting of validatorUrl to null