### PR TITLE
Fix codegen with TransferType

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.11.23"
+version = "1.11.24"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/functional/vault/VaultAccount.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/functional/vault/VaultAccount.kt
@@ -5,8 +5,8 @@ import exchange.dydx.abacus.utils.IList
 import exchange.dydx.abacus.utils.Parser
 import indexer.codegen.IndexerTransferBetweenResponse
 import indexer.codegen.IndexerTransferType.DEPOSIT
-import indexer.codegen.IndexerTransferType.TRANSFERIN
-import indexer.codegen.IndexerTransferType.TRANSFEROUT
+import indexer.codegen.IndexerTransferType.TRANSFER_IN
+import indexer.codegen.IndexerTransferType.TRANSFER_OUT
 import indexer.codegen.IndexerTransferType.WITHDRAWAL
 import kollections.toIList
 import kotlinx.serialization.Serializable
@@ -97,8 +97,8 @@ object VaultAccountCalculator {
                     timestampMs = parser.asDatetime(el.createdAt)?.toEpochMilliseconds()?.toDouble(),
                     amountUsdc = parser.asDouble(el.size),
                     type = when (el.type) {
-                        TRANSFEROUT -> VaultTransferType.DEPOSIT
-                        TRANSFERIN -> VaultTransferType.WITHDRAWAL
+                        TRANSFER_OUT -> VaultTransferType.DEPOSIT
+                        TRANSFER_IN -> VaultTransferType.WITHDRAWAL
                         DEPOSIT, WITHDRAWAL, null -> null
                     },
                     id = el.id,

--- a/src/commonMain/kotlin/indexer/codegen/IndexerTransferType.kt
+++ b/src/commonMain/kotlin/indexer/codegen/IndexerTransferType.kt
@@ -16,13 +16,13 @@ import kotlin.js.JsExport
 
 /**
  *
- * Values: TRANSFERIN,TRANSFEROUT,DEPOSIT,WITHDRAWAL
+ * Values: TRANSFER_IN,TRANSFER_OUT,DEPOSIT,WITHDRAWAL
  */
 @JsExport
 @Serializable
 enum class IndexerTransferType(val value: kotlin.String) {
-    TRANSFERIN("TRANSFER_IN"), // :/
-    TRANSFEROUT("TRANSFER_OUT"), // :/
+    TRANSFER_IN("TRANSFER_IN"), // :/
+    TRANSFER_OUT("TRANSFER_OUT"), // :/
     DEPOSIT("DEPOSIT"), // :/
     WITHDRAWAL("WITHDRAWAL"); // :/
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/functional/vault/VaultAccountTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/functional/vault/VaultAccountTests.kt
@@ -30,13 +30,13 @@ class VaultAccountTests {
                     id = "1",
                     createdAt = Instant.fromEpochMilliseconds(1659465600000).toString(),
                     size = "6000.0",
-                    type = IndexerTransferType.TRANSFEROUT,
+                    type = IndexerTransferType.TRANSFER_OUT,
                 ),
                 IndexerTransferResponseObject(
                     id = "2",
                     createdAt = Instant.fromEpochMilliseconds(1659552000000).toString(),
                     size = "2000.0",
-                    type = IndexerTransferType.TRANSFERIN,
+                    type = IndexerTransferType.TRANSFER_IN,
                 ),
             ),
         )

--- a/swagger_codegen.sh
+++ b/swagger_codegen.sh
@@ -68,6 +68,12 @@ sed -i '' 's/TAKEPROFIT/TAKE_PROFIT/' generated/src/main/kotlin/indexer/codegen/
 # replace TAKEPROFITMARKET with TAKE_PROFIT_MARKET in IndexerAPIOrderType.kt
 sed -i '' 's/TAKEPROFITMARKET/TAKE_PROFIT_MARKET/' generated/src/main/kotlin/indexer/codegen/OrderType.kt
 
+# replace TRANSFERIN with TRANSFER_IN in TransferType.kt
+sed -i '' 's/TRANSFERIN/TRANSFER_IN/' generated/src/main/kotlin/indexer/codegen/TransferType.kt
+
+# replace TRANSFEROUT with TRANSFER_OUT in TransferType.kt
+sed -i '' 's/TRANSFEROUT/TRANSFER_OUT/' generated/src/main/kotlin/indexer/codegen/TransferType.kt
+
 # replace PerpetualPositionsMap with Map<String, PerpetualPositionResponseObject> in SubaccountResponseObject.kt
 sed -i '' 's/\ PerpetualPositionsMap/\ Map<String, IndexerPerpetualPositionResponseObject>/g' generated/src/main/kotlin/indexer/codegen/SubaccountResponseObject.kt
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.11.23'
+    spec.version                  = '1.11.24'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
The enum value has to be the same as the string value for the serialization to work correctly.  Unfortunately, the current codegen utility doesn't do that, so we have to perform extra post-processing.