### PR TITLE
Rename validator data models for Vaults and move them to the correct package

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.12.3"
+version = "1.12.4"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/functional/vault/VaultAccount.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/functional/vault/VaultAccount.kt
@@ -8,32 +8,10 @@ import indexer.codegen.IndexerTransferType.DEPOSIT
 import indexer.codegen.IndexerTransferType.TRANSFER_IN
 import indexer.codegen.IndexerTransferType.TRANSFER_OUT
 import indexer.codegen.IndexerTransferType.WITHDRAWAL
+import indexer.models.chain.OnChainAccountVaultResponse
 import kollections.toIList
 import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
-
-@JsExport
-@Serializable
-data class ShareUnlock(
-    val shares: NumShares?,
-    val unlockBlockHeight: Double?,
-)
-
-@JsExport
-@Serializable
-data class NumShares(
-    val numShares: Double?,
-)
-
-@JsExport
-@Serializable
-data class AccountVaultResponse(
-    val address: String? = null,
-    val shares: NumShares? = null,
-    val shareUnlocks: Array<ShareUnlock>? = null,
-    val equity: Double? = null,
-    val withdrawableEquity: Double? = null,
-)
 
 @JsExport
 @Serializable
@@ -75,8 +53,8 @@ enum class VaultTransferType {
 object VaultAccountCalculator {
     private val parser = Parser()
 
-    fun getAccountVaultResponse(apiResponse: String): AccountVaultResponse? {
-        return parser.asTypedObject<AccountVaultResponse>(apiResponse)
+    fun getAccountVaultResponse(apiResponse: String): OnChainAccountVaultResponse? {
+        return parser.asTypedObject<OnChainAccountVaultResponse>(apiResponse)
     }
 
     fun getTransfersBetweenResponse(apiResponse: String): IndexerTransferBetweenResponse? {
@@ -84,7 +62,7 @@ object VaultAccountCalculator {
     }
 
     fun calculateUserVaultInfo(
-        vaultInfo: AccountVaultResponse,
+        vaultInfo: OnChainAccountVaultResponse,
         vaultTransfers: IndexerTransferBetweenResponse,
     ): VaultAccount {
         val presentValue = vaultInfo.equity?.let { it / 1_000_000 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/functional/vault/VaultDepositWithdrawForm.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/functional/vault/VaultDepositWithdrawForm.kt
@@ -10,6 +10,7 @@ import exchange.dydx.abacus.protocols.asTypedObject
 import exchange.dydx.abacus.utils.IList
 import exchange.dydx.abacus.utils.Parser
 import exchange.dydx.abacus.utils.format
+import indexer.models.chain.OnChainVaultDepositWithdrawSlippageResponse
 import kollections.toIList
 import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
@@ -37,13 +38,6 @@ data class VaultFormAccountData(
     val marginUsage: Double?,
     val freeCollateral: Double?,
     val canViewAccount: Boolean?,
-)
-
-@JsExport
-@Serializable
-data class VaultDepositWithdrawSlippageResponse(
-    val sharesToWithdraw: NumShares,
-    val expectedQuoteQuantums: Double,
 )
 
 object VaultFormValidationErrors {
@@ -203,15 +197,15 @@ object VaultDepositWithdrawFormValidator {
     private const val SLIPPAGE_PERCENT_ACK = 0.04
     private const val SLIPPAGE_TOLERANCE = 0.01
 
-    fun getVaultDepositWithdrawSlippageResponse(apiResponse: String): VaultDepositWithdrawSlippageResponse? {
-        return parser.asTypedObject<VaultDepositWithdrawSlippageResponse>(apiResponse)
+    fun getVaultDepositWithdrawSlippageResponse(apiResponse: String): OnChainVaultDepositWithdrawSlippageResponse? {
+        return parser.asTypedObject<OnChainVaultDepositWithdrawSlippageResponse>(apiResponse)
     }
 
     fun validateVaultForm(
         formData: VaultFormData,
         accountData: VaultFormAccountData?,
         vaultAccount: VaultAccount?,
-        slippageResponse: VaultDepositWithdrawSlippageResponse?
+        slippageResponse: OnChainVaultDepositWithdrawSlippageResponse?
     ): VaultFormValidationResult {
         val errors = mutableListOf<ValidationError>()
         var submissionData: VaultDepositWithdrawSubmissionData? = null

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/internalstate/InternalState.kt
@@ -2,7 +2,6 @@ package exchange.dydx.abacus.state.internalstate
 
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import exchange.dydx.abacus.calculator.CalculationPeriod
-import exchange.dydx.abacus.functional.vault.AccountVaultResponse
 import exchange.dydx.abacus.functional.vault.ThirtyDayPnl
 import exchange.dydx.abacus.functional.vault.VaultDetails
 import exchange.dydx.abacus.output.Asset
@@ -50,6 +49,7 @@ import indexer.codegen.IndexerHistoricalTradingRewardAggregation
 import indexer.codegen.IndexerPerpetualPositionStatus
 import indexer.codegen.IndexerPositionSide
 import indexer.codegen.IndexerTransferBetweenResponse
+import indexer.models.chain.OnChainAccountVaultResponse
 import kotlinx.datetime.Instant
 
 internal data class InternalState(
@@ -243,7 +243,7 @@ internal data class InternalVaultState(
     val positions: List<InternalVaultPositionState>? = null,
     val pnls: MutableMap<String, ThirtyDayPnl> = mutableMapOf(),
     val transfers: IndexerTransferBetweenResponse? = null,
-    val account: AccountVaultResponse? = null,
+    val account: OnChainAccountVaultResponse? = null,
 )
 
 internal data class InternalVaultPositionState(

--- a/src/commonMain/kotlin/indexer/models/chain/OnChainAccountVaultResponse.kt
+++ b/src/commonMain/kotlin/indexer/models/chain/OnChainAccountVaultResponse.kt
@@ -1,0 +1,27 @@
+package indexer.models.chain
+
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+
+@JsExport
+@Serializable
+data class OnChainShareUnlock(
+    val shares: OnChainNumShares?,
+    val unlockBlockHeight: Double?,
+)
+
+@JsExport
+@Serializable
+data class OnChainNumShares(
+    val numShares: Double?,
+)
+
+@JsExport
+@Serializable
+data class OnChainAccountVaultResponse(
+    val address: String? = null,
+    val shares: OnChainNumShares? = null,
+    val shareUnlocks: Array<OnChainShareUnlock>? = null,
+    val equity: Double? = null,
+    val withdrawableEquity: Double? = null,
+)

--- a/src/commonMain/kotlin/indexer/models/chain/OnChainVaultDepositWithdrawSlippageResponse.kt
+++ b/src/commonMain/kotlin/indexer/models/chain/OnChainVaultDepositWithdrawSlippageResponse.kt
@@ -1,0 +1,11 @@
+package indexer.models.chain
+
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+
+@JsExport
+@Serializable
+data class OnChainVaultDepositWithdrawSlippageResponse(
+    val sharesToWithdraw: OnChainNumShares,
+    val expectedQuoteQuantums: Double,
+)

--- a/src/commonTest/kotlin/exchange.dydx.abacus/functional/vault/VaultAccountTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/functional/vault/VaultAccountTests.kt
@@ -4,6 +4,9 @@ import exchange.dydx.abacus.functional.vault.VaultAccountCalculator.calculateUse
 import indexer.codegen.IndexerTransferBetweenResponse
 import indexer.codegen.IndexerTransferResponseObject
 import indexer.codegen.IndexerTransferType
+import indexer.models.chain.OnChainAccountVaultResponse
+import indexer.models.chain.OnChainNumShares
+import indexer.models.chain.OnChainShareUnlock
 import kollections.iListOf
 import kotlinx.datetime.Instant
 import kotlin.test.Test
@@ -14,10 +17,10 @@ class VaultAccountTests {
 
     @Test
     fun calculateUserVaultInfo_basic() {
-        val vaultInfo = AccountVaultResponse(
+        val vaultInfo = OnChainAccountVaultResponse(
             address = "0x123",
-            shares = NumShares(numShares = 100.0),
-            shareUnlocks = arrayOf(ShareUnlock(unlockBlockHeight = 0.0, shares = NumShares(numShares = 50.0))),
+            shares = OnChainNumShares(numShares = 100.0),
+            shareUnlocks = arrayOf(OnChainShareUnlock(unlockBlockHeight = 0.0, shares = OnChainNumShares(numShares = 50.0))),
             equity = 10000.0 * 1_000_000,
             withdrawableEquity = 5000.0 * 1_000_000,
         )

--- a/src/commonTest/kotlin/exchange.dydx.abacus/functional/vault/VaultFormTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/functional/vault/VaultFormTests.kt
@@ -1,6 +1,8 @@
 package exchange.dydx.abacus.functional.vault
 
 import exchange.dydx.abacus.output.input.ValidationError
+import indexer.models.chain.OnChainNumShares
+import indexer.models.chain.OnChainVaultDepositWithdrawSlippageResponse
 import kollections.iListOf
 import kollections.toIList
 import kotlin.test.Test
@@ -85,8 +87,8 @@ class VaultFormTests {
                 withdrawableUsdc = 500.0,
                 balanceShares = 500.0,
             ),
-            slippageResponse = VaultDepositWithdrawSlippageResponse(
-                sharesToWithdraw = NumShares(numShares = 100.0),
+            slippageResponse = OnChainVaultDepositWithdrawSlippageResponse(
+                sharesToWithdraw = OnChainNumShares(numShares = 100.0),
                 expectedQuoteQuantums = 98.0 * 1_000_000,
             ),
         )
@@ -137,8 +139,8 @@ class VaultFormTests {
                 withdrawableUsdc = 500.0,
                 balanceShares = 500.0,
             ),
-            slippageResponse = VaultDepositWithdrawSlippageResponse(
-                sharesToWithdraw = NumShares(numShares = 120.0),
+            slippageResponse = OnChainVaultDepositWithdrawSlippageResponse(
+                sharesToWithdraw = OnChainNumShares(numShares = 120.0),
                 expectedQuoteQuantums = 98.0 * 1_000_000,
             ),
         )
@@ -182,8 +184,8 @@ class VaultFormTests {
                 withdrawableUsdc = 500.0,
                 balanceShares = 500.0,
             ),
-            slippageResponse = VaultDepositWithdrawSlippageResponse(
-                sharesToWithdraw = NumShares(numShares = 600.0),
+            slippageResponse = OnChainVaultDepositWithdrawSlippageResponse(
+                sharesToWithdraw = OnChainNumShares(numShares = 600.0),
                 expectedQuoteQuantums = 500.0 * 1_000_000,
             ),
         )

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.12.3'
+    spec.version                  = '1.12.4'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Currently all the validator response data models are stored at package indexer.models.chain, so it's better to move the new ones there to be consistent....