### PR TITLE
fix: parse out of gas error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.13.2"
+version = "1.13.3"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/app/adaptors/V4TransactionErrors.kt
@@ -6,6 +6,7 @@ import exchange.dydx.abacus.responses.ParsingErrorType
 class V4TransactionErrors {
     companion object {
         private const val QUERY_RESULT_ERROR_PREFIX = "Query failed"
+        private const val OUT_OF_GAS_ERROR_RAW_LOG_PREFIX = "out of gas"
         private val FAILED_SUBACCOUNT_UPDATE_RESULT_PATTERN = Regex("""Subaccount with id \{[^}]+\} failed with UpdateResult:\s*([A-Za-z]+):""")
 
         fun error(code: Int?, message: String?, codespace: String? = null): ParsingError? {
@@ -41,6 +42,17 @@ class V4TransactionErrors {
                     "Subaccount update error: $it",
                     if (matchedUpdateResult != null) "ERRORS.QUERY_ERROR_SUBACCOUNTS_${matchedUpdateResult.toString().uppercase()}" else null,
                 )
+            }
+        }
+
+        fun parseErrorFromRawLog(rawLog: String): ParsingError? {
+            return if (rawLog.startsWith(OUT_OF_GAS_ERROR_RAW_LOG_PREFIX)) {
+                return ParsingError(
+                    ParsingErrorType.BackendError,
+                    "Out of gas: inaccurate gas estimation for transaction",
+                )
+            } else {
+                null
             }
         }
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/NetworkHelper.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/NetworkHelper.kt
@@ -533,11 +533,15 @@ class NetworkHelper(
             val result = parser.decodeJsonObject(response)
             if (result != null) {
                 val error = parser.asMap(result["error"])
+                val rawLog = parser.asString(result["rawLog"])
                 if (error != null) {
                     val message = parser.asString(error["message"])
                     val code = parser.asInt(error["code"])
                     val codespace = parser.asString(error["codespace"])
                     return V4TransactionErrors.error(code, message, codespace)
+                } else if (rawLog != null) {
+                    // certain tx results (e.g. out of gas) are not error but should still be treated as one
+                    return V4TransactionErrors.parseErrorFromRawLog(rawLog)
                 } else {
                     null
                 }

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.13.2'
+    spec.version                  = '1.13.3'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
when a tx failed because of the 'out of gas' result, it isn't treated as an error when it should
'out of gas' happens when our gas estimation is somehow off -- cosmos gas estimation is known to be inaccurate, and we had to bump gas multiplier to account for it. hopefully this should be rare, but at least this will stop the place order to go through when transfer fails during isolated market order

<img width="338" alt="image" src="https://github.com/user-attachments/assets/283b8169-0e10-4ee3-86e5-a997b202d336">
