### PR TITLE
Fix compliance screen bug

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.13.63"
+version = "1.13.64"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/v2/supervisor/AccountSupervisor.kt
@@ -304,6 +304,7 @@ internal open class AccountSupervisor(
             }
 
             sendPushNotificationToken()
+            doComplianceScreening()
         } else {
             subaccountsTimer = null
             screenAccountAddressTimer = null
@@ -831,7 +832,7 @@ internal open class AccountSupervisor(
         return helper.configs.publicApiUrl("complianceGeoblockKeplr")
     }
 
-    open fun screenSourceAddress() {
+    private fun screenSourceAddress() {
         val address = sourceAddress
         if (address != null) {
             screen(address) { restriction ->
@@ -959,9 +960,17 @@ internal open class AccountSupervisor(
     private fun didSetSourceAddress(sourceAddress: String?, oldValue: String?) {
         screenSourceAddressTimer = null
         sourceAddressRestriction = null
-        if (sourceAddress != null) {
+        doComplianceScreening()
+    }
+
+    private var complianceScreeningAddress: String? = null
+
+    private fun doComplianceScreening() {
+        val sourceAddress = sourceAddress
+        if (sourceAddress != null && indexerConnected && complianceScreeningAddress != sourceAddress) {
             screenSourceAddress()
             complianceScreen(EvmAddress(sourceAddress))
+            complianceScreeningAddress = sourceAddress
         }
     }
 

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.13.63'
+    spec.version                  = '1.13.64'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
The compliance screening call needs the indexer config URL to work.  So we need to wait for indexerConnected AND sourceAddress to be available.   Also added complianceScreeningAddress so that we don't call make duplicate calls.