### PR TITLE
feat: add eta to state [OTE-832]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.11.24"
+version = "1.12.0"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TransferInputCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/TransferInputCalculator.kt
@@ -151,9 +151,9 @@ internal class TransferInputCalculator(val parser: ParserProtocol) {
                 val exchangeRate = parser.asDouble(parser.value(transfer, "route.exchangeRate"))
                 summary.safeSet("exchangeRate", exchangeRate)
 
-                val estimatedRouteDuration =
-                    parser.asDouble(parser.value(transfer, "route.estimatedRouteDuration"))
-                summary.safeSet("estimatedRouteDuration", estimatedRouteDuration)
+                val estimatedRouteDurationSeconds =
+                    parser.asDouble(parser.value(transfer, "route.estimatedRouteDurationSeconds"))
+                summary.safeSet("estimatedRouteDurationSeconds", estimatedRouteDurationSeconds)
 
                 if (usdcSize != null) {
                     summary.safeSet("usdcSize", usdcSize)
@@ -204,9 +204,9 @@ internal class TransferInputCalculator(val parser: ParserProtocol) {
                 val exchangeRate = parser.asDouble(parser.value(transfer, "route.exchangeRate"))
                 summary.safeSet("exchangeRate", exchangeRate)
 
-                val estimatedRouteDuration =
-                    parser.asDouble(parser.value(transfer, "route.estimatedRouteDuration"))
-                summary.safeSet("estimatedRouteDuration", estimatedRouteDuration)
+                val estimatedRouteDurationSeconds =
+                    parser.asDouble(parser.value(transfer, "route.estimatedRouteDurationSeconds"))
+                summary.safeSet("estimatedRouteDurationSeconds", estimatedRouteDurationSeconds)
 
                 val bridgeFee = parser.asDouble(parser.value(transfer, "route.bridgeFee"))
                 summary.safeSet("bridgeFee", bridgeFee)

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TransferInputCalculatorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/V2/TransferInputCalculatorV2.kt
@@ -51,7 +51,7 @@ internal class TransferInputCalculatorV2(
 
                 val slippage = parser.asDouble(parser.value(route, "slippage"))
                 val exchangeRate = parser.asDouble(parser.value(route, "exchangeRate"))
-                val estimatedRouteDuration = parser.asDouble(parser.value(route, "estimatedRouteDuration"))
+                val estimatedRouteDurationSeconds = parser.asDouble(parser.value(route, "estimatedRouteDurationSeconds"))
                 val bridgeFee = parser.asDouble(parser.value(route, "bridgeFee"))
                 val gasFee = parser.asDouble(parser.value(route, "gasFee"))
                 val toAmount = parser.asDouble(parser.value(route, "toAmount"))
@@ -74,7 +74,7 @@ internal class TransferInputCalculatorV2(
                     fee = fee,
                     slippage = slippage,
                     exchangeRate = exchangeRate,
-                    estimatedRouteDuration = estimatedRouteDuration,
+                    estimatedRouteDurationSeconds = estimatedRouteDurationSeconds,
                     usdcSize = usdcSize,
                     bridgeFee = bridgeFee,
                     gasFee = gasFee,
@@ -94,7 +94,7 @@ internal class TransferInputCalculatorV2(
 
                 val slippage = parser.asDouble(parser.value(route, "slippage"))
                 val exchangeRate = parser.asDouble(parser.value(route, "exchangeRate"))
-                val estimatedRouteDuration = parser.asDouble(parser.value(route, "estimatedRouteDuration"))
+                val estimatedRouteDurationSeconds = parser.asDouble(parser.value(route, "estimatedRouteDurationSeconds"))
                 val bridgeFee = parser.asDouble(parser.value(route, "bridgeFee"))
                 val gasFee = parser.asDouble(parser.value(route, "gasFee"))
                 val toAmount = parser.asDouble(parser.value(route, "toAmount"))
@@ -109,7 +109,7 @@ internal class TransferInputCalculatorV2(
                     fee = fee,
                     slippage = slippage,
                     exchangeRate = exchangeRate,
-                    estimatedRouteDuration = estimatedRouteDuration,
+                    estimatedRouteDurationSeconds = estimatedRouteDurationSeconds,
                     usdcSize = usdcSize,
                     bridgeFee = bridgeFee,
                     gasFee = gasFee,
@@ -131,7 +131,7 @@ internal class TransferInputCalculatorV2(
                     fee = null,
                     slippage = null,
                     exchangeRate = null,
-                    estimatedRouteDuration = null,
+                    estimatedRouteDurationSeconds = null,
                     bridgeFee = null,
                     toAmount = null,
                     toAmountMin = null,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TransferInput.kt
@@ -354,7 +354,7 @@ data class TransferInputSummary(
     val filled: Boolean,
     val slippage: Double?,
     val exchangeRate: Double?,
-    val estimatedRouteDuration: Double?,
+    val estimatedRouteDurationSeconds: Double?,
     val bridgeFee: Double?,
     val gasFee: Double?,
     val toAmount: Double?,
@@ -377,7 +377,7 @@ data class TransferInputSummary(
                 val filled = parser.asBool(data["filled"]) ?: false
                 val slippage = parser.asDouble(data["slippage"])
                 val exchangeRate = parser.asDouble(data["exchangeRate"])
-                val estimatedRouteDuration = parser.asDouble(data["estimatedRouteDuration"])
+                val estimatedRouteDurationSeconds = parser.asDouble(data["estimatedRouteDurationSeconds"])
                 val bridgeFee = parser.asDouble(data["bridgeFee"])
                 val gasFee = parser.asDouble(data["gasFee"])
                 val toAmount = parser.asDouble(data["toAmount"])
@@ -391,7 +391,7 @@ data class TransferInputSummary(
                     existing?.filled != filled ||
                     existing.slippage != slippage ||
                     existing.exchangeRate != exchangeRate ||
-                    existing.estimatedRouteDuration != estimatedRouteDuration ||
+                    existing.estimatedRouteDurationSeconds != estimatedRouteDurationSeconds ||
                     existing.bridgeFee != bridgeFee ||
                     existing.gasFee != gasFee ||
                     existing.toAmount != toAmount ||
@@ -406,7 +406,7 @@ data class TransferInputSummary(
                         filled,
                         slippage,
                         exchangeRate,
-                        estimatedRouteDuration,
+                        estimatedRouteDurationSeconds,
                         bridgeFee,
                         gasFee,
                         toAmount,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessor.kt
@@ -17,7 +17,7 @@ internal class SkipRouteProcessor(internal val parser: ParserProtocol) {
             "route.estimated_amount_out" to "toAmount",
             "route.swap_price_impact_percent" to "aggregatePriceImpact",
             "route.warning" to "warning",
-
+            "route.estimated_route_duration_seconds" to "estimatedRouteDurationSeconds",
 //            SQUID PARAMS THAT ARE NOW DEPRECATED:
 //            "route.estimate.gasCosts.0.amountUSD" to "gasFee",
 //            "route.estimate.exchangeRate" to "exchangeRate",
@@ -71,6 +71,8 @@ internal class SkipRouteProcessor(internal val parser: ParserProtocol) {
         decimals: Double?
     ): Map<String, Any> {
         val modified = BaseProcessor(parser).transform(existing, payload, keyMap)
+
+        modified.safeSet("estimatedRouteDurationSeconds", parser.value(payload, "route.estimated_route_duration_seconds"))
 
         var bridgeFees = findFee(payload, "BRIDGE") ?: 0.0
 //        TODO: update web UI to show smart relay fees

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalTransferInputState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalTransferInputState.kt
@@ -87,7 +87,7 @@ internal fun TransferInputSummary.Companion.safeCreate(existing: TransferInputSu
         filled = false,
         slippage = null,
         exchangeRate = null,
-        estimatedRouteDuration = null,
+        estimatedRouteDurationSeconds = null,
         bridgeFee = null,
         gasFee = null,
         toAmount = null,

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
@@ -67,7 +67,7 @@ class SkipRouteProcessorTests {
             ),
         )
 //        Sometimes assertEquals behaves strangely where it insists on comparing the memory address.
-//        When this happens I need to tokenize the objects first. This behavior appear to be non-deterministic.
+//        When this happens I need to serialize the objects first. This behavior appear to be non-deterministic.
         assertEquals(expected.toJsonElement(), result.toJsonElement())
     }
 

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
@@ -7,6 +7,7 @@ import exchange.dydx.abacus.utils.DEFAULT_GAS_PRICE
 import exchange.dydx.abacus.utils.JsonEncoder
 import exchange.dydx.abacus.utils.Parser
 import exchange.dydx.abacus.utils.toJsonArray
+import exchange.dydx.abacus.utils.toJsonElement
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -54,17 +55,20 @@ class SkipRouteProcessorTests {
         val expected = mapOf(
             "toAmountUSD" to 1498.18,
             "toAmount" to 1499.8,
+            "estimatedRouteDurationSeconds" to 25,
             "bridgeFee" to .2,
             "slippage" to "1",
             "requestPayload" to mapOf(
-                "data" to "mock-encoded-solana-tx",
                 "fromChainId" to "solana",
                 "fromAddress" to "98bVPZQCHZmCt9v3ni9kwtjKgLuzHBpstQkdPyAucBNx",
                 "toChainId" to "noble-1",
                 "toAddress" to "uusdc",
+                "data" to "mock-encoded-solana-tx",
             ),
         )
-        assertEquals(expected, result)
+//        Sometimes assertEquals behaves strangely where it insists on comparing the memory address.
+//        When this happens I need to tokenize the objects first. This behavior appear to be non-deterministic.
+        assertEquals(expected.toJsonElement(), result.toJsonElement())
     }
 
     /**

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.11.24'
+    spec.version                  = '1.12.0'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
add estimatedRouteDurationSeconds to route + summary state so we can display it in the UI

pretty sure this is a breaking change since we're updating the name of the state attribute. IMO worth doing to make the property more descriptive