### PR TITLE
Set route gasPrice and gasLimit to null

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.13.6"
+version = "1.13.7"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRoutePayloadProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRoutePayloadProcessor.kt
@@ -2,8 +2,6 @@ package exchange.dydx.abacus.processor.router.skip
 
 import exchange.dydx.abacus.processor.base.BaseProcessor
 import exchange.dydx.abacus.protocols.ParserProtocol
-import exchange.dydx.abacus.utils.DEFAULT_GAS_LIMIT
-import exchange.dydx.abacus.utils.DEFAULT_GAS_PRICE
 import exchange.dydx.abacus.utils.JsonEncoder
 import exchange.dydx.abacus.utils.safeSet
 import exchange.dydx.abacus.utils.toCamelCaseKeys
@@ -89,10 +87,7 @@ internal class SkipRoutePayloadProcessor(parser: ParserProtocol) : BaseProcessor
     ): Map<String, Any> {
         val txType = getTxType(payload)
         val modified = transform(existing, payload, keyMap)
-        // squid used to provide these, but now we need to hardcode them
-        // for the API to work (even though they seem to have default values?): https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sendtransaction
-        modified.safeSet("gasPrice", DEFAULT_GAS_PRICE)
-        modified.safeSet("gasLimit", DEFAULT_GAS_LIMIT)
+
         val data = modified["data"]
         if (data != null && txType == TxType.EVM) {
             modified.safeSet("data", "0x$data")
@@ -110,10 +105,6 @@ internal class SkipRoutePayloadProcessor(parser: ParserProtocol) : BaseProcessor
             if (modified["solanaTransaction"] != null) {
                 modified.safeSet("data", modified["solanaTransaction"])
                 modified.remove("solanaTransaction")
-
-                // These are EVM specific fields and do not make sense for solana
-                modified.remove("gasPrice")
-                modified.remove("gasLimit")
             }
         }
         return modified

--- a/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/utils/Constants.kt
@@ -32,9 +32,5 @@ internal const val GEO_POLLING_DURATION_SECONDS = 600.0
 // Autosweep Constants
 internal const val MIN_USDC_AMOUNT_FOR_AUTO_SWEEP = 50000
 
-// Gas Constants based on historical Squid responses
-internal const val DEFAULT_GAS_LIMIT = 1500000
-internal const val DEFAULT_GAS_PRICE = 1520000000
-
 // Limit Close GTT duration in Days
 internal const val LIMIT_CLOSE_ORDER_DEFAULT_DURATION_DAYS = 28.0

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipProcessorTests.kt
@@ -10,8 +10,6 @@ import exchange.dydx.abacus.tests.payloads.SkipChainsMock
 import exchange.dydx.abacus.tests.payloads.SkipRouteMock
 import exchange.dydx.abacus.tests.payloads.SkipTokensMock
 import exchange.dydx.abacus.tests.payloads.SkipVenuesMock
-import exchange.dydx.abacus.utils.DEFAULT_GAS_LIMIT
-import exchange.dydx.abacus.utils.DEFAULT_GAS_PRICE
 import exchange.dydx.abacus.utils.Parser
 import exchange.dydx.abacus.utils.toJsonObject
 import kotlinx.serialization.json.Json
@@ -372,8 +370,6 @@ class SkipProcessorTests {
                         "fromAddress" to "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                         "toChainId" to "noble-1",
                         "toAddress" to "uusdc",
-                        "gasPrice" to DEFAULT_GAS_PRICE,
-                        "gasLimit" to DEFAULT_GAS_LIMIT,
                     ),
                 ),
             ),

--- a/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/processor/router/skip/SkipRouteProcessorTests.kt
@@ -2,8 +2,6 @@ package exchange.dydx.abacus.processor.router.skip
 
 import exchange.dydx.abacus.state.manager.StatsigConfig
 import exchange.dydx.abacus.tests.payloads.SkipRouteMock
-import exchange.dydx.abacus.utils.DEFAULT_GAS_LIMIT
-import exchange.dydx.abacus.utils.DEFAULT_GAS_PRICE
 import exchange.dydx.abacus.utils.JsonEncoder
 import exchange.dydx.abacus.utils.Parser
 import exchange.dydx.abacus.utils.toJsonArray
@@ -37,8 +35,6 @@ class SkipRouteProcessorTests {
                 "fromAddress" to "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                 "toChainId" to "noble-1",
                 "toAddress" to "uusdc",
-                "gasPrice" to DEFAULT_GAS_PRICE,
-                "gasLimit" to DEFAULT_GAS_LIMIT,
             ),
         )
         assertEquals(expected, result)
@@ -112,8 +108,6 @@ class SkipRouteProcessorTests {
                 "toAddress" to "uusdc",
                 "data" to jsonEncoder.encode(expectedDataRaw),
                 "allMessages" to jsonEncoder.encode(listOf(expectedDataRaw)),
-                "gasPrice" to DEFAULT_GAS_PRICE,
-                "gasLimit" to DEFAULT_GAS_LIMIT,
             ),
         )
         assertEquals(expected, result)
@@ -167,8 +161,6 @@ class SkipRouteProcessorTests {
                 "toAddress" to "ethereum-native",
                 "data" to jsonEncoder.encode(expectedDataRaw),
                 "allMessages" to jsonEncoder.encode(listOf(expectedDataRaw)),
-                "gasPrice" to DEFAULT_GAS_PRICE,
-                "gasLimit" to DEFAULT_GAS_LIMIT,
             ),
         )
 
@@ -246,8 +238,6 @@ class SkipRouteProcessorTests {
                 "toAddress" to "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
                 "data" to expectedData,
                 "allMessages" to expectedMessagesArray,
-                "gasPrice" to DEFAULT_GAS_PRICE,
-                "gasLimit" to DEFAULT_GAS_LIMIT,
             ),
         )
         assertEquals(expected, result)
@@ -293,8 +283,6 @@ class SkipRouteProcessorTests {
                 "toAddress" to "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
                 "data" to jsonEncoder.encode(expectedDataRaw),
                 "allMessages" to jsonEncoder.encode(listOf(expectedDataRaw)),
-                "gasPrice" to DEFAULT_GAS_PRICE,
-                "gasLimit" to DEFAULT_GAS_LIMIT,
             ),
         )
         assertEquals(expected, result)

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.13.6'
+    spec.version                  = '1.13.7'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
We used to get gas values for the transfer route with Squid and pass them along to the wallet.  But with Skip we no longer get them.   It's better to set them to null for the wallet to figure out the values.