### PR TITLE
fix: remove self trade validation for sltp orders

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.12.12"
+version = "1.12.13"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/output/input/TradeInput.kt
@@ -767,6 +767,14 @@ enum class OrderType(val rawValue: String) {
         operator fun invoke(rawValue: String?) =
             entries.firstOrNull { it.rawValue == rawValue }
     }
+
+    val isSlTp: Boolean
+        get() = listOf(
+            StopMarket,
+            TakeProfitMarket,
+            StopLimit,
+            TakeProfitLimit,
+        ).contains(this)
 }
 
 @JsExport

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeAccountStateValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeAccountStateValidator.kt
@@ -290,6 +290,9 @@ internal class TradeAccountStateValidator(
             return false
         }
         val type = trade.type ?: return false
+        // does not apply to trigger/stop trades
+        if (type.isSlTp) return false
+
         val price = if (type == OrderType.Market) {
             trade.marketOrder?.worstPrice
         } else {
@@ -347,6 +350,7 @@ internal class TradeAccountStateValidator(
     ): Boolean {
         if (orders != null) {
             val type = parser.asString(trade["type"]) ?: return false
+            if (listOf("STOP_MARKET", "TAKE_PROFIT_MARKET", "STOP_LIMIT", "TAKE_PROFIT").contains(type)) return false
             val price = parser.asDouble(
                 parser.value(
                     trade,

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.12.12'
+    spec.version                  = '1.12.13'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
overly strict FE validation for self-trade is preventing users from placing stop orders
we already have protocol code in place for preventing self-trade (canceling maker orders); therefore we can relax this validation and just let the sl/tp orders be placed, since most likely the open limit orders will be filled before the sltp orders are triggered

testing:
before:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/858422c6-165b-4492-be99-2d04e4346ccf">
after:
<img width="1798" alt="image" src="https://github.com/user-attachments/assets/b754e735-38db-4fd5-aab8-623b86a77a56">

also tested that this validation still exists for other order types (limit)