### PR TITLE
fix: Ignore orders that reduce position in equity check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.13.34"
+version = "1.13.35"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
@@ -14,7 +14,6 @@ import exchange.dydx.abacus.state.internalstate.InternalState
 import exchange.dydx.abacus.state.internalstate.InternalSubaccountState
 import exchange.dydx.abacus.state.internalstate.InternalTradeInputState
 import exchange.dydx.abacus.state.manager.V4Environment
-import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.Numeric
 import exchange.dydx.abacus.validator.BaseInputValidator
 import exchange.dydx.abacus.validator.PositionChange

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeOrderInputValidator.kt
@@ -14,6 +14,7 @@ import exchange.dydx.abacus.state.internalstate.InternalState
 import exchange.dydx.abacus.state.internalstate.InternalSubaccountState
 import exchange.dydx.abacus.state.internalstate.InternalTradeInputState
 import exchange.dydx.abacus.state.manager.V4Environment
+import exchange.dydx.abacus.utils.Logger
 import exchange.dydx.abacus.utils.Numeric
 import exchange.dydx.abacus.validator.BaseInputValidator
 import exchange.dydx.abacus.validator.PositionChange
@@ -159,8 +160,9 @@ internal class TradeOrderInputValidator(
                 val currentFreeCollateral = subaccount.calculated.get(CalculationPeriod.current)?.freeCollateral ?: return null
                 val postFreeCollateral = subaccount.calculated.get(CalculationPeriod.post)?.freeCollateral ?: return null
                 val orderEquity = currentFreeCollateral - postFreeCollateral
+                val isReducingPosition = orderEquity < Numeric.double.ZERO
 
-                if (postFreeCollateral >= Numeric.double.ZERO && orderEquity < isolatedLimitOrderMinimumEquity) {
+                if (postFreeCollateral >= Numeric.double.ZERO && !isReducingPosition && orderEquity < isolatedLimitOrderMinimumEquity) {
                     return createTradeBoxWarningOrError(
                         errorLevel = ErrorType.error,
                         errorCode = "ISOLATED_MARGIN_LIMIT_ORDER_BELOW_MINIMUM",

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.13.34'
+    spec.version                  = '1.13.35'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
This error would be triggered whenever postOrderFreeCollateral is larger than your current free collateral.

When you are reducing your position the orderEquity will be negative.