### PR TITLE
BUG2-213 Use displayable asset ID for token name in validation messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.13.43"
+version = "1.13.44"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeInputDataValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeInputDataValidator.kt
@@ -1,6 +1,7 @@
 package exchange.dydx.abacus.validator.trade
 
 import abs
+import exchange.dydx.abacus.output.Asset
 import exchange.dydx.abacus.output.input.ErrorType
 import exchange.dydx.abacus.output.input.InputType
 import exchange.dydx.abacus.output.input.OrderSide
@@ -60,6 +61,7 @@ internal class TradeInputDataValidator(
         validateSize(
             trade = internalState.input.trade,
             market = market,
+            assets = internalState.assets,
         )?.let {
             errors.addAll(it)
         }
@@ -128,11 +130,13 @@ internal class TradeInputDataValidator(
     private fun validateSize(
         trade: InternalTradeInputState,
         market: InternalMarketState?,
+        assets: Map<String, Asset>?
     ): List<ValidationError>? {
         /*
          ORDER_SIZE_BELOW_MIN_SIZE
          */
-        val symbol = market?.perpetualMarket?.assetId ?: return null
+        val assetId = market?.perpetualMarket?.assetId ?: return null
+        val symbol = assets?.get(assetId)?.displayableAssetId ?: return null
         val size = trade.size?.size ?: return null
         val minOrderSize = market.perpetualMarket?.configs?.minOrderSize ?: return null
         return if (size.abs() < minOrderSize) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradePositionStateValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradePositionStateValidator.kt
@@ -1,6 +1,7 @@
 package exchange.dydx.abacus.validator.trade
 
 import exchange.dydx.abacus.calculator.CalculationPeriod
+import exchange.dydx.abacus.output.Asset
 import exchange.dydx.abacus.output.input.ErrorType
 import exchange.dydx.abacus.output.input.InputType
 import exchange.dydx.abacus.output.input.ValidationError
@@ -42,6 +43,7 @@ internal class TradePositionStateValidator(
         validatePositionSize(
             position = position,
             market = internalState.marketsSummary.markets[trade.marketId],
+            assets = internalState.assets,
         )?.let {
             errors.add(it)
         }
@@ -99,6 +101,7 @@ internal class TradePositionStateValidator(
     private fun validatePositionSize(
         position: InternalPerpetualPosition?,
         market: InternalMarketState?,
+        assets: Map<String, Asset>?,
     ): ValidationError? {
         /*
         NEW_POSITION_SIZE_OVER_MAX
@@ -108,7 +111,8 @@ internal class TradePositionStateValidator(
         if (maxSize == Numeric.double.ZERO) {
             return null
         }
-        val symbol = market?.perpetualMarket?.assetId ?: return null
+        val assetId = market?.perpetualMarket?.assetId ?: return null
+        val symbol = assets?.get(assetId)?.displayableAssetId ?: return null
         return if (size > maxSize) {
             error(
                 type = ErrorType.error,

--- a/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeResctrictedValidator.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/validator/trade/TradeResctrictedValidator.kt
@@ -1,5 +1,6 @@
 package exchange.dydx.abacus.validator.trade
 
+import exchange.dydx.abacus.output.Asset
 import exchange.dydx.abacus.output.input.ErrorType
 import exchange.dydx.abacus.output.input.InputType
 import exchange.dydx.abacus.output.input.ValidationError
@@ -35,6 +36,7 @@ internal class TradeResctrictedValidator(
         val closeOnlyError =
             validateClosingOnly(
                 market = market,
+                assets = internalState.assets,
                 change = change,
                 restricted = restricted,
             )
@@ -64,10 +66,12 @@ internal class TradeResctrictedValidator(
 
     private fun validateClosingOnly(
         market: InternalMarketState?,
+        assets: Map<String, Asset>?,
         change: PositionChange,
         restricted: Boolean,
     ): ValidationError? {
-        val marketId = market?.perpetualMarket?.assetId ?: ""
+        val assetId = market?.perpetualMarket?.assetId ?: return null
+        val marketId = assets?.get(assetId)?.displayableAssetId ?: return null
         val canTrade = market?.perpetualMarket?.status?.canTrade ?: true
         val canReduce = market?.perpetualMarket?.status?.canReduce ?: true
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.13.43'
+    spec.version                  = '1.13.44'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Fix https://linear.app/dydx/issue/BUG2-213/long-name-for-asset-used-in-errors