### PR TITLE
Fix incorrect order of candle sticks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.13.39"
+version = "1.13.40"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/CandlesProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/CandlesProcessor.kt
@@ -48,8 +48,10 @@ internal class CandlesProcessor(
         payload: List<IndexerCandleResponseObject>?
     ): InternalMarketState {
         if (!payload.isNullOrEmpty()) {
-            val candles = payload.reversed().mapNotNull {
+            val candles = payload.mapNotNull {
                 itemProcessor.process(it)
+            }.sortedBy {
+                it.startedAtMilliseconds
             }
             val merged = merge(
                 parser = parser,

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.13.39'
+    spec.version                  = '1.13.40'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
The batch candle update payload is already in ascending order (unlike the the initial candle payload which is in descending order), so we shouldn't do reverse() for updates.  The batch update only contains 1 or 2 items, so adding a sort() just to be safe here.