### PR TITLE
Fix a bug in Android startup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.13.61"
+version = "1.13.62"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketsSummaryProcessor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/processor/markets/MarketsSummaryProcessor.kt
@@ -350,10 +350,10 @@ internal class MarketsSummaryProcessor(
         payload: Map<String, Any>
     ): Map<String, Any>? {
         val markets = marketsProcessor.receivedCandlesChanges(
-            parser.asNativeMap(existing?.get("markets")),
-            market,
-            resolution,
-            payload,
+            existing = parser.asNativeMap(existing?.get("markets")),
+            market = market,
+            resolution = resolution,
+            payload = payload,
         )
         return modify(existing, markets)
     }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/manager/AsyncAbacusStateManagerV2.kt
@@ -91,12 +91,16 @@ class AsyncAbacusStateManagerV2(
             Logger.isDebugEnabled = true
         }
         if (appConfigs.autoStart) {
+            initAfterStart()
             started = true
         }
     }
 
     override fun start() {
-        started = true
+        if (!started) {
+            initAfterStart()
+            started = true
+        }
     }
 
     override val state: PerpetualState?
@@ -286,7 +290,7 @@ class AsyncAbacusStateManagerV2(
         }
     }
 
-    init {
+    private fun initAfterStart() {
         if (ioImplementations.rest === null) {
             throw Error("IOImplementations.rest is not set")
         }

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/MarketSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/MarketSupervisor.kt
@@ -238,9 +238,9 @@ internal open class MarketSupervisor(
         val channel =
             helper.configs.marketTradesChannel() ?: throw Exception("trades channel is null")
         helper.socket(
-            helper.socketAction(subscribe),
-            channel,
-            if (subscribe && shouldBatchMarketTradesChannelData()) {
+            type = helper.socketAction(subscribe),
+            channel = channel,
+            params = if (subscribe && shouldBatchMarketTradesChannelData()) {
                 iMapOf("id" to marketId, "batched" to "true")
             } else {
                 iMapOf("id" to marketId)
@@ -256,9 +256,9 @@ internal open class MarketSupervisor(
     fun candlesChannelSubscription(resolution: String, subscribe: Boolean = true) {
         val channel = helper.configs.candlesChannel() ?: throw Exception("candlesChannel is null")
         helper.socket(
-            helper.socketAction(subscribe),
-            channel,
-            if (subscribe) {
+            type = helper.socketAction(subscribe),
+            channel = channel,
+            params = if (subscribe) {
                 iMapOf("id" to "$marketId/$resolution", "batched" to "true")
             } else {
                 iMapOf("id" to "$marketId/$resolution")

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/MarketsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/MarketsSupervisor.kt
@@ -118,9 +118,9 @@ internal class MarketsSupervisor(
         val channel =
             helper.configs.marketsChannel() ?: throw Exception("markets channel is null")
         helper.socket(
-            helper.socketAction(subscribe),
-            channel,
-            if (subscribe && shouldBatchMarketsChannelData()) {
+            type = helper.socketAction(subscribe),
+            channel = channel,
+            params = if (subscribe && shouldBatchMarketsChannelData()) {
                 iMapOf("batched" to "true")
             } else {
                 null

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/SubaccountSupervisor.kt
@@ -297,9 +297,9 @@ internal class SubaccountSupervisor(
         val channel = helper.configs.subaccountChannel(parent)
             ?: throw Exception("subaccount channel is null")
         helper.socket(
-            helper.socketAction(subscribe),
-            channel,
-            subaccountChannelParams(accountAddress, subaccountNumber, subscribe),
+            type = helper.socketAction(subscribe),
+            channel = channel,
+            params = subaccountChannelParams(accountAddress, subaccountNumber, subscribe),
         )
     }
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.13.61'
+    spec.version                  = '1.13.62'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
Android needs to delay the initialization sequence until after its webview is loaded.  I added this logic from a previous PR, but missed that there is another "init" block in the AsyncAbacusStateManagerV2 class (apparently Kotlin is okay with multiple init blocks in a class).  This causes sporadic trade failure on Android due to the race condition. 