### PR TITLE
Add flag to update user compliance status with new wallet connection only

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ allprojects {
 }
 
 group = "exchange.dydx.abacus"
-version = "1.14.4"
+version = "1.14.5"
 
 repositories {
     google()

--- a/src/commonMain/kotlin/exchange.dydx.abacus/AsyncAbacusStateManagerProtocol.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/AsyncAbacusStateManagerProtocol.kt
@@ -1,6 +1,5 @@
 package exchange.dydx.abacus
 
-import exchange.dydx.abacus.output.ComplianceAction
 import exchange.dydx.abacus.output.Documentation
 import exchange.dydx.abacus.output.PerpetualState
 import exchange.dydx.abacus.output.Restriction
@@ -115,9 +114,6 @@ interface AsyncAbacusStateManagerProtocol {
 
     // Screen for restrictions
     fun screen(address: String, callback: (restriction: Restriction) -> Unit)
-
-    // Trigger update for compliance
-    fun triggerCompliance(action: ComplianceAction, callback: TransactionCallback)
 
     // Get chain data from id. Necessary to know chain name based on chain id
     fun getChainById(chainId: String): TransferChainInfo?

--- a/src/commonMain/kotlin/exchange.dydx.abacus/AsyncAbacusStateManagerProtocol.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/AsyncAbacusStateManagerProtocol.kt
@@ -120,12 +120,14 @@ interface AsyncAbacusStateManagerProtocol {
 
     fun registerPushNotification(token: String, languageCode: String?)
     fun refreshVaultAccount()
+
+    fun setAddresses(source: String?, account: String?, isNew: Boolean)
 }
 
 @JsExport
 interface AsyncAbacusStateManagerSingletonProtocol {
-    var accountAddress: String?
-    var sourceAddress: String?
+    val accountAddress: String?
+    val sourceAddress: String?
     var subaccountNumber: Int
     var market: String?
     var walletConnectionType: WalletConnectionType?
@@ -135,12 +137,3 @@ interface AsyncAbacusStateManagerSingletonProtocol {
 interface SingletonAsyncAbacusStateManagerProtocol :
     AsyncAbacusStateManagerProtocol,
     AsyncAbacusStateManagerSingletonProtocol
-
-@JsExport
-fun AsyncAbacusStateManagerSingletonProtocol.setAddresses(
-    source: String?,
-    account: String?
-) {
-    accountAddress = account
-    sourceAddress = source
-}

--- a/src/commonMain/kotlin/exchange.dydx.abacus/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/AsyncAbacusStateManagerV2.kt
@@ -3,7 +3,6 @@ package exchange.dydx.abacus
 import exchange.dydx.abacus.di.AbacusScope
 import exchange.dydx.abacus.di.Deployment
 import exchange.dydx.abacus.di.DeploymentUri
-import exchange.dydx.abacus.output.ComplianceAction
 import exchange.dydx.abacus.output.Documentation
 import exchange.dydx.abacus.output.PerpetualState
 import exchange.dydx.abacus.output.Restriction
@@ -743,16 +742,6 @@ class AsyncAbacusStateManagerV2(
             trackTransactionError("closeAllPositions", error)
             callback(false, error, null)
             null
-        }
-    }
-
-    override fun triggerCompliance(action: ComplianceAction, callback: TransactionCallback) {
-        try {
-            adaptor?.triggerCompliance(action, callback)
-        } catch (e: Exception) {
-            val error = V4TransactionErrors.Companion.error(null, e.toString())
-            trackTransactionError("triggerCompliance", error)
-            callback(false, error, null)
         }
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/AsyncAbacusStateManagerV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/AsyncAbacusStateManagerV2.kt
@@ -133,8 +133,7 @@ class AsyncAbacusStateManagerV2(
                 field?.dispose()
 
                 value?.market = market
-                value?.accountAddress = accountAddress
-                value?.sourceAddress = sourceAddress
+                value?.setAddresses(source = sourceAddress, account = accountAddress, isNew = true)
                 value?.subaccountNumber = subaccountNumber
                 value?.orderbookGrouping = orderbookGrouping
                 value?.historicalTradingRewardPeriod = historicalTradingRewardPeriod
@@ -181,12 +180,6 @@ class AsyncAbacusStateManagerV2(
         }
 
     override var accountAddress: String? = null
-        set(value) {
-            field = value
-            ioImplementations.threading?.async(ThreadingType.abacus) {
-                adaptor?.accountAddress = field
-            }
-        }
 
     override var walletConnectionType: WalletConnectionType? = WalletConnectionType.Ethereum
         set(value) {
@@ -197,12 +190,6 @@ class AsyncAbacusStateManagerV2(
         }
 
     override var sourceAddress: String? = null
-        set(value) {
-            field = value
-            ioImplementations.threading?.async(ThreadingType.abacus) {
-                adaptor?.sourceAddress = field
-            }
-        }
 
     override var subaccountNumber: Int = 0
         set(value) {
@@ -211,6 +198,12 @@ class AsyncAbacusStateManagerV2(
                 adaptor?.subaccountNumber = field
             }
         }
+
+    override fun setAddresses(source: String?, account: String?, isNew: Boolean) {
+        ioImplementations.threading?.async(ThreadingType.abacus) {
+            adaptor?.setAddresses(source, account, isNew)
+        }
+    }
 
     override var historicalPnlPeriod: HistoricalPnlPeriod = HistoricalPnlPeriod.Period7d
         set(value) {
@@ -261,6 +254,7 @@ class AsyncAbacusStateManagerV2(
             )
         }
     }
+
     private var started: Boolean = false
         set(value) {
             if (field != value) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/StateManagerAdaptorV2.kt
@@ -53,7 +53,6 @@ import exchange.dydx.abacus.state.supervisor.NetworkHelper
 import exchange.dydx.abacus.state.supervisor.OnboardingSupervisor
 import exchange.dydx.abacus.state.supervisor.SystemSupervisor
 import exchange.dydx.abacus.state.supervisor.VaultSupervisor
-import exchange.dydx.abacus.state.supervisor.accountAddress
 import exchange.dydx.abacus.state.supervisor.addressRestriction
 import exchange.dydx.abacus.state.supervisor.adjustIsolatedMargin
 import exchange.dydx.abacus.state.supervisor.adjustIsolatedMarginPayload
@@ -78,7 +77,7 @@ import exchange.dydx.abacus.state.supervisor.orderCanceled
 import exchange.dydx.abacus.state.supervisor.placeOrderPayload
 import exchange.dydx.abacus.state.supervisor.refresh
 import exchange.dydx.abacus.state.supervisor.screen
-import exchange.dydx.abacus.state.supervisor.sourceAddress
+import exchange.dydx.abacus.state.supervisor.setAddresses
 import exchange.dydx.abacus.state.supervisor.stopWatchingLastOrder
 import exchange.dydx.abacus.state.supervisor.subaccountNumber
 import exchange.dydx.abacus.state.supervisor.subaccountTransferPayload
@@ -283,13 +282,9 @@ internal class StateManagerAdaptorV2(
             markets.orderbookGrouping = value
         }
 
-    internal var accountAddress: String?
+    internal val accountAddress: String?
         get() {
             return accounts.accountAddress
-        }
-        set(value) {
-            accounts.accountAddress = value
-            vault.accountAddress = value
         }
 
     internal var walletConnectionType: WalletConnectionType?
@@ -301,12 +296,9 @@ internal class StateManagerAdaptorV2(
             onboarding.walletConnectionType = value
         }
 
-    internal var sourceAddress: String?
+    internal val sourceAddress: String?
         get() {
             return accounts.sourceAddress
-        }
-        set(value) {
-            accounts.sourceAddress = value
         }
 
     internal var historicalPnlPeriod: HistoricalPnlPeriod
@@ -350,6 +342,11 @@ internal class StateManagerAdaptorV2(
         get() {
             return connections.validatorState
         }
+
+    internal fun setAddresses(source: String?, account: String?, isNew: Boolean) {
+        accounts.setAddresses(sourceAddress = source, accountAddress = account, isNew = isNew)
+        vault.accountAddress = account
+    }
 
     private fun didSetReadyToConnect(readyToConnect: Boolean) {
         connections.readyToConnect = readyToConnect

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/StateManagerAdaptorV2.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/StateManagerAdaptorV2.kt
@@ -1,7 +1,6 @@
 package exchange.dydx.abacus.state
 
 import exchange.dydx.abacus.output.Compliance
-import exchange.dydx.abacus.output.ComplianceAction
 import exchange.dydx.abacus.output.ComplianceStatus
 import exchange.dydx.abacus.output.Notification
 import exchange.dydx.abacus.output.PerpetualState
@@ -84,7 +83,6 @@ import exchange.dydx.abacus.state.supervisor.stopWatchingLastOrder
 import exchange.dydx.abacus.state.supervisor.subaccountNumber
 import exchange.dydx.abacus.state.supervisor.subaccountTransferPayload
 import exchange.dydx.abacus.state.supervisor.trade
-import exchange.dydx.abacus.state.supervisor.triggerCompliance
 import exchange.dydx.abacus.state.supervisor.triggerOrders
 import exchange.dydx.abacus.state.supervisor.triggerOrdersPayload
 import exchange.dydx.abacus.state.supervisor.walletConnectionType
@@ -678,10 +676,6 @@ internal class StateManagerAdaptorV2(
 
     internal fun screen(address: String, callback: (restriction: Restriction) -> Unit) {
         accounts.screen(address, callback)
-    }
-
-    internal fun triggerCompliance(action: ComplianceAction, callback: TransactionCallback?) {
-        accounts.triggerCompliance(action, callback)
     }
 
     internal fun registerPushNotification(token: String, languageCode: String?) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountScreener.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountScreener.kt
@@ -315,7 +315,7 @@ internal class AccountScreener(
                         sourceAddressRestriction = restriction
                     }
                     else -> {
-                        throw Exception("Unexpected restriction value")
+                        throw IllegalArgumentException("Unexpected restriction value")
                     }
                 }
                 rerunAddressScreeningDelay(sourceAddressRestriction)?.let {
@@ -346,7 +346,7 @@ internal class AccountScreener(
                     accountAddressRestriction = restriction
                 }
                 else -> {
-                    throw Exception("Unexpected restriction value")
+                    throw IllegalArgumentException("Unexpected restriction value")
                 }
             }
             rerunAddressScreeningDelay(accountAddressRestriction)?.let {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountScreener.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountScreener.kt
@@ -30,7 +30,7 @@ internal class AccountScreener(
     stateMachine: TradingStateMachine,
     helper: NetworkHelper,
     analyticsUtils: AnalyticsUtils,
-    private val screening: Boolean,
+    private val screeningUpdate: Boolean, // do compliance screening and update user compliance status
     internal val accountAddress: String,
     private val complianceUpdated: () -> Unit,
 ) : DynamicNetworkSupervisor(stateMachine, helper, analyticsUtils) {
@@ -104,8 +104,8 @@ internal class AccountScreener(
         }
 
     init {
-        if (screening) {
-            screenAccountAddress()
+        screenAccountAddress()
+        if (screeningUpdate) {
             complianceScreen(DydxAddress(accountAddress), ComplianceAction.CONNECT)
         }
     }
@@ -401,13 +401,13 @@ internal class AccountScreener(
     private var complianceScreeningAddress: String? = null
 
     private fun doComplianceScreening() {
-        if (screening) {
-            val sourceAddress = sourceAddress
-            if (sourceAddress != null && indexerConnected && complianceScreeningAddress != sourceAddress) {
-                screenSourceAddress()
+        val sourceAddress = sourceAddress
+        if (sourceAddress != null && indexerConnected && complianceScreeningAddress != sourceAddress) {
+            screenSourceAddress()
+            if (screeningUpdate) {
                 complianceScreen(EvmAddress(sourceAddress))
-                complianceScreeningAddress = sourceAddress
             }
+            complianceScreeningAddress = sourceAddress
         }
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountScreener.kt.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountScreener.kt.kt
@@ -1,0 +1,475 @@
+package exchange.dydx.abacus.state.supervisor
+
+import exchange.dydx.abacus.output.Compliance
+import exchange.dydx.abacus.output.ComplianceAction
+import exchange.dydx.abacus.output.ComplianceStatus
+import exchange.dydx.abacus.output.PerpetualState
+import exchange.dydx.abacus.output.Restriction
+import exchange.dydx.abacus.output.UsageRestriction
+import exchange.dydx.abacus.protocols.LocalTimerProtocol
+import exchange.dydx.abacus.protocols.ThreadingType
+import exchange.dydx.abacus.protocols.TransactionType
+import exchange.dydx.abacus.state.Changes
+import exchange.dydx.abacus.state.StateChanges
+import exchange.dydx.abacus.state.machine.TradingStateMachine
+import exchange.dydx.abacus.state.manager.utils.Address
+import exchange.dydx.abacus.state.manager.utils.DydxAddress
+import exchange.dydx.abacus.state.manager.utils.EvmAddress
+import exchange.dydx.abacus.utils.AnalyticsUtils
+import exchange.dydx.abacus.utils.CoroutineTimer
+import exchange.dydx.abacus.utils.Logger
+import exchange.dydx.abacus.utils.iMapOf
+import exchange.dydx.abacus.utils.toJsonPrettyPrint
+import kollections.iListOf
+import kollections.iSetOf
+import kollections.toIMap
+import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.days
+
+internal class AccountScreener(
+    stateMachine: TradingStateMachine,
+    helper: NetworkHelper,
+    analyticsUtils: AnalyticsUtils,
+    private val screening: Boolean,
+    internal val accountAddress: String,
+    private val complianceUpdated: () -> Unit,
+) : DynamicNetworkSupervisor(stateMachine, helper, analyticsUtils) {
+
+    private var sourceAddressRestriction: Restriction? = null
+        set(value) {
+            if (field != value) {
+                field = value
+                didSetSourceAddressRestriction(value)
+            }
+        }
+
+    internal var addressRestriction: UsageRestriction? = null
+        set(value) {
+            if (field != value) {
+                field = value
+                didSetAddressRestriction(value)
+            }
+        }
+
+    internal var restriction: UsageRestriction = UsageRestriction.noRestriction
+        set(value) {
+            if (field != value) {
+                field = value
+                didSetRestriction(value)
+            }
+        }
+
+    private var compliance: Compliance = Compliance(null, ComplianceStatus.COMPLIANT, null, null)
+        set(value) {
+            if (field != value) {
+                field = value
+                didSetComplianceStatus(value)
+            }
+        }
+
+    private var screenAccountAddressTimer: LocalTimerProtocol? = null
+        set(value) {
+            if (field !== value) {
+                field?.cancel()
+                field = value
+            }
+        }
+
+    private var accountAddressRestriction: Restriction? = null
+        set(value) {
+            if (field != value) {
+                field = value
+                didSetAccountAddressRestriction(value)
+            }
+        }
+
+    private val addressRetryDuration = 10.0
+    private val addressContinuousMonitoringDuration = 60.0 * 60.0
+
+    private var screenSourceAddressTimer: LocalTimerProtocol? = null
+        set(value) {
+            if (field !== value) {
+                field?.cancel()
+                field = value
+            }
+        }
+
+    var sourceAddress: String? = null
+        internal set(value) {
+            if (field != value) {
+                val oldValue = field
+                field = value
+                didSetSourceAddress(sourceAddress, oldValue)
+            }
+        }
+
+    init {
+        if (screening) {
+            screenAccountAddress()
+            complianceScreen(DydxAddress(accountAddress), ComplianceAction.CONNECT)
+        }
+    }
+
+    override fun didSetIndexerConnected(indexerConnected: Boolean) {
+        super.didSetIndexerConnected(indexerConnected)
+
+        if (indexerConnected) {
+            doComplianceScreening()
+        } else {
+            screenAccountAddressTimer = null
+            screenSourceAddressTimer = null
+        }
+    }
+
+    internal fun screen(address: String, callback: ((Restriction) -> Unit)) {
+        val url = screenUrl() ?: return
+
+        helper.get(
+            url,
+            mapOf("address" to address),
+            null,
+            callback = { _, response, httpCode, _ ->
+                if (helper.success(httpCode) && response != null) {
+                    val payload = helper.parser.decodeJsonObject(response)?.toIMap()
+                    if (payload != null) {
+                        val restricted =
+                            helper.parser.asBool(payload["restricted"]) ?: false
+                        callback(
+                            if (restricted) {
+                                Restriction.USER_RESTRICTED
+                            } else {
+                                Restriction.NO_RESTRICTION
+                            },
+                        )
+                    } else {
+                        callback(Restriction.USER_RESTRICTION_UNKNOWN)
+                    }
+                } else {
+                    if (httpCode == 403) {
+                        // It could be 403 due to GEOBLOCKED
+                        val usageRestriction = restrictionReason(response)
+                        callback(usageRestriction.restriction)
+                    } else {
+                        callback(Restriction.USER_RESTRICTION_UNKNOWN)
+                    }
+                }
+            },
+        )
+    }
+
+    private fun handleComplianceResponse(response: String?, httpCode: Int, address: Address?): ComplianceStatus {
+        var complianceStatus = ComplianceStatus.UNKNOWN
+        var updatedAt: String? = null
+        var expiresAt: String? = null
+        if (helper.success(httpCode) && response != null) {
+            val res = helper.parser.decodeJsonObject(response)?.toIMap()
+            complianceStatus =
+                helper.parser.asString(res?.get("status"))?.let { ComplianceStatus.valueOf(it) }
+                    ?: ComplianceStatus.UNKNOWN
+            updatedAt = helper.parser.asString(res?.get("updatedAt"))
+            if (updatedAt != null) {
+                expiresAt =
+                    try {
+                        Instant.parse(updatedAt).plus(7.days).toString()
+                    } catch (e: IllegalArgumentException) {
+                        Logger.e { "Error parsing compliance updatedAt: $updatedAt" }
+                        null
+                    }
+            }
+        }
+        // If we are screening an EVM address we only update when the compliance status is blocked
+        if (address is DydxAddress || complianceStatus == ComplianceStatus.BLOCKED) {
+            compliance =
+                compliance.copy(
+                    status = complianceStatus,
+                    updatedAt = updatedAt,
+                    expiresAt = expiresAt,
+                )
+        }
+        return complianceStatus
+    }
+
+    private fun updateCompliance(
+        address: DydxAddress,
+        status: ComplianceStatus,
+        complianceAction: ComplianceAction
+    ) {
+        val chainId = helper.environment.dydxChainId
+        val message = "Verify account ownership"
+        val payload =
+            helper.jsonEncoder.encode(
+                mapOf(
+                    "message" to message,
+                    "action" to complianceAction.toString(),
+                    "status" to status.toString(),
+                    "chainId" to chainId.toString(),
+                ),
+            )
+        helper.transaction(
+            TransactionType.SignCompliancePayload,
+            payload,
+        ) { additionalPayload ->
+            val error = helper.parseTransactionResponse(additionalPayload)
+            val result = helper.parser.decodeJsonObject(additionalPayload)
+
+            if (error == null && result != null) {
+                val signedMessage = helper.parser.asString(result["signedMessage"])
+                val publicKey = helper.parser.asString(result["publicKey"])
+                val timestamp = helper.parser.asString(result["timestamp"])
+                val isKeplr = helper.parser.asBool(result["isKeplr"])
+                val url = if (isKeplr == true) complianceGeoblockKeplrUrl() else complianceGeoblockUrl()
+
+                val isUrlAndKeysPresent =
+                    url != null &&
+                        signedMessage != null &&
+                        publicKey != null
+
+                val isKeplrOrHasTimestamp = (timestamp != null || isKeplr == true)
+
+                val isStatusValid = status != ComplianceStatus.UNKNOWN
+
+                if (isUrlAndKeysPresent && isKeplrOrHasTimestamp && isStatusValid) {
+                    val body: Map<String, String> =
+                        if (isKeplr == true) {
+                            iMapOf(
+                                "address" to address.rawAddress,
+                                "message" to message,
+                                "action" to complianceAction.toString(),
+                                "signedMessage" to signedMessage!!,
+                                "pubkey" to publicKey!!,
+                            )
+                        } else {
+                            iMapOf(
+                                "address" to address.rawAddress,
+                                "message" to message,
+                                "currentStatus" to status.toString(),
+                                "action" to complianceAction.toString(),
+                                "signedMessage" to signedMessage!!,
+                                "pubkey" to publicKey!!,
+                                "timestamp" to timestamp!!,
+                            )
+                        }
+                    val header =
+                        iMapOf(
+                            "Content-Type" to "application/json",
+                        )
+                    helper.post(
+                        url = url!!,
+                        headers = header,
+                        body = body.toJsonPrettyPrint(),
+                        callback = { _, response, httpCode, _ ->
+                            handleComplianceResponse(response, httpCode, address)
+                            // retrieve the subaccounts if it does not exist yet. It is possible that the initial
+                            // subaccount retrieval failed due to 403 before updating the compliance status.
+                            if (helper.success(httpCode) && response != null) {
+                                complianceUpdated()
+                            }
+                        },
+                    )
+                } else {
+                    compliance = compliance.copy(status = ComplianceStatus.UNKNOWN)
+                }
+            } else {
+                compliance = compliance.copy(status = ComplianceStatus.UNKNOWN)
+            }
+        }
+    }
+
+    private fun complianceScreen(address: Address, action: ComplianceAction? = null) {
+        val url = complianceScreenUrl(address.rawAddress) ?: return
+
+        helper.get(
+            url = url,
+            params = null,
+            headers = null,
+            callback = { _, response, httpCode, _ ->
+                val complianceStatus = handleComplianceResponse(response, httpCode, address)
+                if (address is DydxAddress && action != null) {
+                    updateCompliance(address, complianceStatus, action)
+                }
+            },
+        )
+    }
+
+    private fun complianceScreenUrl(address: String): String? {
+        val url = helper.configs.publicApiUrl("complianceScreen") ?: return null
+        return "$url/$address"
+    }
+
+    private fun complianceGeoblockUrl(): String? {
+        return helper.configs.publicApiUrl("complianceGeoblock")
+    }
+
+    private fun complianceGeoblockKeplrUrl(): String? {
+        return helper.configs.publicApiUrl("complianceGeoblockKeplr")
+    }
+
+    private fun screenSourceAddress() {
+        val address = sourceAddress
+        if (address != null) {
+            screen(address) { restriction ->
+                when (restriction) {
+                    Restriction.USER_RESTRICTED,
+                    Restriction.NO_RESTRICTION,
+                    Restriction.USER_RESTRICTION_UNKNOWN -> {
+                        sourceAddressRestriction = restriction
+                    }
+                    else -> {
+                        throw Exception("Unexpected restriction value")
+                    }
+                }
+                rerunAddressScreeningDelay(sourceAddressRestriction)?.let {
+                    val timer = helper.ioImplementations.timer ?: CoroutineTimer.instance
+                    screenSourceAddressTimer =
+                        timer.schedule(it, it) {
+                            screenSourceAddress()
+                            true
+                        }
+                }
+            }
+        } else {
+            sourceAddressRestriction = Restriction.NO_RESTRICTION
+        }
+    }
+
+    private fun didSetAccountAddressRestriction(accountAddressRestriction: Restriction?) {
+        updateAddressRestriction()
+    }
+
+    private fun screenAccountAddress() {
+        val address = accountAddress
+        screen(address) { restriction ->
+            when (restriction) {
+                Restriction.USER_RESTRICTED,
+                Restriction.NO_RESTRICTION,
+                Restriction.USER_RESTRICTION_UNKNOWN -> {
+                    accountAddressRestriction = restriction
+                }
+                else -> {
+                    throw Exception("Unexpected restriction value")
+                }
+            }
+            rerunAddressScreeningDelay(accountAddressRestriction)?.let {
+                val timer = helper.ioImplementations.timer ?: CoroutineTimer.instance
+                screenAccountAddressTimer =
+                    timer.schedule(it, it) {
+                        screenAccountAddress()
+                        true
+                    }
+            }
+        }
+    }
+
+    private fun rerunAddressScreeningDelay(restriction: Restriction?): Double? {
+        return when (restriction) {
+            Restriction.NO_RESTRICTION -> addressContinuousMonitoringDuration
+            Restriction.USER_RESTRICTION_UNKNOWN -> addressRetryDuration
+            else -> null
+        }
+    }
+
+    private fun screenUrl(): String? {
+        return helper.configs.publicApiUrl("screen")
+    }
+
+    private fun restrictionReason(response: String?): UsageRestriction {
+        return if (response != null) {
+            val json = helper.parser.decodeJsonObject(response)
+            val errors = helper.parser.asList(helper.parser.value(json, "errors"))
+            val geoRestriciton =
+                errors?.firstOrNull { error ->
+                    val code = helper.parser.asString(helper.parser.value(error, "code"))
+                    code?.contains("GEOBLOCKED") == true
+                }
+
+            if (geoRestriciton !== null) {
+                UsageRestriction.http403Restriction
+            } else {
+                UsageRestriction.userRestriction
+            }
+        } else {
+            UsageRestriction.http403Restriction
+        }
+    }
+
+    private fun didSetSourceAddress(sourceAddress: String?, oldValue: String?) {
+        screenSourceAddressTimer = null
+        sourceAddressRestriction = null
+        doComplianceScreening()
+    }
+
+    private var complianceScreeningAddress: String? = null
+
+    private fun doComplianceScreening() {
+        if (screening) {
+            val sourceAddress = sourceAddress
+            if (sourceAddress != null && indexerConnected && complianceScreeningAddress != sourceAddress) {
+                screenSourceAddress()
+                complianceScreen(EvmAddress(sourceAddress))
+                complianceScreeningAddress = sourceAddress
+            }
+        }
+    }
+
+    private fun didSetSourceAddressRestriction(sourceAddressRestriction: Restriction?) {
+        updateAddressRestriction()
+    }
+
+    private fun updateAddressRestriction() {
+        val restrictions: Set<Restriction?> =
+            iSetOf(accountAddressRestriction, sourceAddressRestriction)
+        addressRestriction =
+            if (restrictions.contains(Restriction.USER_RESTRICTED)) {
+                UsageRestriction.userRestriction
+            } else if (restrictions.contains(Restriction.USER_RESTRICTION_UNKNOWN)) {
+                UsageRestriction.userRestrictionUnknown
+            } else {
+                if (sourceAddressRestriction == null && accountAddressRestriction == null) {
+                    null
+                } else {
+                    UsageRestriction.noRestriction
+                }
+            }
+    }
+
+    private fun didSetAddressRestriction(addressRestriction: UsageRestriction?) {
+        updateRestriction()
+    }
+
+    internal open fun updateRestriction() {
+        restriction = addressRestriction ?: UsageRestriction.noRestriction
+    }
+
+    private fun didSetRestriction(restriction: UsageRestriction?) {
+        val state = stateMachine.state ?: PerpetualState.newState()
+        stateMachine.state = state.copy(restriction = restriction)
+        helper.ioImplementations.threading?.async(ThreadingType.main) {
+            helper.stateNotification?.stateChanged(
+                state = stateMachine.state,
+                changes = StateChanges(
+                    iListOf(Changes.restriction),
+                ),
+            )
+        }
+    }
+
+    private fun didSetComplianceStatus(compliance: Compliance) {
+        val state = stateMachine.state ?: PerpetualState.newState()
+        stateMachine.state = state.copy(
+            compliance = Compliance(
+                geo = state?.compliance?.geo,
+                status = compliance.status,
+                updatedAt = compliance.updatedAt,
+                expiresAt = compliance.expiresAt,
+            ),
+        )
+        helper.ioImplementations.threading?.async(ThreadingType.main) {
+            helper.stateNotification?.stateChanged(
+                state = stateMachine.state,
+                changes = StateChanges(
+                    iListOf(Changes.compliance),
+                ),
+            )
+        }
+    }
+}

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountSupervisor.kt
@@ -1,23 +1,14 @@
 package exchange.dydx.abacus.state.supervisor
 
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
-import exchange.dydx.abacus.output.Compliance
-import exchange.dydx.abacus.output.ComplianceAction
-import exchange.dydx.abacus.output.ComplianceStatus
 import exchange.dydx.abacus.output.Notification
-import exchange.dydx.abacus.output.PerpetualState
-import exchange.dydx.abacus.output.Restriction
-import exchange.dydx.abacus.output.UsageRestriction
 import exchange.dydx.abacus.processor.router.skip.SkipRoutePayloadProcessor
 import exchange.dydx.abacus.protocols.LocalTimerProtocol
 import exchange.dydx.abacus.protocols.QueryType
-import exchange.dydx.abacus.protocols.ThreadingType
 import exchange.dydx.abacus.protocols.TransactionCallback
 import exchange.dydx.abacus.protocols.TransactionType
 import exchange.dydx.abacus.responses.SocketInfo
 import exchange.dydx.abacus.state.Changes
-import exchange.dydx.abacus.state.StateChanges
-import exchange.dydx.abacus.state.helper.V4TransactionErrors
 import exchange.dydx.abacus.state.machine.AdjustIsolatedMarginInputField
 import exchange.dydx.abacus.state.machine.ClosePositionInputField
 import exchange.dydx.abacus.state.machine.TradeInputField
@@ -47,9 +38,6 @@ import exchange.dydx.abacus.state.manager.HumanReadableTriggerOrdersPayload
 import exchange.dydx.abacus.state.manager.HumanReadableWithdrawPayload
 import exchange.dydx.abacus.state.manager.pendingCctpWithdraw
 import exchange.dydx.abacus.state.manager.processingCctpWithdraw
-import exchange.dydx.abacus.state.manager.utils.Address
-import exchange.dydx.abacus.state.manager.utils.DydxAddress
-import exchange.dydx.abacus.state.manager.utils.EvmAddress
 import exchange.dydx.abacus.utils.AnalyticsUtils
 import exchange.dydx.abacus.utils.CoroutineTimer
 import exchange.dydx.abacus.utils.IMap
@@ -60,12 +48,11 @@ import exchange.dydx.abacus.utils.iMapOf
 import exchange.dydx.abacus.utils.mutable
 import exchange.dydx.abacus.utils.toJsonPrettyPrint
 import exchange.dydx.abacus.utils.toNobleAddress
-import kollections.iListOf
-import kollections.iSetOf
-import kollections.toIMap
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlin.Boolean
 import kotlin.collections.mutableMapOf
+import kotlin.coroutines.EmptyCoroutineContext.get
 import kotlin.time.Duration.Companion.days
 
 internal open class AccountSupervisor(
@@ -80,6 +67,19 @@ internal open class AccountSupervisor(
         accountAddress = accountAddress,
     )
 ) : DynamicNetworkSupervisor(stateMachine, helper, analyticsUtils) {
+    val screener = AccountScreener(
+        stateMachine = stateMachine,
+        helper = helper,
+        analyticsUtils = analyticsUtils,
+        screening = screening,
+        accountAddress = accountAddress,
+        complianceUpdated = {
+            if (subaccounts.isEmpty()) {
+                retrieveSubaccounts()
+            }
+        },
+    )
+
     val subaccounts = mutableMapOf<Int, SubaccountSupervisor>()
 
     var currentIncentiveSeason: String? = null
@@ -126,15 +126,6 @@ internal open class AccountSupervisor(
             }
         }
 
-    var sourceAddress: String? = null
-        internal set(value) {
-            if (field != value) {
-                val oldValue = field
-                field = value
-                didSetSourceAddress(sourceAddress, oldValue)
-            }
-        }
-
     var walletConnectionType: WalletConnectionType? = WalletConnectionType.Ethereum
         internal set(value) {
             field = value
@@ -144,65 +135,6 @@ internal open class AccountSupervisor(
             }
 
             sendPushNotificationToken()
-        }
-
-    private var sourceAddressRestriction: Restriction? = null
-        set(value) {
-            if (field != value) {
-                field = value
-                didSetSourceAddressRestriction(value)
-            }
-        }
-
-    internal var addressRestriction: UsageRestriction? = null
-        set(value) {
-            if (field != value) {
-                field = value
-                didSetAddressRestriction(value)
-            }
-        }
-
-    internal open var restriction: UsageRestriction = UsageRestriction.noRestriction
-        set(value) {
-            if (field != value) {
-                field = value
-                didSetRestriction(value)
-            }
-        }
-
-    private var compliance: Compliance = Compliance(null, ComplianceStatus.COMPLIANT, null, null)
-        set(value) {
-            if (field != value) {
-                field = value
-                didSetComplianceStatus(value)
-            }
-        }
-
-    private var screenAccountAddressTimer: LocalTimerProtocol? = null
-        set(value) {
-            if (field !== value) {
-                field?.cancel()
-                field = value
-            }
-        }
-
-    private var accountAddressRestriction: Restriction? = null
-        set(value) {
-            if (field != value) {
-                field = value
-                didSetAccountAddressRestriction(value)
-            }
-        }
-
-    private val addressRetryDuration = 10.0
-    private val addressContinuousMonitoringDuration = 60.0 * 60.0
-
-    private var screenSourceAddressTimer: LocalTimerProtocol? = null
-        set(value) {
-            if (field !== value) {
-                field?.cancel()
-                field = value
-            }
         }
 
     internal var subaccountNumber: Int? // Desired subaccountNumber
@@ -235,13 +167,6 @@ internal open class AccountSupervisor(
 
     private var pushNotificationToken: String? = null
     private var pushNotificationLanguageCode: String? = null
-
-    init {
-        if (screening) {
-            screenAccountAddress()
-            complianceScreen(DydxAddress(accountAddress), ComplianceAction.CONNECT)
-        }
-    }
 
     internal fun subscribeToSubaccount(subaccountNumber: Int) {
         val isSubaccountRealized = stateMachine.state?.subaccount(subaccountNumber) != null
@@ -313,11 +238,8 @@ internal open class AccountSupervisor(
             }
 
             sendPushNotificationToken()
-            doComplianceScreening()
         } else {
             subaccountsTimer = null
-            screenAccountAddressTimer = null
-            screenSourceAddressTimer = null
         }
     }
 
@@ -679,371 +601,6 @@ internal open class AccountSupervisor(
             } else {
                 Logger.e { "sweepNobleBalanceToDydxSkip error, code: $code" }
             }
-        }
-    }
-
-    private fun handleComplianceResponse(response: String?, httpCode: Int, address: Address?): ComplianceStatus {
-        var complianceStatus = ComplianceStatus.UNKNOWN
-        var updatedAt: String? = null
-        var expiresAt: String? = null
-        if (helper.success(httpCode) && response != null) {
-            val res = helper.parser.decodeJsonObject(response)?.toIMap()
-            complianceStatus =
-                helper.parser.asString(res?.get("status"))?.let { ComplianceStatus.valueOf(it) }
-                    ?: ComplianceStatus.UNKNOWN
-            updatedAt = helper.parser.asString(res?.get("updatedAt"))
-            if (updatedAt != null) {
-                expiresAt =
-                    try {
-                        Instant.parse(updatedAt).plus(7.days).toString()
-                    } catch (e: IllegalArgumentException) {
-                        Logger.e { "Error parsing compliance updatedAt: $updatedAt" }
-                        null
-                    }
-            }
-        }
-        // If we are screening an EVM address we only update when the compliance status is blocked
-        if (address is DydxAddress || complianceStatus == ComplianceStatus.BLOCKED) {
-            compliance =
-                compliance.copy(
-                    status = complianceStatus,
-                    updatedAt = updatedAt,
-                    expiresAt = expiresAt,
-                )
-        }
-        return complianceStatus
-    }
-
-    private fun updateCompliance(
-        address: DydxAddress,
-        status: ComplianceStatus,
-        complianceAction: ComplianceAction
-    ) {
-        val chainId = helper.environment.dydxChainId
-        val message = "Verify account ownership"
-        val payload =
-            helper.jsonEncoder.encode(
-                mapOf(
-                    "message" to message,
-                    "action" to complianceAction.toString(),
-                    "status" to status.toString(),
-                    "chainId" to chainId.toString(),
-                ),
-            )
-        helper.transaction(
-            TransactionType.SignCompliancePayload,
-            payload,
-        ) { additionalPayload ->
-            val error = helper.parseTransactionResponse(additionalPayload)
-            val result = helper.parser.decodeJsonObject(additionalPayload)
-
-            if (error == null && result != null) {
-                val signedMessage = helper.parser.asString(result["signedMessage"])
-                val publicKey = helper.parser.asString(result["publicKey"])
-                val timestamp = helper.parser.asString(result["timestamp"])
-                val isKeplr = helper.parser.asBool(result["isKeplr"])
-                val url = if (isKeplr == true) complianceGeoblockKeplrUrl() else complianceGeoblockUrl()
-
-                val isUrlAndKeysPresent =
-                    url != null &&
-                        signedMessage != null &&
-                        publicKey != null
-
-                val isKeplrOrHasTimestamp = (timestamp != null || isKeplr == true)
-
-                val isStatusValid = status != ComplianceStatus.UNKNOWN
-
-                if (isUrlAndKeysPresent && isKeplrOrHasTimestamp && isStatusValid) {
-                    val body: Map<String, String> =
-                        if (isKeplr == true) {
-                            iMapOf(
-                                "address" to address.rawAddress,
-                                "message" to message,
-                                "action" to complianceAction.toString(),
-                                "signedMessage" to signedMessage!!,
-                                "pubkey" to publicKey!!,
-                            )
-                        } else {
-                            iMapOf(
-                                "address" to address.rawAddress,
-                                "message" to message,
-                                "currentStatus" to status.toString(),
-                                "action" to complianceAction.toString(),
-                                "signedMessage" to signedMessage!!,
-                                "pubkey" to publicKey!!,
-                                "timestamp" to timestamp!!,
-                            )
-                        }
-                    val header =
-                        iMapOf(
-                            "Content-Type" to "application/json",
-                        )
-                    helper.post(
-                        url = url!!,
-                        headers = header,
-                        body = body.toJsonPrettyPrint(),
-                        callback = { _, response, httpCode, _ ->
-                            handleComplianceResponse(response, httpCode, address)
-                            // retrieve the subaccounts if it does not exist yet. It is possible that the initial
-                            // subaccount retrieval failed due to 403 before updating the compliance status.
-                            if (helper.success(httpCode) && response != null && subaccounts.isEmpty()) {
-                                retrieveSubaccounts()
-                            }
-                        },
-                    )
-                } else {
-                    compliance = compliance.copy(status = ComplianceStatus.UNKNOWN)
-                }
-            } else {
-                compliance = compliance.copy(status = ComplianceStatus.UNKNOWN)
-            }
-        }
-    }
-
-    private fun complianceScreen(address: Address, action: ComplianceAction? = null) {
-        val url = complianceScreenUrl(address.rawAddress)
-        if (url != null) {
-            helper.get(
-                url = url,
-                params = null,
-                headers = null,
-                callback = { _, response, httpCode, _ ->
-                    val complianceStatus = handleComplianceResponse(response, httpCode, address)
-                    if (address is DydxAddress && action != null) {
-                        updateCompliance(address, complianceStatus, action)
-                    }
-                },
-            )
-        }
-    }
-
-    internal open fun triggerCompliance(action: ComplianceAction, callback: TransactionCallback?) {
-        if (compliance.status != ComplianceStatus.UNKNOWN) {
-            updateCompliance(DydxAddress(accountAddress), compliance.status, action)
-            if (callback != null) {
-                callback(true, null, null)
-            }
-        } else if (callback != null) {
-            callback(false, V4TransactionErrors.error(null, "No account address"), null)
-        }
-    }
-
-    private fun complianceScreenUrl(address: String): String? {
-        val url = helper.configs.publicApiUrl("complianceScreen") ?: return null
-        return "$url/$address"
-    }
-
-    private fun complianceGeoblockUrl(): String? {
-        return helper.configs.publicApiUrl("complianceGeoblock")
-    }
-
-    private fun complianceGeoblockKeplrUrl(): String? {
-        return helper.configs.publicApiUrl("complianceGeoblockKeplr")
-    }
-
-    private fun screenSourceAddress() {
-        val address = sourceAddress
-        if (address != null) {
-            screen(address) { restriction ->
-                when (restriction) {
-                    Restriction.USER_RESTRICTED,
-                    Restriction.NO_RESTRICTION,
-                    Restriction.USER_RESTRICTION_UNKNOWN -> {
-                        sourceAddressRestriction = restriction
-                    }
-                    else -> {
-                        throw Exception("Unexpected restriction value")
-                    }
-                }
-                rerunAddressScreeningDelay(sourceAddressRestriction)?.let {
-                    val timer = helper.ioImplementations.timer ?: CoroutineTimer.instance
-                    screenSourceAddressTimer =
-                        timer.schedule(it, it) {
-                            screenSourceAddress()
-                            true
-                        }
-                }
-            }
-        } else {
-            sourceAddressRestriction = Restriction.NO_RESTRICTION
-        }
-    }
-
-    private fun didSetAccountAddressRestriction(accountAddressRestriction: Restriction?) {
-        updateAddressRestriction()
-    }
-
-    open fun screenAccountAddress() {
-        val address = accountAddress
-        screen(address) { restriction ->
-            when (restriction) {
-                Restriction.USER_RESTRICTED,
-                Restriction.NO_RESTRICTION,
-                Restriction.USER_RESTRICTION_UNKNOWN -> {
-                    accountAddressRestriction = restriction
-                }
-                else -> {
-                    throw Exception("Unexpected restriction value")
-                }
-            }
-            rerunAddressScreeningDelay(accountAddressRestriction)?.let {
-                val timer = helper.ioImplementations.timer ?: CoroutineTimer.instance
-                screenAccountAddressTimer =
-                    timer.schedule(it, it) {
-                        screenAccountAddress()
-                        true
-                    }
-            }
-        }
-    }
-
-    private fun rerunAddressScreeningDelay(restriction: Restriction?): Double? {
-        return when (restriction) {
-            Restriction.NO_RESTRICTION -> addressContinuousMonitoringDuration
-            Restriction.USER_RESTRICTION_UNKNOWN -> addressRetryDuration
-            else -> null
-        }
-    }
-
-    open fun screen(address: String, callback: ((Restriction) -> Unit)) {
-        val url = screenUrl()
-        if (url != null) {
-            helper.get(
-                url,
-                mapOf("address" to address),
-                null,
-                callback = { _, response, httpCode, _ ->
-                    if (helper.success(httpCode) && response != null) {
-                        val payload = helper.parser.decodeJsonObject(response)?.toIMap()
-                        if (payload != null) {
-                            val restricted =
-                                helper.parser.asBool(payload["restricted"]) ?: false
-                            callback(
-                                if (restricted) {
-                                    Restriction.USER_RESTRICTED
-                                } else {
-                                    Restriction.NO_RESTRICTION
-                                },
-                            )
-                        } else {
-                            callback(Restriction.USER_RESTRICTION_UNKNOWN)
-                        }
-                    } else {
-                        if (httpCode == 403) {
-                            // It could be 403 due to GEOBLOCKED
-                            val usageRestriction = restrictionReason(response)
-                            callback(usageRestriction.restriction)
-                        } else {
-                            callback(Restriction.USER_RESTRICTION_UNKNOWN)
-                        }
-                    }
-                },
-            )
-        }
-    }
-
-    private fun screenUrl(): String? {
-        return helper.configs.publicApiUrl("screen")
-    }
-
-    private fun restrictionReason(response: String?): UsageRestriction {
-        return if (response != null) {
-            val json = helper.parser.decodeJsonObject(response)
-            val errors = helper.parser.asList(helper.parser.value(json, "errors"))
-            val geoRestriciton =
-                errors?.firstOrNull { error ->
-                    val code = helper.parser.asString(helper.parser.value(error, "code"))
-                    code?.contains("GEOBLOCKED") == true
-                }
-
-            if (geoRestriciton !== null) {
-                UsageRestriction.http403Restriction
-            } else {
-                UsageRestriction.userRestriction
-            }
-        } else {
-            UsageRestriction.http403Restriction
-        }
-    }
-
-    private fun didSetSourceAddress(sourceAddress: String?, oldValue: String?) {
-        screenSourceAddressTimer = null
-        sourceAddressRestriction = null
-        doComplianceScreening()
-    }
-
-    private var complianceScreeningAddress: String? = null
-
-    private fun doComplianceScreening() {
-        if (screening) {
-            val sourceAddress = sourceAddress
-            if (sourceAddress != null && indexerConnected && complianceScreeningAddress != sourceAddress) {
-                screenSourceAddress()
-                complianceScreen(EvmAddress(sourceAddress))
-                complianceScreeningAddress = sourceAddress
-            }
-        }
-    }
-
-    private fun didSetSourceAddressRestriction(sourceAddressRestriction: Restriction?) {
-        updateAddressRestriction()
-    }
-
-    private fun updateAddressRestriction() {
-        val restrictions: Set<Restriction?> =
-            iSetOf(accountAddressRestriction, sourceAddressRestriction)
-        addressRestriction =
-            if (restrictions.contains(Restriction.USER_RESTRICTED)) {
-                UsageRestriction.userRestriction
-            } else if (restrictions.contains(Restriction.USER_RESTRICTION_UNKNOWN)) {
-                UsageRestriction.userRestrictionUnknown
-            } else {
-                if (sourceAddressRestriction == null && accountAddressRestriction == null) {
-                    null
-                } else {
-                    UsageRestriction.noRestriction
-                }
-            }
-    }
-
-    private fun didSetAddressRestriction(addressRestriction: UsageRestriction?) {
-        updateRestriction()
-    }
-
-    internal open fun updateRestriction() {
-        restriction = addressRestriction ?: UsageRestriction.noRestriction
-    }
-
-    private fun didSetRestriction(restriction: UsageRestriction?) {
-        val state = stateMachine.state ?: PerpetualState.newState()
-        stateMachine.state = state.copy(restriction = restriction)
-        helper.ioImplementations.threading?.async(ThreadingType.main) {
-            helper.stateNotification?.stateChanged(
-                state = stateMachine.state,
-                changes = StateChanges(
-                    iListOf(Changes.restriction),
-                ),
-            )
-        }
-    }
-
-    private fun didSetComplianceStatus(compliance: Compliance) {
-        val state = stateMachine.state ?: PerpetualState.newState()
-        stateMachine.state = state.copy(
-            compliance = Compliance(
-                geo = state?.compliance?.geo,
-                status = compliance.status,
-                updatedAt = compliance.updatedAt,
-                expiresAt = compliance.expiresAt,
-            ),
-        )
-        helper.ioImplementations.threading?.async(ThreadingType.main) {
-            helper.stateNotification?.stateChanged(
-                state = stateMachine.state,
-                changes = StateChanges(
-                    iListOf(Changes.compliance),
-                ),
-            )
         }
     }
 

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountSupervisor.kt
@@ -52,7 +52,6 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.Boolean
 import kotlin.collections.mutableMapOf
-import kotlin.coroutines.EmptyCoroutineContext.get
 import kotlin.time.Duration.Companion.days
 
 internal open class AccountSupervisor(
@@ -71,7 +70,7 @@ internal open class AccountSupervisor(
         stateMachine = stateMachine,
         helper = helper,
         analyticsUtils = analyticsUtils,
-        screening = screening,
+        screeningUpdate = screening,
         accountAddress = accountAddress,
         complianceUpdated = {
             if (subaccounts.isEmpty()) {

--- a/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountsSupervisor.kt
+++ b/src/commonMain/kotlin/exchange.dydx.abacus/state/supervisor/AccountsSupervisor.kt
@@ -1,6 +1,5 @@
 package exchange.dydx.abacus.state.supervisor
 
-import exchange.dydx.abacus.output.ComplianceAction
 import exchange.dydx.abacus.output.Notification
 import exchange.dydx.abacus.output.Restriction
 import exchange.dydx.abacus.output.UsageRestriction
@@ -253,10 +252,10 @@ internal var AccountsSupervisor.walletConnectionType: WalletConnectionType?
 
 internal var AccountsSupervisor.sourceAddress: String?
     get() {
-        return account?.sourceAddress
+        return account?.screener?.sourceAddress
     }
     set(value) {
-        account?.sourceAddress = value
+        account?.screener?.sourceAddress = value
     }
 
 internal var AccountsSupervisor.subaccountNumber: Int
@@ -274,7 +273,7 @@ internal val AccountsSupervisor.connectedSubaccountNumber: Int?
 
 internal val AccountsSupervisor.addressRestriction: UsageRestriction?
     get() {
-        return account?.addressRestriction
+        return account?.screener?.addressRestriction
     }
 
 internal val AccountsSupervisor.notifications: IMap<String, Notification>
@@ -400,12 +399,5 @@ internal fun AccountsSupervisor.screen(
     address: String,
     callback: (restriction: Restriction) -> Unit
 ) {
-    account?.screen(address, callback)
-}
-
-internal fun AccountsSupervisor.triggerCompliance(
-    action: ComplianceAction,
-    callback: TransactionCallback?
-) {
-    account?.triggerCompliance(action, callback)
+    account?.screener?.screen(address, callback)
 }

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4ForegroundCycleTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4ForegroundCycleTests.kt
@@ -7,7 +7,6 @@ import exchange.dydx.abacus.app.manager.TestRest
 import exchange.dydx.abacus.app.manager.TestState
 import exchange.dydx.abacus.app.manager.TestWebSocket
 import exchange.dydx.abacus.payload.BaseTests
-import exchange.dydx.abacus.setAddresses
 import exchange.dydx.abacus.state.StateManagerAdaptorV2
 import exchange.dydx.abacus.state.supervisor.AccountConfigs
 import exchange.dydx.abacus.state.supervisor.AppConfigsV2
@@ -84,7 +83,7 @@ class V4ForegroundCycleTests : NetworkTests() {
 
     private fun setStateMachineConnectedWithMarketsAndSubaccounts(stateManager: AsyncAbacusStateManagerV2) {
         setStateMachineConnectedWithMarkets(stateManager)
-        stateManager.setAddresses(null, testCosmoAddress)
+        stateManager.setAddresses(null, testCosmoAddress, false)
     }
 
     @Test
@@ -343,7 +342,7 @@ class V4ForegroundCycleTests : NetworkTests() {
         setStateMachineConnected(stateManager)
 
         val testAddress = "0xsecondaryFakeAddress"
-        stateManager.setAddresses(null, testAddress)
+        stateManager.setAddresses(null, testAddress, false)
 
         compareExpectedRequests(
             """
@@ -360,7 +359,6 @@ class V4ForegroundCycleTests : NetworkTests() {
                     "https://api.examples.com/configs/exchanges.json",
                     "https://api.dydx.exchange/v4/geo",
                     "https://indexer.v4staging.dydx.exchange/v4/screen?address=0xsecondaryFakeAddress",
-                    "https://indexer.v4staging.dydx.exchange/v4/compliance/screen/0xsecondaryFakeAddress",
                     "https://dydx.exchange/v4-launch-incentive/query/api/dydx/points/0xsecondaryFakeAddress?n=2",
                     "https://indexer.v4staging.dydx.exchange/v4/addresses/0xsecondaryFakeAddress",
                     "https://indexer.v4staging.dydx.exchange/v4/historicalTradingRewardAggregations/0xsecondaryFakeAddress?period=DAILY"
@@ -400,7 +398,7 @@ class V4ForegroundCycleTests : NetworkTests() {
         setStateMachineReadyToConnect(stateManager)
         setStateMachineConnected(stateManager)
 
-        stateManager.setAddresses(null, testAddress)
+        stateManager.setAddresses(null, testAddress, false)
 
         compareExpectedRequests(
             """
@@ -417,7 +415,6 @@ class V4ForegroundCycleTests : NetworkTests() {
                     "https://api.examples.com/configs/exchanges.json",
                     "https://api.dydx.exchange/v4/geo",
                     "https://indexer.v4staging.dydx.exchange/v4/screen?address=cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
-                    "https://indexer.v4staging.dydx.exchange/v4/compliance/screen/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
                     "https://dydx.exchange/v4-launch-incentive/query/api/dydx/points/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm?n=2",
                     "https://indexer.v4staging.dydx.exchange/v4/addresses/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
                     "https://indexer.v4staging.dydx.exchange/v4/fills?address=cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm&subaccountNumber=0",
@@ -482,7 +479,7 @@ class V4ForegroundCycleTests : NetworkTests() {
         setStateMachineReadyToConnect(stateManager)
         setStateMachineConnected(stateManager)
 
-        stateManager.setAddresses(null, testAddress)
+        stateManager.setAddresses(null, testAddress, false)
 
         compareExpectedRequests(
             """
@@ -513,7 +510,7 @@ class V4ForegroundCycleTests : NetworkTests() {
         setStateMachineReadyToConnect(stateManager)
         setStateMachineConnected(stateManager)
 
-        stateManager.setAddresses(null, testAddress)
+        stateManager.setAddresses(null, testAddress, false)
 
         compareExpectedRequests(
             """
@@ -530,7 +527,6 @@ class V4ForegroundCycleTests : NetworkTests() {
                     "https://api.examples.com/configs/exchanges.json",
                     "https://api.dydx.exchange/v4/geo",
                     "https://indexer.v4staging.dydx.exchange/v4/screen?address=cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
-                    "https://indexer.v4staging.dydx.exchange/v4/compliance/screen/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
                     "https://dydx.exchange/v4-launch-incentive/query/api/dydx/points/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm?n=2",
                     "https://indexer.v4staging.dydx.exchange/v4/addresses/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
                     "https://indexer.v4staging.dydx.exchange/v4/fills?address=cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm&subaccountNumber=0",
@@ -559,11 +555,11 @@ class V4ForegroundCycleTests : NetworkTests() {
         setStateMachineReadyToConnect(stateManager)
         setStateMachineConnected(stateManager)
 
-        stateManager.setAddresses(null, testAddress)
+        stateManager.setAddresses(null, testAddress, false)
 
         testWebSocket?.simulateConnected(true)
         testWebSocket?.simulateReceived(mock.accountsChannel.v4_subscribed)
-        stateManager.setAddresses(null, secondAddress)
+        stateManager.setAddresses(null, secondAddress, true)
 
         compareExpectedRequests(
             """
@@ -580,7 +576,6 @@ class V4ForegroundCycleTests : NetworkTests() {
                     "https://api.examples.com/configs/exchanges.json",
                     "https://api.dydx.exchange/v4/geo",
                     "https://indexer.v4staging.dydx.exchange/v4/screen?address=cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
-                    "https://indexer.v4staging.dydx.exchange/v4/compliance/screen/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
                     "https://dydx.exchange/v4-launch-incentive/query/api/dydx/points/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm?n=2",
                     "https://indexer.v4staging.dydx.exchange/v4/addresses/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
                     "https://indexer.v4staging.dydx.exchange/v4/fills?address=cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm&subaccountNumber=0",
@@ -634,7 +629,7 @@ class V4ForegroundCycleTests : NetworkTests() {
     }
 
     @Test
-    fun settingWalletCosmoAddressToNullShoulUnsubscribeFromSubaccountsChannel() {
+    fun settingWalletCosmoAddressToNullShouldUnsubscribeFromSubaccountsChannel() {
         reset()
 
         val testAddress = "cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm"
@@ -647,10 +642,10 @@ class V4ForegroundCycleTests : NetworkTests() {
         setStateMachineReadyToConnect(stateManager)
         setStateMachineConnected(stateManager)
 
-        stateManager.setAddresses(null, testAddress)
+        stateManager.setAddresses(null, testAddress, false)
 
         testWebSocket?.simulateReceived(mock.accountsChannel.v4_subscribed)
-        stateManager.setAddresses(null, null)
+        stateManager.setAddresses(null, null, false)
 
         compareExpectedRequests(
             """
@@ -667,7 +662,6 @@ class V4ForegroundCycleTests : NetworkTests() {
                     "https://api.examples.com/configs/exchanges.json",
                     "https://api.dydx.exchange/v4/geo",
                     "https://indexer.v4staging.dydx.exchange/v4/screen?address=cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
-                    "https://indexer.v4staging.dydx.exchange/v4/compliance/screen/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
                     "https://dydx.exchange/v4-launch-incentive/query/api/dydx/points/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm?n=2",
                     "https://indexer.v4staging.dydx.exchange/v4/addresses/cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm",
                     "https://indexer.v4staging.dydx.exchange/v4/fills?address=cosmos1fq8q55896ljfjj7v3x0qd0z3sr78wmes940uhm&subaccountNumber=0",

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4RestrictionsTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4RestrictionsTests.kt
@@ -9,7 +9,6 @@ import exchange.dydx.abacus.app.manager.TestWebSocket
 import exchange.dydx.abacus.output.ComplianceStatus
 import exchange.dydx.abacus.output.Restriction
 import exchange.dydx.abacus.payload.BaseTests
-import exchange.dydx.abacus.setAddresses
 import exchange.dydx.abacus.state.supervisor.AppConfigsV2
 import exchange.dydx.abacus.tests.payloads.AbacusMockData
 import kotlin.test.BeforeTest
@@ -73,7 +72,7 @@ class V4RestrictionsTests : NetworkTests() {
 
     private fun setStateMachineConnectedWithMarketsAndSubaccounts(stateManager: AsyncAbacusStateManagerV2) {
         setStateMachineConnectedWithMarkets(stateManager)
-        stateManager.setAddresses(null, testCosmoAddress)
+        stateManager.setAddresses(null, testCosmoAddress, false)
     }
 
     @Test
@@ -129,7 +128,7 @@ class V4RestrictionsTests : NetworkTests() {
         )
 
         setStateMachineConnected(stateManager)
-        stateManager.setAddresses(null, testCosmoAddress)
+        stateManager.setAddresses(null, testCosmoAddress, true)
 
         testRest?.setResponse(
             "https://indexer.v4staging.dydx.exchange/v4/compliance/screen/$testCosmoAddress",

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4RestrictionsTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4RestrictionsTests.kt
@@ -6,7 +6,6 @@ import exchange.dydx.abacus.app.manager.TestChain
 import exchange.dydx.abacus.app.manager.TestRest
 import exchange.dydx.abacus.app.manager.TestState
 import exchange.dydx.abacus.app.manager.TestWebSocket
-import exchange.dydx.abacus.output.ComplianceAction
 import exchange.dydx.abacus.output.ComplianceStatus
 import exchange.dydx.abacus.output.Restriction
 import exchange.dydx.abacus.payload.BaseTests
@@ -153,10 +152,6 @@ class V4RestrictionsTests : NetworkTests() {
                 }
             """.trimIndent(),
         )
-
-        stateManager.triggerCompliance(ComplianceAction.CONNECT) { successful, error, data ->
-            print("")
-        }
 
         assertEquals(
             ComplianceStatus.CLOSE_ONLY,

--- a/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
+++ b/src/commonTest/kotlin/exchange.dydx.abacus/app/manager/v2/V4TransactionTests.kt
@@ -8,7 +8,6 @@ import exchange.dydx.abacus.app.manager.TestState
 import exchange.dydx.abacus.app.manager.TestWebSocket
 import exchange.dydx.abacus.payload.BaseTests
 import exchange.dydx.abacus.protocols.TransactionCallback
-import exchange.dydx.abacus.setAddresses
 import exchange.dydx.abacus.state.machine.ClosePositionInputField
 import exchange.dydx.abacus.state.machine.TradeInputField
 import exchange.dydx.abacus.state.machine.TriggerOrdersInputField
@@ -90,7 +89,7 @@ class V4TransactionTests : NetworkTests() {
         testWebSocket?.simulateReceived(mock.accountsChannel.v4_subscribed)
         stateManager.market = "ETH-USD"
         testWebSocket?.simulateReceived(mock.orderbookChannel.load_test_2_subscribed)
-        stateManager.setAddresses(null, testCosmoAddress)
+        stateManager.setAddresses(null, testCosmoAddress, true)
     }
 
     private fun tradeInput(isShortTerm: Boolean, size: String = "0.01", limitPrice: String = "2000") {
@@ -437,7 +436,7 @@ class V4TransactionTests : NetworkTests() {
         testWebSocket?.simulateReceived(mock.marketsChannel.v4_subscribed_r1)
         stateManager.market = "ETH-USD"
         testWebSocket?.simulateReceived(mock.orderbookChannel.load_test_2_subscribed)
-        stateManager.setAddresses(null, "dydx155va0m7wz5n8zcqscn9afswwt04n4usj46wvp5")
+        stateManager.setAddresses(null, "dydx155va0m7wz5n8zcqscn9afswwt04n4usj46wvp5", true)
 
         if (withPositions) {
             testWebSocket?.simulateReceived(mock.v4ParentSubaccountsMock.subscribed_with_positions)

--- a/v4_abacus.podspec
+++ b/v4_abacus.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'v4_abacus'
-    spec.version                  = '1.14.4'
+    spec.version                  = '1.14.5'
     spec.homepage                 = 'https://github.com/dydxprotocol/v4-abacus'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
This allows the app to mutate the compliance state only when user connects a new wallet from a non-compliant region on mobile.

Context: https://dydx-team.slack.com/archives/C05K1ACJ8MB/p1748367331584029

Also refactor the compliance logic to separate it out from AccountSupervisor.