### PR TITLE
feat: toggle autosweep [OTE-866]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.12.29"
+version = "1.12.30"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Environment.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Environment.kt
@@ -553,6 +553,7 @@ data object StatsigConfig {
 }
 
 @JsExport
+@Suppress("PropertyName")
 data object AutoSweepConfig {
     var disable_autosweep: Boolean = false
 }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Environment.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/manager/Environment.kt
@@ -553,6 +553,11 @@ data object StatsigConfig {
 }
 
 @JsExport
+data object AutoSweepConfig {
+    var disable_autosweep: Boolean = false
+}
+
+@JsExport
 class AppSettings(
     val ios: AppSetting?,
     val android: AppSetting?,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -19,6 +19,7 @@ import exchange.dydx.abacus.state.app.adaptors.V4TransactionErrors
 import exchange.dydx.abacus.state.changes.Changes
 import exchange.dydx.abacus.state.changes.StateChanges
 import exchange.dydx.abacus.state.manager.ApiData
+import exchange.dydx.abacus.state.manager.AutoSweepConfig
 import exchange.dydx.abacus.state.manager.BlockAndTime
 import exchange.dydx.abacus.state.manager.HistoricalTradingRewardsPeriod
 import exchange.dydx.abacus.state.manager.HumanReadableCancelAllOrdersPayload
@@ -466,6 +467,9 @@ internal open class AccountSupervisor(
     private fun retrieveNobleBalance() {
         if (walletConnectionType == WalletConnectionType.Cosmos) {
             nobleBalancesTimer = null
+            return
+        }
+        if (AutoSweepConfig.disable_autosweep) {
             return
         }
         val timer = helper.ioImplementations.timer ?: CoroutineTimer.instance

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.12.29'
+    spec.version                  = '1.12.30'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Ability to toggle autosweep so FE can temporarily disable it while performing multi tx withdrawals. This way the frontend wont be dependent on abacus' polling logic