### PR TITLE
fix: fix trade form not showing deposit button when no equity

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/AccountInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/AccountInputValidator.kt
@@ -141,7 +141,7 @@ internal class AccountInputValidator(
         wallet: InternalWalletState,
         subaccountNumber: Int?,
     ): ValidationError? {
-        val isChildSubaccountForIsolatedMargin = subaccountNumber == null || subaccountNumber >= NUM_PARENT_SUBACCOUNTS
+        val isChildSubaccountForIsolatedMargin = subaccountNumber != null && subaccountNumber >= NUM_PARENT_SUBACCOUNTS
         val subaccount = wallet.account.subaccounts[subaccountNumber]
         val equity = subaccount?.calculated?.get(CalculationPeriod.current)?.equity
 
@@ -171,7 +171,7 @@ internal class AccountInputValidator(
     ): Map<String, Any>? {
         val equity = parser.asDouble(parser.value(subaccount, "equity.current"))
         val subaccountNumber = parser.asInt(subaccount?.get("subaccountNumber"))
-        val isChildSubaccountForIsolatedMargin = subaccountNumber == null || subaccountNumber >= NUM_PARENT_SUBACCOUNTS
+        val isChildSubaccountForIsolatedMargin = subaccountNumber != null && subaccountNumber >= NUM_PARENT_SUBACCOUNTS
 
         return if (equity != null && equity > 0) {
             null


### PR DESCRIPTION
we weren't getting the deposit button on web with 0 equity - traced it back to an incorrect check for child subaccount (i.e. correct way is [here](https://github.com/dydxprotocol/v4-abacus/blob/main/src/commonMain/kotlin/exchange.dydx.abacus/validator/InputValidator.kt#L108))

verified by building locally

<img width="375" alt="Screenshot 2024-09-27 at 5 02 58 PM" src="https://github.com/user-attachments/assets/8f744031-df68-4c23-a72a-9d3e9a8c259f">
