### PR TITLE
fix: revert default validator url logic

### DIFF
--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/ConnectionsSupervisor.kt
@@ -102,7 +102,6 @@ internal class ConnectionsSupervisor(
             indexerConfig = null
             validatorConnected = false
             socketConnected = false
-            validatorUrl = null
             disconnectSocket()
         }
     }
@@ -175,14 +174,8 @@ internal class ConnectionsSupervisor(
     }
 
     private fun bestEffortConnectChain() {
-        if (validatorUrl == null) {
-            val endpointUrls = helper.configs.validatorUrls()
-            validatorUrl = endpointUrls?.firstOrNull()
-        }
         findOptimalNode { url ->
-            if (url != this.validatorUrl) {
-                this.validatorUrl = url
-            }
+            this.validatorUrl = url
         }
     }
 
@@ -391,7 +384,6 @@ internal class ConnectionsSupervisor(
             val timer = helper.ioImplementations.timer ?: CoroutineTimer.instance
             chainTimer = timer.schedule(serverPollingDuration, null) {
                 if (readyToConnect) {
-                    validatorUrl = null
                     bestEffortConnectChain()
                 }
                 false


### PR DESCRIPTION
revert core logic of https://github.com/dydxprotocol/v4-abacus/pull/661 
PR 661 optimistically assigned a node and then attempted to connect to the optimalnode in the background. This was intended to reduce latency to find an optimal validator.

However, defaulting to the first node occasionally results in a connection failure. v4-web doesn't have the ability to properly reconnect once a connection attempt has failed which has cause a significant degradation in user experience in a significant number of cases