### PR TITLE
Wait for the position values before calculating subaccount

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.12.21"
+version = "1.12.22"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/calculator/SubaccountCalculator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/calculator/SubaccountCalculator.kt
@@ -245,7 +245,20 @@ internal class SubaccountCalculator(val parser: ParserProtocol) {
     ) {
         for (period in periods) {
             val quoteBalance = parser.asDouble(value(subaccount, "quoteBalance", period))
-            if (quoteBalance != null) {
+
+            var hasPositionCalculated = false
+            positions?.let {
+                for ((key, position) in positions) {
+                    val valueTotal = parser.asDouble(value(position, "valueTotal", period))
+                    if (valueTotal != null) {
+                        hasPositionCalculated = true
+                        break
+                    }
+                }
+            }
+            val positionsReady = positions.isNullOrEmpty() || hasPositionCalculated
+
+            if (quoteBalance != null && positionsReady) {
                 var notionalTotal = Numeric.double.ZERO
                 var valueTotal = Numeric.double.ZERO
                 var initialRiskTotal = Numeric.double.ZERO
@@ -464,12 +477,9 @@ internal class SubaccountCalculator(val parser: ParserProtocol) {
     ) {
         for (period in periods) {
             val quoteBalance = parser.asDouble(value(subaccount, "quoteBalance", period))
-            if (quoteBalance != null) {
-                val equity =
-                    parser.asDouble(value(subaccount, "equity", period)) ?: Numeric.double.ZERO
-                val initialRiskTotal =
-                    parser.asDouble(value(subaccount, "initialRiskTotal", period))
-                        ?: Numeric.double.ZERO
+            val equity = parser.asDouble(value(subaccount, "equity", period))
+            val initialRiskTotal = parser.asDouble(value(subaccount, "initialRiskTotal", period))
+            if (quoteBalance != null && equity != null && initialRiskTotal != null) {
                 val imf =
                     parser.asDouble(configs?.get("initialMarginFraction"))
                         ?: parser.asDouble(0.05)!!

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.12.21'
+    spec.version                  = '1.12.22'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Position calculation needs oracle price for the market.  During initial app loads, the oracle prices might come after the subaccount data.  In this case, we will want to delay the subaccount calculation until the oracle prices arrive.  Otherwise, the app would display incorrect portfolio values.

Tested it on Android.

Before:
[old1.webm](https://github.com/user-attachments/assets/4f049c80-c2c6-4d73-805a-ca25784f1358)


After:
[newl1.webm](https://github.com/user-attachments/assets/bf7116d1-a4a4-4a38-a96a-ca52ac082ba5)

